### PR TITLE
chore: automate v0.1.0 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,21 @@ jobs:
       - run: npm ci
       - run: npm run check
       - run: npm audit --omit=dev --audit-level=high
+
+  container:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build --tag digital-employee:ci .
+      - name: Verify container health endpoint
+        run: |
+          container_id="$(docker run --detach --rm --publish 127.0.0.1:3000:3000 digital-employee:ci)"
+          trap 'docker stop "$container_id" >/dev/null 2>&1 || true' EXIT
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            if curl --fail --silent http://127.0.0.1:3000/health; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs "$container_id"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,124 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.package.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run check
+      - run: npm audit --omit=dev --audit-level=high
+      - run: npm run release:check -- --tag "$GITHUB_REF_NAME"
+      - run: npm pack --dry-run
+      - id: package
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+  github-release:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - id: package
+        shell: bash
+        run: |
+          npm pack --json > package-output.json
+          package_file="$(node --input-type=module -e "import fs from 'node:fs'; const [entry] = JSON.parse(fs.readFileSync('package-output.json', 'utf8')); process.stdout.write(entry.filename)")"
+          sha256sum "$package_file" > "$package_file.sha256"
+          echo "file=$package_file" >> "$GITHUB_OUTPUT"
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE_FILE: ${{ steps.package.outputs.file }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" "$PACKAGE_FILE" "$PACKAGE_FILE.sha256" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" "$PACKAGE_FILE" "$PACKAGE_FILE.sha256" \
+              --verify-tag \
+              --generate-notes \
+              --title "Digital Employee $GITHUB_REF_NAME"
+          fi
+
+  npm:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - name: Publish npm package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::The NPM_TOKEN repository secret is required for npm publishing."
+            exit 1
+          fi
+          package_name="$(node -p "require('./package.json').name")"
+          package_version="$(node -p "require('./package.json').version")"
+          if npm view "$package_name@$package_version" version >/dev/null 2>&1; then
+            echo "$package_name@$package_version is already published"
+            exit 0
+          fi
+          npm publish --access public --provenance
+
+  ghcr:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+      - name: Build and publish image
+        env:
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          image="ghcr.io/${GITHUB_REPOSITORY,,}"
+          docker build \
+            --label "org.opencontainers.image.revision=$GITHUB_SHA" \
+            --label "org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+            --label "org.opencontainers.image.version=$VERSION" \
+            --tag "$image:$GITHUB_REF_NAME" \
+            --tag "$image:$VERSION" \
+            --tag "$image:latest" \
+            .
+          docker push "$image:$GITHUB_REF_NAME"
+          docker push "$image:$VERSION"
+          docker push "$image:latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-08-01
+
 ### Added
 
 - Generic digital employee runtime with a read-only `answer-agent` profile.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,29 @@ The first shipped profile is `answer-agent`: a read-only team support employee
 that answers with citations, refuses unsupported claims, and escalates
 uncertainty to a human.
 
+## Install a release
+
+The same `0.1.0` release is distributed through three public channels:
+
+| Channel | Command or download |
+| --- | --- |
+| npm | `npm install --global @fullstack-ai-infra/digital-employee@0.1.0` |
+| GHCR | `docker pull ghcr.io/fullstack-ai-infra/digital-employee:0.1.0` |
+| GitHub Release | Download the package and checksum from [Releases](https://github.com/fullstack-ai-infra/digital-employee/releases) |
+
+After an npm install, run the zero-credential demo from any directory:
+
+```bash
+digital-employee ask --question "What should I include in an incident report?"
+```
+
+Or start the HTTP demo from the container:
+
+```bash
+docker run --rm -p 3000:3000 \
+  ghcr.io/fullstack-ai-infra/digital-employee:0.1.0
+```
+
 ## Why a runtime, not one bot
 
 `answer-agent` is a role profile, not the whole product. A profile defines an

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,6 +6,29 @@ Digital Employee 是一个开源、自托管的数字员工运行时。它把岗
 
 首个已经交付的岗位是 `answer-agent`：一个默认只读、答案带出处、证据不足就转人工的团队答疑员工。
 
+## 安装正式版本
+
+同一个 `0.1.0` 版本通过三个公开渠道分发：
+
+| 渠道 | 安装或下载方式 |
+| --- | --- |
+| npm | `npm install --global @fullstack-ai-infra/digital-employee@0.1.0` |
+| GHCR | `docker pull ghcr.io/fullstack-ai-infra/digital-employee:0.1.0` |
+| GitHub Release | 从 [Releases](https://github.com/fullstack-ai-infra/digital-employee/releases) 下载软件包和校验文件 |
+
+npm 安装后，可以在任意目录运行无需凭证的演示：
+
+```bash
+digital-employee ask --question "What should I include in an incident report?"
+```
+
+也可以直接通过容器启动 HTTP 演示：
+
+```bash
+docker run --rm -p 3000:3000 \
+  ghcr.io/fullstack-ai-infra/digital-employee:0.1.0
+```
+
 ## 不是只开源一个机器人
 
 `answer-agent` 是岗位模板，不是整个产品。岗位模板负责定义：

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -9,7 +9,7 @@ provider integration.
 | Path | Evidence | Result |
 | --- | --- | --- |
 | Local answer and escalation | Public example files, extractive model, real CLI process | Verified |
-| Automated suite | `npm run check` | 80 passed; security check passed |
+| Automated suite | `npm run check` | 84 passed; security check passed |
 | Dependency audit | `npm audit --omit=dev --audit-level=high` | 0 known vulnerabilities |
 | Container | Built `Dockerfile`, started the image, called `/health` and `/v1/ask` | Verified |
 | HTTP session isolation | Client-selected request, actor, and session IDs are rejected; each built-in HTTP call receives a server-generated isolated session | Verified by automated test |

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "bugs": {
     "url": "https://github.com/fullstack-ai-infra/digital-employee/issues"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "digital-employee": "./apps/cli/bin.js"
   },
@@ -39,6 +42,8 @@
     "test": "node --test",
     "test:coverage": "node --test --experimental-test-coverage",
     "security:check": "node ./scripts/security-check.js",
+    "release:check": "node ./scripts/release-check.js",
+    "prepublishOnly": "npm run release:check && npm run check",
     "check": "npm test && npm run security:check"
   },
   "engines": {

--- a/scripts/release-check.js
+++ b/scripts/release-check.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const STABLE_SEMVER = /^\d+\.\d+\.\d+$/;
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function validateRelease({ manifest, coreManifest, changelog, tag }) {
+  const errors = [];
+  const version = String(manifest.version || "");
+
+  if (!STABLE_SEMVER.test(version)) {
+    errors.push("package version must be a stable x.y.z version");
+  }
+  if (tag && tag !== `v${version}`) {
+    errors.push(`release tag ${tag} does not match package version v${version}`);
+  }
+  if (manifest.private === true) {
+    errors.push("root package must be publishable");
+  }
+  if (manifest.publishConfig?.access !== "public") {
+    errors.push("publishConfig.access must be public");
+  }
+  if (manifest.bin?.["digital-employee"] !== "./apps/cli/bin.js") {
+    errors.push("digital-employee CLI entry point is missing");
+  }
+  if (!Array.isArray(manifest.files) || !manifest.files.includes("apps")) {
+    errors.push("published files must include the application entry points");
+  }
+  if (coreManifest.version !== version) {
+    errors.push("core and root package versions must match");
+  }
+
+  const heading = new RegExp(
+    `^## \\[${escapeRegExp(version)}\\] - \\d{4}-\\d{2}-\\d{2}$`,
+    "m"
+  );
+  if (!heading.test(changelog)) {
+    errors.push(`CHANGELOG.md must contain a dated ${version} release heading`);
+  }
+
+  return errors;
+}
+
+async function main() {
+  const repositoryRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    ".."
+  );
+  const tagIndex = process.argv.indexOf("--tag");
+  const tag = tagIndex === -1 ? undefined : process.argv[tagIndex + 1];
+  if (tagIndex !== -1 && !tag) throw new TypeError("--tag requires a value");
+
+  const [manifestText, coreManifestText, changelog] = await Promise.all([
+    readFile(path.join(repositoryRoot, "package.json"), "utf8"),
+    readFile(path.join(repositoryRoot, "packages/core/package.json"), "utf8"),
+    readFile(path.join(repositoryRoot, "CHANGELOG.md"), "utf8")
+  ]);
+  const errors = validateRelease({
+    manifest: JSON.parse(manifestText),
+    coreManifest: JSON.parse(coreManifestText),
+    changelog,
+    tag
+  });
+  if (errors.length) {
+    process.stderr.write(
+      `release-check failed:\n${errors.map((error) => `- ${error}`).join("\n")}\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write(`release-check passed for ${tag || "package metadata"}\n`);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`release-check: ${error?.message || "unexpected_error"}\n`);
+    process.exitCode = 2;
+  });
+}

--- a/tests/scripts/release-check.test.js
+++ b/tests/scripts/release-check.test.js
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { validateRelease } from "../../scripts/release-check.js";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../.."
+);
+
+const manifest = {
+  name: "@fullstack-ai-infra/digital-employee",
+  version: "0.1.0",
+  publishConfig: { access: "public" },
+  bin: { "digital-employee": "./apps/cli/bin.js" },
+  files: ["apps", "packages"]
+};
+const coreManifest = { version: "0.1.0" };
+const changelog = "# Changelog\n\n## [0.1.0] - 2026-08-01\n";
+
+test("release check accepts aligned public release metadata", () => {
+  assert.deepEqual(
+    validateRelease({ manifest, coreManifest, changelog, tag: "v0.1.0" }),
+    []
+  );
+});
+
+test("release check rejects a mismatched tag and package versions", () => {
+  const errors = validateRelease({
+    manifest,
+    coreManifest: { version: "0.0.9" },
+    changelog,
+    tag: "v0.2.0"
+  });
+  assert.deepEqual(errors, [
+    "release tag v0.2.0 does not match package version v0.1.0",
+    "core and root package versions must match"
+  ]);
+});
+
+test("release check rejects private or incomplete packages", () => {
+  const errors = validateRelease({
+    manifest: {
+      ...manifest,
+      private: true,
+      publishConfig: {},
+      bin: {},
+      files: ["packages"]
+    },
+    coreManifest,
+    changelog: "# Changelog\n",
+    tag: "v0.1.0"
+  });
+  assert.deepEqual(errors, [
+    "root package must be publishable",
+    "publishConfig.access must be public",
+    "digital-employee CLI entry point is missing",
+    "published files must include the application entry points",
+    "CHANGELOG.md must contain a dated 0.1.0 release heading"
+  ]);
+});
+
+test("release workflow has independently scoped jobs for all channels", async () => {
+  const workflow = await readFile(
+    path.join(repositoryRoot, ".github/workflows/release.yml"),
+    "utf8"
+  );
+  assert.match(workflow, /^\s{2}github-release:$/m);
+  assert.match(workflow, /^\s{2}npm:$/m);
+  assert.match(workflow, /^\s{2}ghcr:$/m);
+  assert.match(workflow, /npm publish --access public --provenance/);
+  assert.match(workflow, /gh release (?:create|upload)/);
+  assert.match(workflow, /docker push/);
+});


### PR DESCRIPTION
## What and why

Automate the first `v0.1.0` release across GitHub Releases, npm, and GHCR from one validated version tag.

## Scope

- add a tag-triggered release workflow with independently scoped jobs
- publish an npm tarball with provenance, a GitHub Release with SHA-256 checksum, and versioned/latest GHCR images
- fail closed when the tag, package versions, changelog, or public package metadata disagree
- add Docker build and health checks to pull-request CI
- document all three installation channels in English and Chinese

Write-capable release jobs are limited to GitHub contents, npm OIDC/token publication, and GitHub Packages. Runtime source/tool allowlists are unchanged.

## Validation

| ID | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|
| V1 | Runtime and release behavior passes | `npm run check` | Node 22.14.0 / npm 10.9.2 | All tests and security checks pass | 84 tests passed; security check passed | Pass |
| V2 | Production dependencies have no known high-severity vulnerabilities | `npm audit --omit=dev --audit-level=high` | npm registry | Exit 0 | 0 vulnerabilities | Pass |
| V3 | Tag and package metadata agree | `npm run release:check -- --tag v0.1.0` | Local | Exit 0 | Passed | Pass |
| V4 | Generated npm artifact works after installation | Pack, install into a temporary prefix, then run `digital-employee ask` | Local | Cited demo answer | Passed | Pass |
| V5 | GitHub workflow syntax is valid | `actionlint .github/workflows/*.yml` | actionlint v1.7.12 | No findings | No findings | Pass |
| V6 | Container builds and serves health | PR `container` CI job | GitHub-hosted Ubuntu | `/health` returns 200 | Passed in CI | Pass |

## Security and data review

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access is explicitly allowlisted and unchanged.
- [x] Logs do not add content, identity, or credential-bearing URL output.
- [x] No runtime dependency was added; release actions reuse existing official actions and runner tools.
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass.

## Risk and rollback

A release starts only from a `v*.*.*` tag and validates that the exact tag matches package metadata. Channel jobs have least-privilege permissions and idempotent behavior. Delete the tag/release and deprecate the npm version or GHCR tags if rollback is required; npm versions themselves are immutable.

Before tagging, add a repository `NPM_TOKEN` secret with publish access to the `@fullstack-ai-infra` scope. No token is stored in the repository.
