### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,11 @@ jobs:
     outputs:
       version: ${{ steps.package.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
-          cache: npm
+          node-version: 24
+          package-manager-cache: false
       - run: npm ci
       - run: npm run check
       - run: npm audit --omit=dev --audit-level=high
@@ -37,11 +37,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
-          cache: npm
+          node-version: 24
+          package-manager-cache: false
       - run: npm ci
       - id: package
         shell: bash
@@ -71,28 +71,24 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
-          cache: npm
+          node-version: 24
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org
+      - name: Install npm with trusted publishing support
+        run: npm install --global npm@11.18.0
       - run: npm ci
       - name: Publish npm package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          if [ -z "$NODE_AUTH_TOKEN" ]; then
-            echo "::error::The NPM_TOKEN repository secret is required for npm publishing."
-            exit 1
-          fi
           package_name="$(node -p "require('./package.json').name")"
           package_version="$(node -p "require('./package.json').version")"
           if npm view "$package_name@$package_version" version >/dev/null 2>&1; then
             echo "$package_name@$package_version is already published"
             exit 0
           fi
-          npm publish --access public --provenance
+          npm publish --access public
 
   ghcr:
     needs: verify
@@ -101,7 +97,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Log in to GHCR
         env:
           GHCR_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- npm releases now use GitHub Actions OIDC trusted publishing instead of a long-lived repository token.
+
 ## [0.1.0] - 2026-08-01
 
 ### Added

--- a/tests/scripts/release-check.test.js
+++ b/tests/scripts/release-check.test.js
@@ -70,7 +70,12 @@ test("release workflow has independently scoped jobs for all channels", async ()
   assert.match(workflow, /^\s{2}github-release:$/m);
   assert.match(workflow, /^\s{2}npm:$/m);
   assert.match(workflow, /^\s{2}ghcr:$/m);
-  assert.match(workflow, /npm publish --access public --provenance/);
+  assert.match(workflow, /^\s{6}id-token: write$/m);
+  assert.match(workflow, /npm install --global npm@11\.18\.0/);
+  assert.match(workflow, /npm publish --access public/);
+  assert.doesNotMatch(workflow, /NPM_TOKEN|NODE_AUTH_TOKEN/);
+  assert.match(workflow, /actions\/checkout@v6/);
+  assert.match(workflow, /actions\/setup-node@v6/);
   assert.match(workflow, /gh release (?:create|upload)/);
   assert.match(workflow, /docker push/);
 });


### PR DESCRIPTION
## What changed

- switch npm releases from `NPM_TOKEN` to GitHub Actions OIDC trusted publishing
- run release jobs on Node 24 with npm 11.18.0 and current GitHub Actions
- disable package-manager caching in release builds
- add observable workflow assertions and document the change

## Why

The bootstrap granular token expires and should not be a long-lived publishing dependency. Trusted publishing uses short-lived workflow-bound credentials and generates provenance automatically.

## Validation

- `npm run check` (84 tests passed)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml`
- npm trusted publisher read-back confirms `fullstack-ai-infra/digital-employee` + `release.yml` with publish permission
