### PR TITLE
chore: add @Bindy-lbb as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-# All changes require review from the organization administrator.
-* @PeterGuy326
+# Changes require review from the organization administrator or the designated
+# independent reviewer, so code-owner review is satisfiable without admin bypass.
+* @PeterGuy326 @Bindy-lbb


### PR DESCRIPTION
## Summary
- Add @Bindy-lbb (independent reviewer, now with write access on all four org repos) alongside @PeterGuy326 in CODEOWNERS.

## Why
Follow-up to the finding in design-system#3 post-merge review: with only @PeterGuy326 listed — who authors most PRs and cannot approve his own — `require_code_owner_reviews` was structurally unsatisfiable and every merge used the admin bypass. This makes the gate satisfiable through the normal flow.

## Test plan
- [x] Same content applied to all four org repos
- [ ] CI green
- [ ] Approved by @Bindy-lbb (this PR itself still needs admin merge: the base-branch CODEOWNERS in effect is the old single-owner one)