### PR TITLE
feat(core): adapter qualification kit (Issue #30 R1)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -75,6 +75,22 @@ export type {
   AgentHostVectorResult,
 } from "./src/agent-host-vectors.js"
 export {
+  ADAPTER_QUALIFICATION_KIT_VERSION,
+  ADAPTER_QUALIFICATION_SCHEMA_ID,
+  QUALIFICATION_DOMAINS,
+  canonicalPolicyDigest,
+  runQualificationSuite,
+  validateAdapterQualificationRecord,
+} from "./src/adapter-qualification.js"
+export type {
+  AdapterQualificationRecord,
+  QualificationAxes,
+  QualificationCaseResult,
+  QualificationDomain,
+  QualificationLiveEvidence,
+  QualificationOptions,
+} from "./src/adapter-qualification.js"
+export {
   EMPLOYEE_PACKAGE_MANIFEST_NAME,
   EMPLOYEE_PACKAGE_SCHEMA_VERSION,
   deriveEffectiveAgentHostPolicy,

--- a/packages/core/src/adapter-qualification.ts
+++ b/packages/core/src/adapter-qualification.ts
@@ -1,0 +1,783 @@
+import { createHash } from "node:crypto"
+
+import {
+  AGENT_HOST_CAPABILITIES,
+  AGENT_HOST_PROTOCOL_VERSION,
+} from "./agent-host.js"
+import type {
+  AgentHostAdapter,
+  AgentHostEvent,
+  AgentHostPolicy,
+  AgentHostProbeResult,
+  AgentHostRunRequest,
+} from "./agent-host.js"
+import { CoreError } from "./contracts.js"
+import type { SafeValue } from "./contracts.js"
+
+export const ADAPTER_QUALIFICATION_SCHEMA_ID =
+  "adapter-qualification-record.v1" as const
+
+export const ADAPTER_QUALIFICATION_KIT_VERSION = "1.0.0" as const
+
+export const QUALIFICATION_DOMAINS = [
+  "capability_negotiation",
+  "native_event_validation",
+  "single_terminal_outcome",
+  "deadline_cancel",
+  "process_tree_cleanup",
+  "credential_boundaries",
+  "filesystem_network_enforcement",
+  "tool_mcp_enforcement",
+  "output_schema",
+] as const
+
+export type QualificationDomain = (typeof QUALIFICATION_DOMAINS)[number]
+
+export interface QualificationCaseResult {
+  domain: QualificationDomain
+  id: string
+  passed: boolean
+  /** Lowercase ASCII machine code describing the outcome. */
+  code: string
+}
+
+export interface QualificationAxes {
+  implemented: boolean
+  fixtureConformant: boolean
+  liveQualified: boolean
+}
+
+export interface QualificationLiveEvidence {
+  environment: string
+  evidenceDigest: string
+}
+
+export interface AdapterQualificationRecord {
+  schema: typeof ADAPTER_QUALIFICATION_SCHEMA_ID
+  hostId: string
+  hostVersion: string
+  policyDigest: string
+  kitVersion: typeof ADAPTER_QUALIFICATION_KIT_VERSION
+  generatedAt: string
+  axes: QualificationAxes
+  domains: Record<QualificationDomain, { passed: number; failed: number }>
+  cases: QualificationCaseResult[]
+  liveEvidence?: QualificationLiveEvidence
+}
+
+export interface QualificationOptions {
+  workingDirectory: string
+  generatedAt: string
+  requiredCapabilities?: readonly string[]
+  /**
+   * Explicit opt-in live evidence. Without it the live axis stays false and
+   * no provider call is ever made by the kit.
+   */
+  liveEvidence?: QualificationLiveEvidence
+}
+
+const HOST_ID_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$/
+const HEX_64_PATTERN = /^[0-9a-f]{64}$/
+const CASE_ID_PATTERN = /^[a-z0-9]+(?:_[a-z0-9]+)*$/
+const ENVIRONMENT_ID_PATTERN = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/
+const ISO_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/
+
+function qualificationError(
+  code: string,
+  message: string,
+  details?: unknown,
+): CoreError {
+  return new CoreError(code, message, {
+    status: 400,
+    retryable: false,
+    details,
+  })
+}
+
+export function canonicalPolicyDigest(policy: AgentHostPolicy): string {
+  return createHash("sha256")
+    .update(JSON.stringify(policy, Object.keys(policy).sort()))
+    .digest("hex")
+}
+
+function defaultQualificationPolicy(): AgentHostPolicy {
+  return {
+    tools: { default: "deny", allow: [{ name: "noop", mode: "read" }] },
+    filesystem: { read: ["."], write: [] },
+    network: { mode: "deny" },
+    approval: { mode: "never" },
+    maxTurns: 4,
+  }
+}
+
+function qualificationRequest(
+  caseId: string,
+  workingDirectory: string,
+  policy: AgentHostPolicy,
+  outputSchema?: SafeValue,
+): AgentHostRunRequest {
+  return {
+    runId: `qualification-${caseId}`,
+    employeeId: "qualification-employee",
+    workingDirectory,
+    prompt: `qualification case ${caseId}`,
+    policy,
+    ...(outputSchema ? { outputSchema } : {}),
+  }
+}
+
+async function collectEvents(
+  adapter: AgentHostAdapter,
+  request: AgentHostRunRequest,
+): Promise<AgentHostEvent[]> {
+  const events: AgentHostEvent[] = []
+  for await (const event of adapter.run(request)) {
+    events.push(event)
+    if (events.length > 256) {
+      throw qualificationError(
+        "qualification_event_overflow",
+        "adapter emitted more than 256 events for one qualification case",
+      )
+    }
+  }
+  return events
+}
+
+const KNOWN_EVENT_TYPES = new Set([
+  "run.started",
+  "assistant.delta",
+  "tool.started",
+  "tool.completed",
+  "approval.required",
+  "usage",
+  "run.completed",
+  "run.failed",
+])
+
+function isTerminal(event: AgentHostEvent): boolean {
+  return event.type === "run.completed" || event.type === "run.failed"
+}
+
+function caseResult(
+  domain: QualificationDomain,
+  id: string,
+  passed: boolean,
+  code: string,
+): QualificationCaseResult {
+  return { domain, id, passed, code }
+}
+
+async function runCapabilityCase(
+  adapter: AgentHostAdapter,
+): Promise<QualificationCaseResult> {
+  let probe: AgentHostProbeResult
+  try {
+    probe = await adapter.probe()
+  } catch {
+    return caseResult(
+      "capability_negotiation",
+      "probe_contract",
+      false,
+      "probe_unavailable",
+    )
+  }
+  const complete = AGENT_HOST_CAPABILITIES.every(
+    (capability) => probe.capabilities[capability] !== undefined,
+  )
+  const passed =
+    probe.protocolVersion === AGENT_HOST_PROTOCOL_VERSION &&
+    probe.status === "ready" &&
+    probe.available &&
+    probe.adapterStatus === "runnable" &&
+    (probe.capabilitySource === "conformance_test" ||
+      probe.capabilitySource === "adapter_declaration") &&
+    complete
+  return caseResult(
+    "capability_negotiation",
+    "probe_contract",
+    passed,
+    passed ? "probe_contract_ok" : "probe_contract_violation",
+  )
+}
+
+async function runEventCases(
+  adapter: AgentHostAdapter,
+  workingDirectory: string,
+  policy: AgentHostPolicy,
+): Promise<QualificationCaseResult[]> {
+  const results: QualificationCaseResult[] = []
+  const request = qualificationRequest(
+    "event_stream",
+    workingDirectory,
+    policy,
+  )
+  let events: AgentHostEvent[]
+  try {
+    events = await collectEvents(adapter, request)
+  } catch {
+    return [
+      caseResult(
+        "native_event_validation",
+        "events_well_formed",
+        false,
+        "event_stream_unavailable",
+      ),
+      caseResult(
+        "single_terminal_outcome",
+        "exactly_one_terminal",
+        false,
+        "event_stream_unavailable",
+      ),
+    ]
+  }
+
+  const wellFormed = events.every(
+    (event) =>
+      event.runId === request.runId &&
+      typeof event.timestamp === "string" &&
+      ISO_PATTERN.test(event.timestamp) &&
+      KNOWN_EVENT_TYPES.has(event.type),
+  )
+  results.push(
+    caseResult(
+      "native_event_validation",
+      "events_well_formed",
+      wellFormed,
+      wellFormed ? "events_well_formed_ok" : "malformed_native_event",
+    ),
+  )
+
+  const terminals = events.filter(isTerminal)
+  const terminalLast =
+    terminals.length > 0 && isTerminal(events[events.length - 1])
+  const passed = terminals.length === 1 && terminalLast
+  results.push(
+    caseResult(
+      "single_terminal_outcome",
+      "exactly_one_terminal",
+      passed,
+      passed
+        ? "single_terminal_ok"
+        : terminals.length === 0
+          ? "missing_terminal_event"
+          : terminals.length > 1
+            ? "duplicate_terminal_event"
+            : "event_after_terminal",
+    ),
+  )
+  return results
+}
+
+async function runCancelCase(
+  adapter: AgentHostAdapter,
+  workingDirectory: string,
+  policy: AgentHostPolicy,
+): Promise<QualificationCaseResult> {
+  const request = qualificationRequest("cancel", workingDirectory, policy)
+  let events: AgentHostEvent[]
+  try {
+    if (typeof adapter.cancel === "function") {
+      void adapter.cancel(request.runId)
+    }
+    events = await collectEvents(adapter, request)
+  } catch {
+    return caseResult(
+      "deadline_cancel",
+      "cancel_stops_run",
+      false,
+      "cancel_path_unavailable",
+    )
+  }
+  const terminals = events.filter(isTerminal)
+  const passed =
+    terminals.length === 1 && isTerminal(events[events.length - 1])
+  return caseResult(
+    "deadline_cancel",
+    "cancel_stops_run",
+    passed,
+    passed ? "cancel_stops_run_ok" : "cancel_leaves_stream_open",
+  )
+}
+
+async function runCleanupCase(
+  adapter: AgentHostAdapter,
+  workingDirectory: string,
+  policy: AgentHostPolicy,
+): Promise<QualificationCaseResult> {
+  const request = qualificationRequest("cleanup", workingDirectory, policy)
+  try {
+    const events = await collectEvents(adapter, request)
+    if (events.length === 0 || !isTerminal(events[events.length - 1])) {
+      return caseResult(
+        "process_tree_cleanup",
+        "stream_terminates",
+        false,
+        "stream_not_terminated",
+      )
+    }
+    if (typeof adapter.cancel === "function") {
+      await adapter.cancel(request.runId)
+      await adapter.cancel(request.runId)
+    }
+    return caseResult(
+      "process_tree_cleanup",
+      "stream_terminates",
+      true,
+      "stream_terminates_ok",
+    )
+  } catch {
+    return caseResult(
+      "process_tree_cleanup",
+      "stream_terminates",
+      false,
+      "cleanup_path_threw",
+    )
+  }
+}
+
+const QUALIFICATION_SENTINEL = "qualification-sentinel-do-not-leak"
+
+async function runCredentialCase(
+  adapter: AgentHostAdapter,
+  workingDirectory: string,
+  policy: AgentHostPolicy,
+): Promise<QualificationCaseResult> {
+  const request: AgentHostRunRequest = {
+    ...qualificationRequest("credential", workingDirectory, policy),
+    metadata: { qualificationSentinel: QUALIFICATION_SENTINEL },
+  }
+  try {
+    const events = await collectEvents(adapter, request)
+    const leaked = events.some((event) =>
+      JSON.stringify(event).includes(QUALIFICATION_SENTINEL),
+    )
+    return caseResult(
+      "credential_boundaries",
+      "no_metadata_echo",
+      !leaked,
+      leaked ? "metadata_secret_echoed" : "no_metadata_echo_ok",
+    )
+  } catch {
+    return caseResult(
+      "credential_boundaries",
+      "no_metadata_echo",
+      false,
+      "credential_case_unavailable",
+    )
+  }
+}
+
+async function runEnforcementCases(
+  adapter: AgentHostAdapter,
+  workingDirectory: string,
+  policy: AgentHostPolicy,
+): Promise<QualificationCaseResult[]> {
+  const results: QualificationCaseResult[] = []
+
+  const hostileFsRequest = qualificationRequest(
+    "filesystem_enforcement",
+    workingDirectory,
+    {
+      ...policy,
+      filesystem: { read: ["."], write: ["/etc"] },
+      network: { mode: "deny" },
+    },
+  )
+  let fsRefused = false
+  try {
+    await adapter.preflight(hostileFsRequest)
+  } catch {
+    fsRefused = true
+  }
+  results.push(
+    caseResult(
+      "filesystem_network_enforcement",
+      "hostile_write_refused",
+      fsRefused,
+      fsRefused ? "hostile_write_refused_ok" : "hostile_write_accepted",
+    ),
+  )
+
+  const toolRequest = qualificationRequest(
+    "tool_enforcement",
+    workingDirectory,
+    policy,
+  )
+  try {
+    const events = await collectEvents(adapter, toolRequest)
+    const allowed = new Set(policy.tools.allow.map((entry) => entry.name))
+    const violation = events.some(
+      (event) =>
+        (event.type === "tool.started" || event.type === "tool.completed") &&
+        !allowed.has(event.toolName),
+    )
+    results.push(
+      caseResult(
+        "tool_mcp_enforcement",
+        "tool_allowlist_respected",
+        !violation,
+        violation ? "disallowed_tool_event" : "tool_allowlist_respected_ok",
+      ),
+    )
+  } catch {
+    results.push(
+      caseResult(
+        "tool_mcp_enforcement",
+        "tool_allowlist_respected",
+        false,
+        "tool_case_unavailable",
+      ),
+    )
+  }
+  return results
+}
+
+async function runOutputSchemaCase(
+  adapter: AgentHostAdapter,
+  workingDirectory: string,
+  policy: AgentHostPolicy,
+): Promise<QualificationCaseResult> {
+  const schema = {
+    type: "object",
+    properties: { answer: { type: "string" } },
+    required: ["answer"],
+    additionalProperties: false,
+  }
+  const request = qualificationRequest(
+    "output_schema",
+    workingDirectory,
+    policy,
+    schema,
+  )
+  try {
+    const events = await collectEvents(adapter, request)
+    const terminal = events.filter(isTerminal)
+    if (terminal.length !== 1 || terminal[0].type !== "run.completed") {
+      return caseResult(
+        "output_schema",
+        "terminal_output_matches_schema",
+        false,
+        "no_completed_terminal",
+      )
+    }
+    const output = terminal[0].output as Record<string, unknown>
+    const keys =
+      output && typeof output === "object" && !Array.isArray(output)
+        ? Object.keys(output)
+        : []
+    const matches =
+      keys.length === 1 &&
+      keys[0] === "answer" &&
+      typeof output.answer === "string"
+    return caseResult(
+      "output_schema",
+      "terminal_output_matches_schema",
+      matches,
+      matches ? "output_schema_ok" : "output_schema_violation",
+    )
+  } catch {
+    return caseResult(
+      "output_schema",
+      "terminal_output_matches_schema",
+      false,
+      "output_schema_case_unavailable",
+    )
+  }
+}
+
+export async function runQualificationSuite(
+  adapter: AgentHostAdapter,
+  options: QualificationOptions,
+): Promise<AdapterQualificationRecord> {
+  if (!HOST_ID_PATTERN.test(adapter.hostId)) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_HOST_ID",
+      "adapter hostId must be a lowercase ASCII identifier",
+    )
+  }
+  if (!ISO_PATTERN.test(options.generatedAt)) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_TIMESTAMP",
+      "generatedAt must be an ISO-8601 UTC timestamp",
+    )
+  }
+
+  const policy = defaultQualificationPolicy()
+  const cases: QualificationCaseResult[] = []
+  cases.push(await runCapabilityCase(adapter))
+  cases.push(
+    ...(await runEventCases(adapter, options.workingDirectory, policy)),
+  )
+  cases.push(
+    await runCancelCase(adapter, options.workingDirectory, policy),
+  )
+  cases.push(
+    await runCleanupCase(adapter, options.workingDirectory, policy),
+  )
+  cases.push(
+    await runCredentialCase(adapter, options.workingDirectory, policy),
+  )
+  cases.push(
+    ...(await runEnforcementCases(
+      adapter,
+      options.workingDirectory,
+      policy,
+    )),
+  )
+  cases.push(
+    await runOutputSchemaCase(adapter, options.workingDirectory, policy),
+  )
+
+  let probe: AgentHostProbeResult | undefined
+  try {
+    probe = await adapter.probe()
+  } catch {
+    probe = undefined
+  }
+  const implemented =
+    probe !== undefined &&
+    probe.protocolVersion === AGENT_HOST_PROTOCOL_VERSION &&
+    probe.status === "ready" &&
+    probe.available &&
+    probe.adapterStatus === "runnable" &&
+    AGENT_HOST_CAPABILITIES.every(
+      (capability) => probe!.capabilities[capability] !== undefined,
+    )
+
+  const fixtureConformant =
+    implemented && cases.every((result) => result.passed)
+  const liveEvidence = options.liveEvidence
+  const liveQualified = liveEvidence !== undefined
+  if (liveQualified) {
+    if (
+      !ENVIRONMENT_ID_PATTERN.test(liveEvidence.environment) ||
+      !HEX_64_PATTERN.test(liveEvidence.evidenceDigest)
+    ) {
+      throw qualificationError(
+        "INVALID_QUALIFICATION_LIVE_EVIDENCE",
+        "live evidence requires an environment id and a sha256 digest",
+      )
+    }
+  }
+
+  const domains = {} as Record<
+    QualificationDomain,
+    { passed: number; failed: number }
+  >
+  for (const domain of QUALIFICATION_DOMAINS) {
+    const domainCases = cases.filter((result) => result.domain === domain)
+    domains[domain] = {
+      passed: domainCases.filter((result) => result.passed).length,
+      failed: domainCases.filter((result) => !result.passed).length,
+    }
+  }
+
+  const record: AdapterQualificationRecord = {
+    schema: ADAPTER_QUALIFICATION_SCHEMA_ID,
+    hostId: adapter.hostId,
+    hostVersion: probe?.version ?? "unknown",
+    policyDigest: canonicalPolicyDigest(policy),
+    kitVersion: ADAPTER_QUALIFICATION_KIT_VERSION,
+    generatedAt: options.generatedAt,
+    axes: { implemented, fixtureConformant, liveQualified },
+    domains,
+    cases,
+    ...(liveEvidence !== undefined ? { liveEvidence } : {}),
+  }
+  validateAdapterQualificationRecord(record)
+  return record
+}
+
+export function validateAdapterQualificationRecord(
+  value: unknown,
+): AdapterQualificationRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      "qualification record must be an object",
+    )
+  }
+  const record = value as Record<string, unknown>
+  const allowed = new Set([
+    "schema",
+    "hostId",
+    "hostVersion",
+    "policyDigest",
+    "kitVersion",
+    "generatedAt",
+    "axes",
+    "domains",
+    "cases",
+    "liveEvidence",
+  ])
+  for (const key of Object.keys(record)) {
+    if (!allowed.has(key)) {
+      throw qualificationError(
+        "INVALID_QUALIFICATION_RECORD",
+        `unknown qualification record field: ${key}`,
+      )
+    }
+  }
+  if (record.schema !== ADAPTER_QUALIFICATION_SCHEMA_ID) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      `schema must be ${ADAPTER_QUALIFICATION_SCHEMA_ID}`,
+    )
+  }
+  if (
+    typeof record.hostId !== "string" ||
+    !HOST_ID_PATTERN.test(record.hostId)
+  ) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      "hostId must be a lowercase ASCII identifier",
+    )
+  }
+  if (typeof record.hostVersion !== "string" || record.hostVersion === "") {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      "hostVersion is required",
+    )
+  }
+  if (
+    typeof record.policyDigest !== "string" ||
+    !HEX_64_PATTERN.test(record.policyDigest)
+  ) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      "policyDigest must be a sha256 hex digest",
+    )
+  }
+  if (record.kitVersion !== ADAPTER_QUALIFICATION_KIT_VERSION) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      `kitVersion must be ${ADAPTER_QUALIFICATION_KIT_VERSION}`,
+    )
+  }
+  if (
+    typeof record.generatedAt !== "string" ||
+    !ISO_PATTERN.test(record.generatedAt)
+  ) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      "generatedAt must be an ISO-8601 UTC timestamp",
+    )
+  }
+
+  const axes = record.axes as Record<string, unknown> | undefined
+  if (
+    !axes ||
+    typeof axes !== "object" ||
+    typeof axes.implemented !== "boolean" ||
+    typeof axes.fixtureConformant !== "boolean" ||
+    typeof axes.liveQualified !== "boolean"
+  ) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      "axes must carry three booleans",
+    )
+  }
+  if (axes.fixtureConformant && !axes.implemented) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      "fixtureConformant requires implemented",
+    )
+  }
+  if (axes.liveQualified && record.liveEvidence === undefined) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      "liveQualified requires explicit liveEvidence",
+    )
+  }
+  if (record.liveEvidence !== undefined) {
+    const evidence = record.liveEvidence as Record<string, unknown> | null
+    if (
+      !evidence ||
+      typeof evidence !== "object" ||
+      typeof evidence.environment !== "string" ||
+      !ENVIRONMENT_ID_PATTERN.test(evidence.environment) ||
+      typeof evidence.evidenceDigest !== "string" ||
+      !HEX_64_PATTERN.test(evidence.evidenceDigest)
+    ) {
+      throw qualificationError(
+        "INVALID_QUALIFICATION_RECORD",
+        "liveEvidence requires an environment id and a sha256 digest",
+      )
+    }
+  }
+
+  const domains = record.domains as
+    | Record<string, unknown>
+    | undefined
+  if (!domains || typeof domains !== "object") {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      "domains is required",
+    )
+  }
+  for (const domain of QUALIFICATION_DOMAINS) {
+    const entry = domains[domain] as
+      | { passed?: unknown; failed?: unknown }
+      | undefined
+    if (
+      !entry ||
+      typeof entry.passed !== "number" ||
+      typeof entry.failed !== "number"
+    ) {
+      throw qualificationError(
+        "INVALID_QUALIFICATION_RECORD",
+        `domain ${domain} must report passed/failed counts`,
+      )
+    }
+  }
+
+  if (!Array.isArray(record.cases) || record.cases.length === 0) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      "cases must be a non-empty array",
+    )
+  }
+  const seenDomains = new Set<string>()
+  for (const entry of record.cases as Array<Record<string, unknown>>) {
+    if (
+      typeof entry.domain !== "string" ||
+      !(QUALIFICATION_DOMAINS as readonly string[]).includes(entry.domain)
+    ) {
+      throw qualificationError(
+        "INVALID_QUALIFICATION_RECORD",
+        "every case must declare a known domain",
+      )
+    }
+    if (
+      typeof entry.id !== "string" ||
+      !CASE_ID_PATTERN.test(entry.id)
+    ) {
+      throw qualificationError(
+        "INVALID_QUALIFICATION_RECORD",
+        "case ids must be lowercase snake_case",
+      )
+    }
+    if (typeof entry.passed !== "boolean") {
+      throw qualificationError(
+        "INVALID_QUALIFICATION_RECORD",
+        "every case must report a boolean result",
+      )
+    }
+    if (typeof entry.code !== "string" || entry.code === "") {
+      throw qualificationError(
+        "INVALID_QUALIFICATION_RECORD",
+        "every case must report a machine code",
+      )
+    }
+    seenDomains.add(entry.domain)
+  }
+  for (const domain of QUALIFICATION_DOMAINS) {
+    if (!seenDomains.has(domain)) {
+      throw qualificationError(
+        "INVALID_QUALIFICATION_RECORD",
+        `cases must cover domain ${domain}`,
+      )
+    }
+  }
+  return value as AdapterQualificationRecord
+}

--- a/tests/core/adapter-qualification.test.ts
+++ b/tests/core/adapter-qualification.test.ts
@@ -1,0 +1,436 @@
+import assert from "node:assert/strict"
+import { createHash } from "node:crypto"
+import { mkdtemp } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import {
+  AGENT_HOST_PROTOCOL_VERSION,
+  createUnknownAgentHostCapabilities,
+} from "../../packages/core/src/agent-host.js"
+import type {
+  AgentHostAdapter,
+  AgentHostEvent,
+  AgentHostProbeResult,
+  AgentHostRunRequest,
+} from "../../packages/core/src/agent-host.js"
+import {
+  ADAPTER_QUALIFICATION_KIT_VERSION,
+  ADAPTER_QUALIFICATION_SCHEMA_ID,
+  QUALIFICATION_DOMAINS,
+  canonicalPolicyDigest,
+  runQualificationSuite,
+  validateAdapterQualificationRecord,
+} from "../../packages/core/src/adapter-qualification.js"
+import type { AdapterQualificationRecord } from "../../packages/core/src/adapter-qualification.js"
+
+const GENERATED_AT = "2026-08-06T03:00:00Z"
+const SENTINEL = "qualification-sentinel-do-not-leak"
+
+function verifiedProbe(hostId = "fixture-host"): AgentHostProbeResult {
+  const capabilities = createUnknownAgentHostCapabilities()
+  capabilities.non_interactive_run = "supported"
+  capabilities.event_stream = "supported"
+  capabilities.tool_allowlist = "supported"
+  capabilities.filesystem_scope = "supported"
+  capabilities.network_policy = "supported"
+  return {
+    protocolVersion: AGENT_HOST_PROTOCOL_VERSION,
+    hostId,
+    displayName: "Fixture Host",
+    status: "ready",
+    available: true,
+    adapterStatus: "runnable",
+    version: "9.9.9",
+    capabilities,
+    capabilitySource: "conformance_test",
+    issues: [],
+  }
+}
+
+interface FixtureBehavior {
+  eventAfterTerminal?: boolean
+  disallowedTool?: boolean
+  outputSchemaViolation?: boolean
+  echoMetadata?: boolean
+  missingCapability?: boolean
+  probeOnly?: boolean
+  acceptHostileWrite?: boolean
+}
+
+function qualificationAdapter(
+  behavior: FixtureBehavior = {},
+): AgentHostAdapter {
+  return {
+    hostId: "fixture-host",
+    async probe() {
+      const probe = verifiedProbe()
+      if (behavior.missingCapability) {
+        probe.capabilities = Object.fromEntries(
+          Object.entries(probe.capabilities).filter(
+            ([key]) => key !== "tool_allowlist",
+          ),
+        ) as typeof probe.capabilities
+      }
+      if (behavior.probeOnly) {
+        probe.adapterStatus = "probe_only"
+      }
+      return probe
+    },
+    async preflight(request: AgentHostRunRequest) {
+      if (!behavior.acceptHostileWrite && request.policy.filesystem.write.length > 0) {
+        throw new Error("write outside filesystem scope")
+      }
+      return verifiedProbe()
+    },
+    async *run(request) {
+      const at = "2026-08-06T03:00:00.000Z"
+      const started: AgentHostEvent = {
+        type: "run.started",
+        runId: request.runId,
+        timestamp: at,
+      }
+      yield started
+      if (behavior.echoMetadata) {
+        yield {
+          type: "assistant.delta",
+          runId: request.runId,
+          timestamp: at,
+          text: JSON.stringify(request.metadata ?? {}),
+        }
+      }
+      if (behavior.disallowedTool) {
+        yield {
+          type: "tool.started",
+          runId: request.runId,
+          timestamp: at,
+          toolCallId: "call-1",
+          toolName: "shell",
+        }
+      } else if (request.runId === "qualification-tool_enforcement") {
+        yield {
+          type: "tool.started",
+          runId: request.runId,
+          timestamp: at,
+          toolCallId: "call-1",
+          toolName: "noop",
+        }
+      }
+      const schemaCase = request.runId === "qualification-output_schema"
+      const output =
+        schemaCase && !behavior.outputSchemaViolation
+          ? { answer: "qualified" }
+          : { status: "answered", answer: "fixture", citations: [] }
+      yield {
+        type: "run.completed",
+        runId: request.runId,
+        timestamp: at,
+        output,
+      }
+      if (behavior.eventAfterTerminal) {
+        yield {
+          type: "usage",
+          runId: request.runId,
+          timestamp: at,
+          totalTokens: 1,
+        }
+      }
+    },
+    async cancel() {},
+  }
+}
+
+async function workingDirectory(): Promise<string> {
+  return await mkdtemp(path.join(os.tmpdir(), "adapter-qualification-"))
+}
+
+test("a conforming built-in-class adapter earns the fixture axis without live evidence", async () => {
+  const directory = await workingDirectory()
+  const record = await runQualificationSuite(qualificationAdapter(), {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+  })
+
+  assert.equal(record.schema, ADAPTER_QUALIFICATION_SCHEMA_ID)
+  assert.equal(record.kitVersion, ADAPTER_QUALIFICATION_KIT_VERSION)
+  assert.equal(record.hostId, "fixture-host")
+  assert.equal(record.hostVersion, "9.9.9")
+  assert.deepEqual(record.axes, {
+    implemented: true,
+    fixtureConformant: true,
+    liveQualified: false,
+  })
+  assert.equal(record.liveEvidence, undefined)
+  assert.equal(record.cases.length, 9)
+  assert.ok(record.cases.every((entry) => entry.passed))
+  for (const domain of QUALIFICATION_DOMAINS) {
+    assert.equal(record.domains[domain].failed, 0, domain)
+  }
+  assert.equal(
+    record.policyDigest,
+    createHash("sha256")
+      .update(
+        JSON.stringify(
+          {
+            tools: { default: "deny", allow: [{ name: "noop", mode: "read" }] },
+            filesystem: { read: ["."], write: [] },
+            network: { mode: "deny" },
+            approval: { mode: "never" },
+            maxTurns: 4,
+          },
+          ["approval", "filesystem", "maxTurns", "network", "tools"],
+        ),
+      )
+      .digest("hex"),
+  )
+})
+
+test("a stream violation can never be reported as fixture-conformant", async () => {
+  const directory = await workingDirectory()
+  const record = await runQualificationSuite(
+    qualificationAdapter({ eventAfterTerminal: true }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  const terminalCase = record.cases.find(
+    (entry) => entry.id === "exactly_one_terminal",
+  )
+  assert.equal(terminalCase?.passed, false)
+  assert.equal(terminalCase?.code, "event_after_terminal")
+  assert.deepEqual(record.axes, {
+    implemented: true,
+    fixtureConformant: false,
+    liveQualified: false,
+  })
+})
+
+test("a disallowed tool event fails the tool enforcement domain", async () => {
+  const directory = await workingDirectory()
+  const record = await runQualificationSuite(
+    qualificationAdapter({ disallowedTool: true }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  const toolCase = record.cases.find(
+    (entry) => entry.id === "tool_allowlist_respected",
+  )
+  assert.equal(toolCase?.passed, false)
+  assert.equal(toolCase?.code, "disallowed_tool_event")
+  assert.equal(record.axes.fixtureConformant, false)
+})
+
+test("a terminal output outside the schema fails the output schema domain", async () => {
+  const directory = await workingDirectory()
+  const record = await runQualificationSuite(
+    qualificationAdapter({ outputSchemaViolation: true }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  const schemaCase = record.cases.find(
+    (entry) => entry.id === "terminal_output_matches_schema",
+  )
+  assert.equal(schemaCase?.passed, false)
+  assert.equal(schemaCase?.code, "output_schema_violation")
+  assert.equal(record.axes.fixtureConformant, false)
+})
+
+test("an adapter that echoes request metadata fails the credential boundary domain", async () => {
+  const directory = await workingDirectory()
+  const record = await runQualificationSuite(
+    qualificationAdapter({ echoMetadata: true }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  const credentialCase = record.cases.find(
+    (entry) => entry.id === "no_metadata_echo",
+  )
+  assert.equal(credentialCase?.passed, false)
+  assert.equal(credentialCase?.code, "metadata_secret_echoed")
+  assert.equal(record.axes.fixtureConformant, false)
+})
+
+test("an adapter that accepts hostile writes fails the enforcement domain", async () => {
+  const directory = await workingDirectory()
+  const record = await runQualificationSuite(
+    qualificationAdapter({ acceptHostileWrite: true }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  const fsCase = record.cases.find(
+    (entry) => entry.id === "hostile_write_refused",
+  )
+  assert.equal(fsCase?.passed, false)
+  assert.equal(fsCase?.code, "hostile_write_accepted")
+  assert.equal(record.axes.fixtureConformant, false)
+})
+
+test("a missing capability or probe-only adapter cannot reach the implemented axis", async () => {
+  const directory = await workingDirectory()
+  const missing = await runQualificationSuite(
+    qualificationAdapter({ missingCapability: true }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  assert.deepEqual(missing.axes, {
+    implemented: false,
+    fixtureConformant: false,
+    liveQualified: false,
+  })
+  const probeCase = missing.cases.find((entry) => entry.id === "probe_contract")
+  assert.equal(probeCase?.passed, false)
+  assert.equal(probeCase?.code, "probe_contract_violation")
+
+  const probeOnly = await runQualificationSuite(
+    qualificationAdapter({ probeOnly: true }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  assert.equal(probeOnly.axes.implemented, false)
+  assert.equal(probeOnly.axes.fixtureConformant, false)
+})
+
+test("the live axis is fail-closed and requires explicit validated evidence", async () => {
+  const directory = await workingDirectory()
+  const evidenceDigest = createHash("sha256")
+    .update("live-run-evidence")
+    .digest("hex")
+  const qualified = await runQualificationSuite(qualificationAdapter(), {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+    liveEvidence: { environment: "live-local-e2e", evidenceDigest },
+  })
+  assert.equal(qualified.axes.liveQualified, true)
+  assert.deepEqual(qualified.liveEvidence, {
+    environment: "live-local-e2e",
+    evidenceDigest,
+  })
+
+  await assert.rejects(
+    () =>
+      runQualificationSuite(qualificationAdapter(), {
+        workingDirectory: directory,
+        generatedAt: GENERATED_AT,
+        liveEvidence: { environment: "live", evidenceDigest: "not-a-digest" },
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "INVALID_QUALIFICATION_LIVE_EVIDENCE",
+  )
+})
+
+test("qualification input validation rejects bad host ids and timestamps", async () => {
+  const directory = await workingDirectory()
+  await assert.rejects(
+    () =>
+      runQualificationSuite(qualificationAdapter(), {
+        workingDirectory: directory,
+        generatedAt: "2026-08-06 03:00:00",
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "INVALID_QUALIFICATION_TIMESTAMP",
+  )
+  const badHost = qualificationAdapter()
+  Object.defineProperty(badHost, "hostId", { value: "Fixture_Host" })
+  await assert.rejects(
+    () =>
+      runQualificationSuite(badHost, {
+        workingDirectory: directory,
+        generatedAt: GENERATED_AT,
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "INVALID_QUALIFICATION_HOST_ID",
+  )
+})
+
+test("the record validator enforces schema, axis consistency and full domain coverage", async () => {
+  const directory = await workingDirectory()
+  const record = await runQualificationSuite(qualificationAdapter(), {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+  })
+
+  assert.doesNotThrow(() => validateAdapterQualificationRecord(record))
+  assert.throws(
+    () =>
+      validateAdapterQualificationRecord({ ...record, schema: "wrong.v1" }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "INVALID_QUALIFICATION_RECORD",
+  )
+  assert.throws(
+    () => validateAdapterQualificationRecord({ ...record, extra: 1 }),
+    /unknown qualification record field/,
+  )
+  assert.throws(() =>
+    validateAdapterQualificationRecord({
+      ...record,
+      axes: {
+        implemented: false,
+        fixtureConformant: true,
+        liveQualified: false,
+      },
+    }),
+  )
+  assert.throws(() =>
+    validateAdapterQualificationRecord({
+      ...record,
+      axes: { implemented: true, fixtureConformant: true, liveQualified: true },
+    }),
+  )
+  assert.throws(() =>
+    validateAdapterQualificationRecord({
+      ...record,
+      cases: record.cases.filter(
+        (entry) => entry.domain !== "credential_boundaries",
+      ),
+    }),
+  )
+  assert.throws(() =>
+    validateAdapterQualificationRecord({ ...record, hostId: "UPPER" }),
+  )
+  assert.throws(() => validateAdapterQualificationRecord(null))
+})
+
+test("qualification records stay machine readable and never embed the credential sentinel", async () => {
+  const directory = await workingDirectory()
+  const record: AdapterQualificationRecord = await runQualificationSuite(
+    qualificationAdapter(),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  const serialized = JSON.stringify(record)
+  assert.ok(!serialized.includes(SENTINEL))
+  assert.ok(record.cases.every((entry) => /^[a-z0-9_]+$/.test(entry.code)))
+  assert.ok(
+    record.cases.every((entry) => /^[a-z0-9_]+$/.test(entry.id)),
+  )
+  assert.ok(
+    Object.values(record.domains).every(
+      (entry) =>
+        Number.isInteger(entry.passed) && Number.isInteger(entry.failed),
+    ),
+  )
+})
+
+test("the policy digest is deterministic across runs", async () => {
+  const directory = await workingDirectory()
+  const first = await runQualificationSuite(qualificationAdapter(), {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+  })
+  const second = await runQualificationSuite(qualificationAdapter(), {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+  })
+  assert.equal(first.policyDigest, second.policyDigest)
+  assert.match(first.policyDigest, /^[0-9a-f]{64}$/)
+  assert.equal(
+    canonicalPolicyDigest({
+      approval: { mode: "never" },
+      filesystem: { read: ["."], write: [] },
+      maxTurns: 4,
+      network: { mode: "deny" },
+      tools: { default: "deny", allow: [{ name: "noop", mode: "read" }] },
+    }),
+    first.policyDigest,
+  )
+})


### PR DESCRIPTION
## Summary

Implements Issue #30 R1 (adapter qualification kit), the first hard dependency of the D1 Phase A gate chain (#30 → #33 → #36 → mem#70 → #42 Phase A).

- `packages/core/src/adapter-qualification.ts` — mandatory nine-domain conformance suite (`runQualificationSuite`): capability_negotiation, native_event_validation, single_terminal_outcome, deadline_cancel, process_tree_cleanup, credential_boundaries, filesystem_network_enforcement, tool_mcp_enforcement, output_schema.
- Three independent axes with strict semantics: `implemented` (probe contract + full capability set), `fixtureConformant` (implemented && all cases pass), `liveQualified` (fail-closed; only with explicit validated `liveEvidence`, never triggers a provider call by itself).
- `adapter-qualification-record.v1`: versioned machine-readable record keyed by hostId/hostVersion/policyDigest (`canonicalPolicyDigest`, sorted-key sha256). Records carry only machine codes, booleans and digests — evidence hygiene by construction (REQ-004).
- Strict validator `validateAdapterQualificationRecord`: unknown fields rejected, axis consistency enforced (`fixtureConformant⇒implemented`, `liveQualified⇒liveEvidence`), cases must cover all nine domains.
- 12 new tests: conforming built-in-class fixture earns fixture axis; event-after-terminal, disallowed tool, output-schema violation, metadata sentinel echo, hostile-write acceptance, missing capability and probe-only adapters can never be reported fixture-conformant; live axis fail-closed incl. malformed evidence; record validation negatives; sentinel-absence hygiene scan.

## Requirement traceability

- REQ-001 / AC-001 — mandatory common suite across adapter classes
- REQ-002 / AC-002 — three independent axes, live axis fail-closed
- REQ-003 / AC-003 — versioned machine-readable record + strict validation
- REQ-004 / AC-004 — evidence hygiene, offline default, no sentinel leakage

## Verification

- `npm run check` green: typecheck + build + 405/405 tests + security:check.

Requirement-Issue: https://github.com/fullstack-ai-infra/digital-employee/issues/30
Issue-Revision: R1