### PR TITLE
fix: close Qoder credential output boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,21 +16,34 @@ jobs:
         node-version:
           - 20
           - 22
+          - 24
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
+          package-manager-cache: false
       - run: npm ci
       - run: npm run check
       - run: npm audit --omit=dev --audit-level=high
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          package-manager-cache: false
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:coverage
+
   container:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: docker build --tag digital-employee:ci .
       - name: Verify default Agent-native entry point
         run: docker run --rm digital-employee:ci | grep --fixed-strings "Agent-native usage:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          # Node 24's experimental test coverage reporter can end with a JSON
+          # aggregation error after every test passes. Keep release coverage on
+          # the repository-supported Node 22 line; normal CI still tests Node 24.
+          node-version: 22
           package-manager-cache: false
       - run: npm ci
       - run: npm run check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+- Qoder assistant text is now buffered until successful process and cleanup
+  completion, then scrubbed as one value with the exact service credential.
+  This prevents secrets split across native stream chunks from escaping in
+  standard events. Tool input values are scrubbed before truncation,
+  credential-bearing tool identifiers and keys are rejected, and schema-bound
+  structured output that would require credential or pattern redaction fails
+  closed.
+
 ## [0.3.0] - 2026-08-04
 
 This source candidate adds the publisher-owned Runner execution boundary. It

--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@ Qwen disables slash commands and pins its unreachable built-in agent catalog;
 CodeBuddy denies every built-in tool in the verified version because its empty
 `--tools` flag alone is insufficient. Qoder instead receives a minimum
 read-only file projection and must attest its exact read/search tool set plus
-empty MCP/Skill/plugin sets.
+empty MCP/Skill/plugin sets. Qoder assistant text is held until process and
+credential cleanup succeeds, then scrubbed as one value with the exact service
+credential. Tool values are scrubbed before truncation, credential-bearing tool
+identifiers and keys are rejected, and schema-bound structured output that
+would require credential or pattern redaction fails closed.
 
 These paths are local/single-tenant technical previews, not a marketplace-ready
 online employee service. All four reject MCP, attachments, session resume,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,7 +46,7 @@ printf '%s\n' '{"message":"批准资料里怎么说？"}' | \
   node ./dist/apps/cli/bin.js run ../team-answer --engine qoder --stdin
 ```
 
-Claude Code、Qwen Code 或 CodeBuddy 使用同样的 `validate/run` 命令，改为对应 `--engine` 并配置该 Adapter 的服务 API Key 即可。`--stdin`/`--input-file` 让任务数据不进入外层进程参数。Claude Code、Qwen Code 和 CodeBuddy 只接收由 manifest 显式选中、有上限的密封 UTF-8 资产投影，并在空白且隔离的工作目录、HOME 和配置目录中运行；输出被信任前必须确认模型可见 tools 与 MCP 均为空。Claude 还会确认 plugins、Skills 和 slash commands 为空；Qwen 会禁用 slash commands 并锁定不可调用的内建 Agent 目录；CodeBuddy 则会显式拒绝已验证版本的每一个内建工具，因为单独使用空 `--tools` 并不能真正清空工具。Qoder 使用最小只读文件投影，并确认精确的读取/搜索工具集以及空 MCP/Skill/plugin 集。
+Claude Code、Qwen Code 或 CodeBuddy 使用同样的 `validate/run` 命令，改为对应 `--engine` 并配置该 Adapter 的服务 API Key 即可。`--stdin`/`--input-file` 让任务数据不进入外层进程参数。Claude Code、Qwen Code 和 CodeBuddy 只接收由 manifest 显式选中、有上限的密封 UTF-8 资产投影，并在空白且隔离的工作目录、HOME 和配置目录中运行；输出被信任前必须确认模型可见 tools 与 MCP 均为空。Claude 还会确认 plugins、Skills 和 slash commands 为空；Qwen 会禁用 slash commands 并锁定不可调用的内建 Agent 目录；CodeBuddy 则会显式拒绝已验证版本的每一个内建工具，因为单独使用空 `--tools` 并不能真正清空工具。Qoder 使用最小只读文件投影，并确认精确的读取/搜索工具集以及空 MCP/Skill/plugin 集；回答文本会等进程与凭证清理成功后再整体按真实服务 Token 脱敏。工具值会在截断前脱敏，包含服务 Token 的工具标识或键会被拒绝，需要凭证或通用模式脱敏的 schema 结构化输出会 fail closed。
 
 四条链路仍是本机/单租户技术预览，不是已经可供市场租赁的在线员工服务；都会 fail-closed 拒绝 MCP、附件、会话恢复、写操作与审批回调。模型认证/推理控制面保持可达，员工 tool/MCP 数据面网络被禁止。当前只完成了一致性 fixture，没有使用真实模型权益验收。
 

--- a/apps/cli/qoder-agent-host.ts
+++ b/apps/cli/qoder-agent-host.ts
@@ -384,13 +384,27 @@ function qoderNativeTools(policy: AgentHostRunRequest["policy"]): string[] {
   ]
 }
 
+function scrubSecret(value: string, secret: string): string {
+  const replacement = secret && "[REDACTED]".includes(secret) ? "" : "[REDACTED]"
+  const scrubbed = secret ? value.split(secret).join(replacement) : value
+  const redacted = redactText(scrubbed)
+  return secret ? redacted.split(secret).join("") : redacted
+}
+
+function textNeedsScrubbing(value: string, secret: string): boolean {
+  return Boolean(secret && value.includes(secret)) || redactText(value) !== value
+}
+
 function safeToolValue(
   value: unknown,
+  secret: string,
   depth = 0,
   seen = new WeakSet<object>(),
 ): SafeValue {
   if (value === null || value === undefined) return value
-  if (typeof value === "string") return redactText(value.slice(0, 4_096))
+  if (typeof value === "string") {
+    return scrubSecret(value, secret).slice(0, 4_096)
+  }
   if (typeof value === "number") return Number.isFinite(value) ? value : null
   if (typeof value === "boolean") return value
   if (typeof value !== "object") return undefined
@@ -398,18 +412,25 @@ function safeToolValue(
   seen.add(value)
   if (Array.isArray(value)) {
     return value.slice(0, 64).map((entry) =>
-      safeToolValue(entry, depth + 1, seen),
+      safeToolValue(entry, secret, depth + 1, seen),
     )
   }
   const output: { [key: string]: SafeValue } = {}
   for (const [key, entry] of Object.entries(value).slice(0, 64)) {
+    if (textNeedsScrubbing(key, secret)) {
+      throw new QoderAdapterError("qoder_tool_input_sensitive_key_denied")
+    }
+    const safeKey = key.slice(0, 256)
+    if (Object.prototype.hasOwnProperty.call(output, safeKey)) {
+      throw new QoderAdapterError("qoder_tool_input_key_collision")
+    }
     const safe = /(?:authorization|cookie|password|secret|token|api[-_]?key)/i.test(
       key,
     )
       ? "[REDACTED]"
-      : safeToolValue(entry, depth + 1, seen)
+      : safeToolValue(entry, secret, depth + 1, seen)
     if (safe === undefined) continue
-    Object.defineProperty(output, key.slice(0, 256), {
+    Object.defineProperty(output, safeKey, {
       value: safe,
       enumerable: true,
       configurable: true,
@@ -417,6 +438,46 @@ function safeToolValue(
     })
   }
   return output
+}
+
+function scrubOutput(
+  value: SafeValue,
+  secret: string,
+  rejectChanges = false,
+  depth = 0,
+): SafeValue {
+  if (depth > 32) return "[Truncated]"
+  if (typeof value === "string") {
+    if (rejectChanges && textNeedsScrubbing(value, secret)) {
+      throw new QoderAdapterError("qoder_output_sensitive_value_denied")
+    }
+    const safe = scrubSecret(value, secret)
+    return safe
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) =>
+      scrubOutput(entry, secret, rejectChanges, depth + 1),
+    )
+  }
+  if (value && typeof value === "object") {
+    const output: { [key: string]: SafeValue } = {}
+    for (const [key, entry] of Object.entries(value)) {
+      if (
+        textNeedsScrubbing(key, secret) ||
+        Object.prototype.hasOwnProperty.call(output, key)
+      ) {
+        throw new QoderAdapterError("qoder_output_sensitive_key_denied")
+      }
+      Object.defineProperty(output, key, {
+        value: scrubOutput(entry, secret, rejectChanges, depth + 1),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      })
+    }
+    return output
+  }
+  return value
 }
 
 function normalizeOutputValue(
@@ -429,7 +490,7 @@ function normalizeOutputValue(
     throw new QoderAdapterError("qoder_output_too_complex")
   }
   if (value === null) return null
-  if (typeof value === "string") return redactText(value)
+  if (typeof value === "string") return value
   if (typeof value === "boolean") return value
   if (typeof value === "number") {
     if (!Number.isFinite(value)) {
@@ -752,6 +813,8 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
     this.activeRuns.set(request.runId, active)
     let runRoot: string | undefined
     let authPayloadPath: string | undefined
+    let credential = ""
+    let pendingAssistantText = ""
     let abortListener: (() => void) | undefined
     let deadlineTimer: NodeJS.Timeout | undefined
     let terminalEvent:
@@ -864,7 +927,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
       const settingsPath = path.join(configDirectory, "adapter-settings.json")
       const mcpPath = path.join(configDirectory, "empty-mcp.json")
       authPayloadPath = path.join(configDirectory, "auth-payload.json")
-      const credential = this.environment.QODER_PERSONAL_ACCESS_TOKEN?.trim()
+      credential = this.environment.QODER_PERSONAL_ACCESS_TOKEN?.trim() ?? ""
       if (!credential) {
         throw new QoderAdapterError("qoder_service_token_not_configured")
       }
@@ -1186,12 +1249,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
             }
             sawPartialText = true
             if (protocolCode || active.reason) continue
-            yield {
-              type: "assistant.delta",
-              runId: request.runId,
-              timestamp: timestamp(),
-              text: redactText(delta.text),
-            }
+            pendingAssistantText += delta.text
           }
           continue
         }
@@ -1210,6 +1268,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
           const hasToolUse = blocks.some((block) => block?.type === "tool_use")
           const pendingEvents: AgentHostEvent[] = []
           const pendingToolNames = new Map<string, string>()
+          let pendingAssistantDelta = ""
           let nextAssistantSnapshot = assistantSnapshot
           if (hasToolUse) {
             for (const block of blocks) {
@@ -1226,6 +1285,10 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
                 protocolFailure("qoder_duplicate_tool_call")
                 break
               }
+              if (textNeedsScrubbing(block.id, credential)) {
+                protocolFailure("qoder_sensitive_tool_call_id_denied")
+                break
+              }
               pendingToolNames.set(block.id, block.name)
               pendingEvents.push({
                 type: "tool.started",
@@ -1234,7 +1297,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
                 toolCallId: block.id,
                 toolName: block.name,
                 ...(block.input !== undefined
-                  ? { input: safeToolValue(block.input) }
+                  ? { input: safeToolValue(block.input, credential) }
                   : {}),
               })
             }
@@ -1250,12 +1313,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
                 : block.text
               nextAssistantSnapshot = block.text
               if (delta) {
-                pendingEvents.push({
-                  type: "assistant.delta",
-                  runId: request.runId,
-                  timestamp: timestamp(),
-                  text: redactText(delta),
-                })
+                pendingAssistantDelta += delta
               }
             }
           }
@@ -1264,6 +1322,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
             toolNames.set(toolCallId, toolName)
           }
           assistantSnapshot = nextAssistantSnapshot
+          pendingAssistantText += pendingAssistantDelta
           for (const normalized of pendingEvents) {
             if (protocolCode || active.reason) break
             yield normalized
@@ -1373,9 +1432,10 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
       }
       let output: SafeValue
       try {
-        output = parseAndValidateOutput(
-          resultEvent!.result,
-          request.outputSchema,
+        output = scrubOutput(
+          parseAndValidateOutput(resultEvent!.result, request.outputSchema),
+          credential,
+          request.outputSchema !== undefined,
         )
       } catch (error) {
         const code =
@@ -1458,6 +1518,17 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
     const terminal =
       terminalEvent ??
       failedEvent(request.runId, timestamp(), "qoder_terminal_missing")
+    if (terminal.type === "run.completed") {
+      const safeAssistantText = scrubSecret(pendingAssistantText, credential)
+      if (safeAssistantText) {
+        yield {
+          type: "assistant.delta",
+          runId: request.runId,
+          timestamp: timestamp(),
+          text: safeAssistantText,
+        }
+      }
+    }
     yield { ...terminal, timestamp: timestamp() }
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,7 +124,12 @@ fixtures in this repository:
 - Qoder CLI 1.1.x receives a per-run minimum read-only file projection. Its
   isolated SDK-process configuration restricts native tools to the exact
   `Read/Grep/Glob` set when local assets are present and requires empty MCP,
-  Skill and plugin attestations.
+  Skill and plugin attestations. Assistant text is buffered until successful
+  process and credential cleanup, then scrubbed as one value using the exact
+  service credential. Tool values are scrubbed before truncation,
+  credential-bearing tool identifiers and keys are rejected, and schema-bound
+  structured output that would require credential or pattern redaction fails
+  closed.
 - Claude Code `>=2.1.214 <2.2.0`, Qwen Code `0.17.1` and CodeBuddy Code
   `2.106.4` are context-only. An adapter reads only manifest-selected,
   policy-allowed, bounded UTF-8 regular files, seals their path, length, digest

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -9,11 +9,11 @@ provider integration.
 | Path | Evidence | Result |
 | --- | --- | --- |
 | Local answer and escalation | Public example files, extractive model, real CLI process | Verified |
-| Automated suite | `npm run check` | 337/337 tests plus strict TypeScript, build and the repository security scan passed on 2026-08-04; provider fixtures do not make live model requests |
-| Coverage gate | `npm run test:coverage` on Node.js 24.13.0 | 337/337 tests; 91.93% line, 73.21% branch and 90.40% function coverage |
+| Automated suite | `npm run check` | 343/343 tests plus strict TypeScript, build and the repository security scan passed on 2026-08-04; provider fixtures do not make live model requests |
+| Coverage gate | `npm run test:coverage` on Node.js 22.23.2 | 343/343 tests; 91.97% line, 73.48% branch and 90.44% function coverage |
 | Strict TypeScript | `npm run typecheck` | 0 errors across shipped runtime sources |
 | Agent-host install probes | Real local version/init probes plus bounded fixture processes | Qoder CLI 1.1.12, Codex CLI 0.146.0, Qwen Code 0.17.1 and CodeBuddy Code 2.106.4 found locally; Claude Code 2.1.209 is below the verified range and its probe failed; live authentication/model access not tested |
-| Qoder run adapter | Adapter-specific deterministic child-process fixtures; not a reusable third-party certification harness | Qoder CLI 1.1.x SDK process-mode initialize/user/EOF transport, private auth payload, argument isolation, minimum read-only projection, filtered environment, exact read/search tool plus empty MCP/plugin/Skill attestation, package-aware preflight, atomic event publication, cancellation, file-identity checks, cleanup and terminal invariants verified; no live model request made |
+| Qoder run adapter | Adapter-specific deterministic child-process fixtures; not a reusable third-party certification harness | Qoder CLI 1.1.x SDK process-mode initialize/user/EOF transport, private auth payload, argument isolation, minimum read-only projection, filtered environment, exact read/search tool plus empty MCP/plugin/Skill attestation, package-aware preflight, atomic event publication, cross-delta exact-credential scrubbing, pre-truncation tool-value scrubbing, credential-bearing tool identifier/key rejection, schema-bound output redaction rejection, cancellation, file-identity checks, cleanup and terminal invariants verified; no live model request made |
 | Claude Code run adapter | Adapter-specific deterministic version-locked child-process fixtures only | Claude Code `>=2.1.214 <2.2.0`, explicit `ANTHROPIC_API_KEY`, `--bare --tools ""`, strict empty MCP, disabled commands/session persistence, sealed UTF-8 stdin assets, empty isolated workspace, home, configuration and temp directories, runtime empty tool/MCP/plugin/Skill attestation, strict unknown-event rejection, process-group descendant cleanup, cancellation and terminal invariants verified on POSIX; no live model request made |
 | Qwen Code run adapter | Exact-version child-process fixtures plus real local init against an unreachable loopback endpoint | Qwen Code `0.17.1`, explicit `OPENAI_API_KEY` and `OPENAI_MODEL`, sealed UTF-8 stdin assets, disposable empty workspace, home, configuration and temp directories, empty tool/MCP/slash-command surface and exact non-callable built-in Agent catalog, secret-safe structured output, cancellation, process-group cleanup and terminal invariants verified on POSIX; no model request reached a provider |
 | CodeBuddy Code run adapter | Exact-version child-process fixtures plus real local init against an unreachable loopback endpoint | CodeBuddy Code `2.106.4`, explicit `CODEBUDDY_API_KEY` and `CODEBUDDY_MODEL`, sealed UTF-8 stdin assets, disposable empty workspace/config/session/temp state, exhaustive built-in deny list and final empty tool/MCP attestation, strict status/snapshot/unknown-event checks, secret-safe structured output, cancellation, process-group cleanup and terminal invariants verified on POSIX; no model request reached a provider |
@@ -48,9 +48,9 @@ npm run test:coverage
 npm audit --audit-level=high
 ```
 
-Node.js 24.13.0 also completed all 334 business tests, but its experimental
-full-suite coverage reporter intermittently ended with `Unexpected end of JSON
-input` while aggregating child-process coverage. The same coverage command
-reported successfully on the repository-supported Node.js 22 line; this is
-recorded as a reporter/environment risk, not presented as a second passing
-Node.js 24 coverage gate.
+Node.js 24.13.0 completed all 343 tests through `npm run check`, and Node 24 is
+part of the regular CI matrix. Its experimental full-suite coverage reporter
+can end with `Unexpected end of JSON input` while aggregating child-process
+coverage, including three consecutive reproductions after every test passed on
+the pre-fix `main` snapshot. The authoritative coverage job and release gate
+therefore run on the repository-supported Node.js 22 line.

--- a/tests/apps/fixtures/fake-qoder.mjs
+++ b/tests/apps/fixtures/fake-qoder.mjs
@@ -76,6 +76,15 @@ async function writeCapture() {
   )
 }
 
+async function readCredential() {
+  const authPayloadPath = process.env.QODER_SDK_AUTH_PAYLOAD_FILE
+  const payload = JSON.parse(await readFile(authPayloadPath, "utf8"))
+  if (typeof payload.accessToken !== "string" || !payload.accessToken) {
+    throw new Error("fixture credential missing")
+  }
+  return payload.accessToken
+}
+
 const init = {
   type: "system",
   subtype: "init",
@@ -135,6 +144,17 @@ async function executeRun() {
     await new Promise(() => {})
   }
 
+  const credential = mode.includes("credential")
+    ? await readCredential()
+    : undefined
+  const toolUseId = mode === "tool-id-credential" ? credential : "tool-1"
+  const toolInput =
+    mode === "tool-input-credential"
+      ? { note: credential }
+      : mode === "tool-key-credential"
+        ? { [`${"x".repeat(250)}${credential}`]: "unsafe" }
+        : { file_path: "knowledge/README.md" }
+
   emit({
     type: "assistant",
     session_id: sessionId,
@@ -142,9 +162,9 @@ async function executeRun() {
       content: [
         {
           type: "tool_use",
-          id: "tool-1",
+          id: toolUseId,
           name: "Read",
-          input: { file_path: "knowledge/README.md" },
+          input: toolInput,
         },
       ],
     },
@@ -156,7 +176,7 @@ async function executeRun() {
       content: [
         {
           type: "tool_result",
-          tool_use_id: "tool-1",
+          tool_use_id: toolUseId,
           is_error: false,
           content: "approved knowledge",
         },
@@ -170,6 +190,36 @@ async function executeRun() {
       message: {
         content: [{ type: "text", text: "api_key=fixture-secret" }],
       },
+    })
+  } else if (mode === "snapshot-split-credential") {
+    emit({
+      type: "assistant",
+      session_id: sessionId,
+      message: { content: [{ type: "text", text: "api_key=" }] },
+    })
+    emit({
+      type: "assistant",
+      session_id: sessionId,
+      message: {
+        content: [{ type: "text", text: `api_key=${credential}` }],
+      },
+    })
+  } else if (
+    mode === "stream-split-credential" ||
+    mode === "stream-credential-result-error"
+  ) {
+    for (const text of ["Bearer ", credential]) {
+      emit({
+        type: "stream_event",
+        session_id: sessionId,
+        event: { delta: { type: "text_delta", text } },
+      })
+    }
+  } else if (mode === "stream-bare-credential") {
+    emit({
+      type: "stream_event",
+      session_id: sessionId,
+      event: { delta: { type: "text_delta", text: credential } },
     })
   } else {
     emit({
@@ -186,16 +236,20 @@ async function executeRun() {
       },
     })
   }
-  const output = JSON.stringify({
+  const outputValue = {
     status: "answered",
-    answer: "fixture answer",
+    answer: mode === "output-value-credential" ? credential : "fixture answer",
     citations: [{ label: "Approved", uri: "knowledge/README.md" }],
-  })
+    ...(mode === "output-key-credential" ? { [credential]: "unsafe" } : {}),
+  }
+  const output = JSON.stringify(outputValue)
+  const resultError =
+    mode === "result-error" || mode === "stream-credential-result-error"
   const result = {
     type: "result",
     session_id: sessionId,
-    subtype: mode === "result-error" ? "error_during_execution" : "success",
-    is_error: mode === "result-error",
+    subtype: resultError ? "error_during_execution" : "success",
+    is_error: resultError,
     result: mode === "invalid-output" ? `\`\`\`json\n${output}\n\`\`\`` : output,
   }
   emit(result)

--- a/tests/apps/qoder-agent-host.test.ts
+++ b/tests/apps/qoder-agent-host.test.ts
@@ -299,6 +299,213 @@ test("Qoder redacts both native stream and assistant snapshot deltas", async () 
   }
 })
 
+test("Qoder buffers and scrubs the actual credential across stream boundaries", async () => {
+  for (const [mode, expected] of [
+    ["stream-split-credential", "Bearer [REDACTED]"],
+    ["snapshot-split-credential", "api_key=[REDACTED]"],
+    ["stream-bare-credential", "[REDACTED]"],
+  ] as const) {
+    const parent = await mkdtemp(path.join(os.tmpdir(), `qoder-${mode}-`))
+    const request = await employeeRequest(parent, `run-${mode}`)
+    const events = await collect(adapter(parent, mode).run(request))
+    const deltas = events.filter(
+      (event): event is Extract<AgentHostEvent, { type: "assistant.delta" }> =>
+        event.type === "assistant.delta",
+    )
+
+    assert.equal(events.at(-1)?.type, "run.completed")
+    assert.deepEqual(deltas.map((event) => event.text), [expected])
+    assert.equal(JSON.stringify(events).includes("fixture-service-token"), false)
+  }
+})
+
+test("Qoder scrubs credentials from tool input and rejects sensitive keys and ids", async () => {
+  const inputParent = await mkdtemp(
+    path.join(os.tmpdir(), "qoder-tool-input-credential-"),
+  )
+  const inputRequest = await employeeRequest(
+    inputParent,
+    "run-tool-input-credential",
+  )
+  const inputEvents = await collect(
+    adapter(inputParent, "tool-input-credential").run(inputRequest),
+  )
+  const toolStarted = inputEvents.find((event) => event.type === "tool.started")
+
+  assert.equal(inputEvents.at(-1)?.type, "run.completed")
+  assert.deepEqual(
+    toolStarted?.type === "tool.started" && toolStarted.input,
+    { note: "[REDACTED]" },
+  )
+  assert.equal(
+    JSON.stringify(inputEvents).includes("fixture-service-token"),
+    false,
+  )
+
+  const idParent = await mkdtemp(
+    path.join(os.tmpdir(), "qoder-tool-id-credential-"),
+  )
+  const idRequest = await employeeRequest(idParent, "run-tool-id-credential")
+  const idEvents = await collect(
+    adapter(idParent, "tool-id-credential").run(idRequest),
+  )
+  const idTerminal = idEvents.at(-1)
+
+  assert.equal(idTerminal?.type, "run.failed")
+  assert.equal(
+    idTerminal?.type === "run.failed" && idTerminal.error.code,
+    "qoder_sensitive_tool_call_id_denied",
+  )
+  assert.equal(JSON.stringify(idEvents).includes("fixture-service-token"), false)
+
+  const keyParent = await mkdtemp(
+    path.join(os.tmpdir(), "qoder-tool-key-credential-"),
+  )
+  const keyRequest = await employeeRequest(keyParent, "run-tool-key-credential")
+  const keyEvents = await collect(
+    adapter(keyParent, "tool-key-credential").run(keyRequest),
+  )
+  const keyTerminal = keyEvents.at(-1)
+
+  assert.equal(keyTerminal?.type, "run.failed")
+  assert.equal(
+    keyTerminal?.type === "run.failed" && keyTerminal.error.code,
+    "qoder_tool_input_sensitive_key_denied",
+  )
+  assert.equal(JSON.stringify(keyEvents).includes("fixture-service-token"), false)
+})
+
+test("Qoder scrubs complete host values before applying event size bounds", async () => {
+  const parent = await mkdtemp(
+    path.join(os.tmpdir(), "qoder-long-tool-input-credential-"),
+  )
+  const request = await employeeRequest(
+    parent,
+    "run-long-tool-input-credential",
+  )
+  const credential = `qoder-${"x".repeat(5_000)}-tail`
+  const events = await collect(
+    adapter(parent, "tool-input-credential", undefined, 30_000, {
+      environment: {
+        PATH: process.env.PATH,
+        QODER_PERSONAL_ACCESS_TOKEN: credential,
+      },
+    }).run(request),
+  )
+  const toolStarted = events.find((event) => event.type === "tool.started")
+  const serialized = JSON.stringify(events)
+
+  assert.equal(events.at(-1)?.type, "run.completed")
+  assert.deepEqual(
+    toolStarted?.type === "tool.started" && toolStarted.input,
+    { note: "[REDACTED]" },
+  )
+  assert.equal(serialized.includes(credential), false)
+  assert.equal(serialized.includes(credential.slice(0, 4_096)), false)
+})
+
+test("Qoder does not confuse the actual credential with its redaction marker", async () => {
+  const credential = "[REDACTED]"
+  for (const [mode, expectedTerminal, expectedCode] of [
+    ["stream-bare-credential", "run.completed", undefined],
+    [
+      "output-value-credential",
+      "run.failed",
+      "qoder_output_sensitive_value_denied",
+    ],
+  ] as const) {
+    const parent = await mkdtemp(path.join(os.tmpdir(), `qoder-marker-${mode}-`))
+    const request = await employeeRequest(parent, `run-marker-${mode}`)
+    const events = await collect(
+      adapter(parent, mode, undefined, 30_000, {
+        environment: {
+          PATH: process.env.PATH,
+          QODER_PERSONAL_ACCESS_TOKEN: credential,
+        },
+      }).run(request),
+    )
+    const terminal = events.at(-1)
+
+    assert.equal(terminal?.type, expectedTerminal)
+    if (expectedCode) {
+      assert.equal(
+        terminal?.type === "run.failed" && terminal.error.code,
+        expectedCode,
+      )
+    }
+    assert.equal(JSON.stringify(events).includes(credential), false)
+  }
+})
+
+test("Qoder fails closed when structured output contains its credential", async () => {
+  for (const [mode, expectedCode] of [
+    ["output-value-credential", "qoder_output_sensitive_value_denied"],
+    ["output-key-credential", "qoder_output_sensitive_key_denied"],
+  ] as const) {
+    const parent = await mkdtemp(path.join(os.tmpdir(), `qoder-${mode}-`))
+    const request = await employeeRequest(parent, `run-${mode}`)
+    if (mode === "output-key-credential") {
+      request.outputSchema = {
+        type: "object",
+        additionalProperties: true,
+      }
+    }
+    const events = await collect(adapter(parent, mode).run(request))
+    const terminal = events.at(-1)
+
+    assert.equal(terminal?.type, "run.failed")
+    assert.equal(
+      terminal?.type === "run.failed" && terminal.error.code,
+      expectedCode,
+    )
+    assert.equal(JSON.stringify(events).includes("fixture-service-token"), false)
+  }
+
+  const parent = await mkdtemp(
+    path.join(os.tmpdir(), "qoder-unstructured-output-credential-"),
+  )
+  const request = await employeeRequest(
+    parent,
+    "run-unstructured-output-credential",
+  )
+  request.outputSchema = undefined
+  const events = await collect(
+    adapter(parent, "output-value-credential").run(request),
+  )
+  const terminal = events.at(-1)
+
+  assert.equal(terminal?.type, "run.completed")
+  assert.match(
+    terminal?.type === "run.completed" && typeof terminal.output === "string"
+      ? terminal.output
+      : "",
+    /\[REDACTED\]/,
+  )
+  assert.equal(JSON.stringify(events).includes("fixture-service-token"), false)
+})
+
+test("Qoder never flushes buffered credentials after a failed run", async () => {
+  const parent = await mkdtemp(
+    path.join(os.tmpdir(), "qoder-stream-credential-result-error-"),
+  )
+  const request = await employeeRequest(
+    parent,
+    "run-stream-credential-result-error",
+  )
+  const events = await collect(
+    adapter(parent, "stream-credential-result-error").run(request),
+  )
+  const terminal = events.at(-1)
+
+  assert.equal(events.some((event) => event.type === "assistant.delta"), false)
+  assert.equal(terminal?.type, "run.failed")
+  assert.equal(
+    terminal?.type === "run.failed" && terminal.error.code,
+    "qoder_execution_failed",
+  )
+  assert.equal(JSON.stringify(events).includes("fixture-service-token"), false)
+})
+
 for (const [mode, expectedCode] of [
   ["malformed", "qoder_stream_invalid_json"],
   ["policy-mismatch", "qoder_runtime_policy_mismatch"],
@@ -581,7 +788,7 @@ test("Qoder cleanup failure replaces success with an explicit failed terminal", 
   const parent = await mkdtemp(path.join(os.tmpdir(), "qoder-cleanup-failure-"))
   const request = await employeeRequest(parent, "run-cleanup-failure")
   let cleanupCalls = 0
-  const host = adapter(parent, "success", undefined, 10_000, {
+  const host = adapter(parent, "stream-split-credential", undefined, 10_000, {
     removeRunRoot: async () => {
       cleanupCalls += 1
       throw Object.assign(new Error("fixture cleanup failure"), { code: "EACCES" })
@@ -591,6 +798,8 @@ test("Qoder cleanup failure replaces success with an explicit failed terminal", 
   const events = await collect(host.run(request))
   assert.equal(cleanupCalls, 2)
   assert.equal(terminalEvents(events).length, 1)
+  assert.equal(events.some((event) => event.type === "assistant.delta"), false)
+  assert.equal(JSON.stringify(events).includes("fixture-service-token"), false)
   assert.equal(events.at(-1)?.type, "run.failed")
   const failed = events.at(-1)
   assert.equal(


### PR DESCRIPTION
## Summary

- buffer Qoder assistant text until the child process and credential cleanup both succeed, then scrub the complete value with the exact service credential
- scrub tool values before truncation; fail closed for credential-bearing tool identifiers/keys and schema-bound output that would require credential or generic-pattern redaction
- add regression coverage for split stream/snapshot credentials, tool and output boundaries, long values, redaction-marker collisions, failed runs, and cleanup failures
- test supported Node.js 20/22/24 in normal CI and add an authoritative Node.js 22 coverage job; keep release coverage on Node.js 22 while Node.js 24's experimental reporter is unstable

## #22 historical CI follow-up

The red Node.js 22 job on the merge run for #22 was a deterministic fixture problem: an unresolved top-level await did not retain an active event-loop handle and Node.js exited with code 13. Main already contains the fixture correction in `ea1a86c` (use an active interval), and the successor main run passed 337/337 tests. Historical GitHub Actions records are immutable, so that old red run remains visible even though its root cause is fixed.

This follow-up also closes a separately discovered Qoder credential boundary before further acceptance: a credential split across multiple assistant events could previously evade per-delta redaction.

## Verification

- `npm run check` — 343/343
- `npm run typecheck`
- Qoder adapter tests — 36/36
- `npm run test:coverage` on Node.js 22.23.2 — 91.97% lines / 73.48% branches / 90.44% functions
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `npm run release:check`
- release-check tests — 5/5
- root and core package dry runs

Live provider entitlement/model access is not claimed by these deterministic adapter fixtures.
