### PR TITLE
feat(core): agent-host-stdio.v1 external adapter protocol (Issue #33 R1)

### DIFF
--- a/apps/cli/bin.ts
+++ b/apps/cli/bin.ts
@@ -2,9 +2,13 @@
 
 import { parseArgs } from "node:util";
 import { createReadStream } from "node:fs";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { DigitalEmployee } from "../../packages/core/src/digital-employee.js";
+import { validateStdioAdapterConfig } from "../../packages/core/src/agent-host-stdio-config.js";
+import type { AgentHostPolicy } from "../../packages/core/src/agent-host.js";
+import { ExternalStdioAgentHostAdapter } from "./stdio-agent-host.js";
 import {
   BUILT_IN_AGENT_HOST_IDS,
 } from "./agent-hosts.js";
@@ -54,6 +58,7 @@ Agent-native usage:
   digital-employee validate [directory] [--engine claude-code|qoder|codex|qwen-code|codebuddy] [--json]
   digital-employee eval [directory] [--json]
   digital-employee run [directory] --engine claude-code|qoder|qwen-code|codebuddy (--stdin | --input-file path | --question "..." | --input '{"message":"..."}') [--json]
+  digital-employee stdio-host <config.json> [--question "..."] [--json]
 
 Standalone-v1 compatibility:
   digital-employee legacy <ask|sync|start|serve> [options]
@@ -526,7 +531,63 @@ async function main() {
   if (command === "validate") return validate(values, positionals);
   if (command === "eval") return evalFixtures(values, positionals);
   if (command === "run") return run(values, positionals);
+  if (command === "stdio-host") return stdioHost(values, positionals);
   throw new TypeError(`unknown_command:${command}`);
+}
+
+function stdioHostPolicy(): AgentHostPolicy {
+  return {
+    tools: { default: "deny", allow: [] },
+    filesystem: { read: ["."], write: [] },
+    network: { mode: "deny" },
+    approval: { mode: "never" },
+    maxTurns: 4,
+  };
+}
+
+async function stdioHost(values: CommandValues, positionals: string[]) {
+  const configPath = positionals[0];
+  if (!configPath) {
+    throw new TypeError("stdio_host_config_required");
+  }
+  const config = validateStdioAdapterConfig(
+    JSON.parse(await readFile(configPath, "utf8")),
+  );
+  const adapter = new ExternalStdioAgentHostAdapter(config);
+  try {
+    const probe = await adapter.probe();
+    if (!values.question) {
+      process.stdout.write(`${JSON.stringify(probe, null, 2)}\n`);
+      return;
+    }
+    await adapter.preflight({
+      runId: "cli-stdio-preflight",
+      employeeId: "cli",
+      workingDirectory: process.cwd(),
+      prompt: values.question,
+      policy: stdioHostPolicy(),
+    });
+    const events = [];
+    for await (const event of adapter.run({
+      runId: "cli-stdio-run",
+      employeeId: "cli",
+      workingDirectory: process.cwd(),
+      prompt: values.question,
+      policy: stdioHostPolicy(),
+    })) {
+      events.push(event);
+    }
+    if (values.json) {
+      process.stdout.write(`${JSON.stringify(events, null, 2)}\n`);
+      return;
+    }
+    const terminal = events[events.length - 1];
+    process.stdout.write(
+      `${terminal && terminal.type === "run.completed" ? JSON.stringify(terminal.output) : "run_failed"}\n`,
+    );
+  } finally {
+    await adapter.dispose();
+  }
 }
 
 main().catch((error: unknown) => {

--- a/apps/cli/reference-stdio-host.ts
+++ b/apps/cli/reference-stdio-host.ts
@@ -1,0 +1,258 @@
+import readline from "node:readline"
+import { spawn } from "node:child_process"
+
+import {
+  AGENT_HOST_PROTOCOL_VERSION,
+  createUnknownAgentHostCapabilities,
+} from "../../packages/core/src/agent-host.js"
+import type { AgentHostProbeResult } from "../../packages/core/src/agent-host.js"
+import {
+  AGENT_HOST_STDIO_PROTOCOL_VERSION,
+  encodeAgentHostStdioLine,
+  parseAgentHostStdioRequest,
+} from "../../packages/core/src/agent-host-stdio.js"
+import type { AgentHostStdioRequest } from "../../packages/core/src/agent-host-stdio.js"
+
+export const REFERENCE_STDIO_HOST_ID = "reference-stdio-host"
+
+/**
+ * Builds the reference Adapter's probe result. Conformance fixtures vary it
+ * only through explicit overrides, never through runtime branching.
+ */
+export function referenceStdioProbe(
+  overrides: {
+    hostId?: string
+    status?: AgentHostProbeResult["status"]
+    adapterStatus?: AgentHostProbeResult["adapterStatus"]
+    capabilitySource?: AgentHostProbeResult["capabilitySource"]
+    missingCapability?: string
+  } = {},
+): AgentHostProbeResult {
+  const capabilities = createUnknownAgentHostCapabilities()
+  capabilities.non_interactive_run = "supported"
+  capabilities.event_stream = "supported"
+  capabilities.tool_allowlist = "supported"
+  capabilities.filesystem_scope = "supported"
+  capabilities.network_policy = "supported"
+  if (overrides.missingCapability) {
+    delete (capabilities as Record<string, unknown>)[overrides.missingCapability]
+  }
+  return {
+    protocolVersion: AGENT_HOST_PROTOCOL_VERSION,
+    hostId: overrides.hostId ?? REFERENCE_STDIO_HOST_ID,
+    displayName: "Reference Stdio Host",
+    status: overrides.status ?? "ready",
+    available: true,
+    adapterStatus: overrides.adapterStatus ?? "runnable",
+    version: "1.0.0",
+    capabilities,
+    capabilitySource: overrides.capabilitySource ?? "conformance_test",
+    issues: [],
+  }
+}
+
+function envFlag(name: string): boolean {
+  return process.env[name] === "1"
+}
+
+function write(message: unknown): void {
+  process.stdout.write(`${encodeAgentHostStdioLine(message)}\n`)
+}
+
+function diagnostics(text: string): void {
+  // stderr is diagnostics-only and bounded; stdout carries protocol only.
+  process.stderr.write(`[reference-stdio-host] ${text}\n`.slice(0, 512))
+}
+
+function successResponse(id: string, result?: unknown): void {
+  write({
+    protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+    id,
+    kind: "response",
+    ok: true,
+    ...(result === undefined ? {} : { result }),
+  })
+}
+
+function errorResponse(id: string, code: string): void {
+  write({
+    protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+    id,
+    kind: "response",
+    ok: false,
+    error: { code, message: "reference host refused the request", retryable: false },
+  })
+}
+
+function event(id: string, runId: string, body: Record<string, unknown>): void {
+  write({
+    protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+    id,
+    kind: "event",
+    event: { runId, timestamp: new Date().toISOString(), ...body },
+  })
+}
+
+/**
+ * Serves agent-host-stdio.v1 on this process's stdio. Violation fixtures are
+ * selected through REFERENCE_STDIO_* environment flags so each AC-002 path is
+ * deterministic and reviewable.
+ */
+export function serveReferenceStdioHost(): void {
+  const lineReader = readline.createInterface({ input: process.stdin })
+  let cancelledRunId: string | null = null
+  let activeRun: { id: string; runId: string } | null = null
+
+  if (envFlag("REFERENCE_STDIO_SPAWN_CHILD")) {
+    // Same process group, unref'd and detached from stdio: it survives the
+    // host's own exit, so only a real process-tree cleanup can stop it.
+    const leaked = spawn(
+      process.execPath,
+      ["-e", "setInterval(() => {}, 1000)"],
+      { stdio: "ignore" },
+    )
+    leaked.unref()
+    diagnostics(`spawned child pid ${leaked.pid ?? 0}`)
+  }
+
+  lineReader.on("line", (line) => {
+    let request: AgentHostStdioRequest
+    try {
+      request = parseAgentHostStdioRequest(line)
+    } catch (error) {
+      diagnostics("rejecting malformed request line")
+      errorResponse("unparsed", "agent_host_stdio_bad_framing")
+      void error
+      return
+    }
+    switch (request.kind) {
+      case "probe": {
+        const probe = referenceStdioProbe({
+          status: envFlag("REFERENCE_STDIO_NOT_READY")
+            ? "not_ready"
+            : "ready",
+          adapterStatus: envFlag("REFERENCE_STDIO_PROBE_ONLY")
+            ? "probe_only"
+            : "runnable",
+          missingCapability: envFlag("REFERENCE_STDIO_MISSING_CAPABILITY")
+            ? "tool_allowlist"
+            : undefined,
+        })
+        if (envFlag("REFERENCE_STDIO_UNKNOWN_FIELD")) {
+          write({
+            protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+            id: request.id,
+            kind: "response",
+            ok: true,
+            result: { ...probe, extraField: true },
+          })
+        } else {
+          successResponse(request.id, probe)
+        }
+        return
+      }
+      case "preflight": {
+        const payload = request.payload as { policy?: { filesystem?: { write?: string[] } } }
+        const writes = payload.policy?.filesystem?.write ?? []
+        if (writes.length > 0 && !envFlag("REFERENCE_STDIO_HOSTILE_WRITE_OK")) {
+          errorResponse(request.id, "agent_host_preflight_invalid")
+          return
+        }
+        successResponse(request.id, referenceStdioProbe())
+        return
+      }
+      case "cancel": {
+        const payload = request.payload as { runId: string }
+        if (!envFlag("REFERENCE_STDIO_REFUSE_CANCEL")) {
+          cancelledRunId = payload.runId
+          diagnostics(`cancel requested for ${payload.runId}`)
+          if (activeRun && activeRun.runId === payload.runId) {
+            event(activeRun.id, payload.runId, {
+              type: "run.failed",
+              error: {
+                code: "agent_host_cancelled",
+                message: "run cancelled",
+                retryable: false,
+              },
+            })
+            successResponse(activeRun.id)
+            activeRun = null
+          }
+        }
+        return
+      }
+      case "run": {
+        const payload = request.payload as {
+          runId: string
+          outputSchema?: unknown
+        }
+        activeRun = { id: request.id, runId: payload.runId }
+        diagnostics(`run started for ${payload.runId}`)
+        event(request.id, payload.runId, { type: "run.started" })
+        if (envFlag("REFERENCE_STDIO_DISALLOWED_TOOL")) {
+          event(request.id, payload.runId, {
+            type: "tool.started",
+            toolCallId: "call-1",
+            toolName: "shell",
+          })
+        }
+        if (envFlag("REFERENCE_STDIO_HANG")) {
+          return
+        }
+        if (cancelledRunId === payload.runId) {
+          event(request.id, payload.runId, {
+            type: "run.failed",
+            error: {
+              code: "agent_host_cancelled",
+              message: "run cancelled",
+              retryable: false,
+            },
+          })
+          successResponse(request.id)
+          activeRun = null
+          return
+        }
+        const output =
+          payload.outputSchema !== undefined
+            ? { answer: "reference" }
+            : { status: "answered", answer: "reference host", citations: [] }
+        event(request.id, payload.runId, {
+          type: "run.completed",
+          output,
+        })
+        if (envFlag("REFERENCE_STDIO_DUP_TERMINAL")) {
+          event(request.id, payload.runId, {
+            type: "run.completed",
+            output,
+          })
+        }
+        if (envFlag("REFERENCE_STDIO_AFTER_TERMINAL")) {
+          event(request.id, payload.runId, {
+            type: "usage",
+            totalTokens: 1,
+          })
+        }
+        if (!envFlag("REFERENCE_STDIO_NO_CLOSE")) {
+          successResponse(request.id)
+        }
+        activeRun = null
+        if (envFlag("REFERENCE_STDIO_EXIT_AFTER_RUN")) {
+          process.exit(0)
+        }
+        return
+      }
+      default:
+        errorResponse(request.id, "agent_host_stdio_unknown_message")
+    }
+  })
+  lineReader.on("close", () => {
+    process.exit(0)
+  })
+}
+
+const invokedDirectly =
+  typeof process.argv[1] === "string" &&
+  process.argv[1].includes("reference-stdio-host")
+if (invokedDirectly) {
+  serveReferenceStdioHost()
+}

--- a/apps/cli/stdio-agent-host.ts
+++ b/apps/cli/stdio-agent-host.ts
@@ -1,0 +1,471 @@
+import { createHash } from "node:crypto"
+import { spawn } from "node:child_process"
+import type { ChildProcess } from "node:child_process"
+import { dirname } from "node:path"
+import { readFile } from "node:fs/promises"
+
+import { CoreError } from "../../packages/core/src/contracts.js"
+import type {
+  AgentHostAdapter,
+  AgentHostEvent,
+  AgentHostProbeResult,
+  AgentHostRunRequest,
+} from "../../packages/core/src/agent-host.js"
+import {
+  validateAgentHostEventWire,
+  validateAgentHostRunRequestWire,
+} from "../../packages/core/src/agent-host-wire.js"
+import type { AgentHostRegistration } from "../../packages/core/src/agent-host-registry.js"
+import type { StdioAdapterConfig } from "../../packages/core/src/agent-host-stdio-config.js"
+import { stdioAdapterEnvironment } from "../../packages/core/src/agent-host-stdio-config.js"
+import {
+  AGENT_HOST_STDIO_PROTOCOL_VERSION,
+  encodeAgentHostStdioLine,
+  parseAgentHostStdioHostLine,
+  probeResultFromStdioResponse,
+} from "../../packages/core/src/agent-host-stdio.js"
+import type { AgentHostStdioMessage } from "../../packages/core/src/agent-host-stdio.js"
+import {
+  signalAgentHostProcessTree,
+  waitForAgentHostProcessTreeExit,
+} from "./agent-host-process-tree.js"
+
+const STDIO_CODES = {
+  digestMismatch: "agent_host_stdio_digest_mismatch",
+  spawnFailed: "agent_host_stdio_spawn_failed",
+  timeout: "agent_host_stdio_timeout",
+  badFraming: "agent_host_stdio_bad_framing",
+  hostError: "agent_host_stdio_host_error",
+  terminalContractViolated: "agent_host_terminal_contract_violated",
+  cleanupFailed: "agent_host_stdio_cleanup_failed",
+  streamFailed: "agent_host_stream_failed",
+} as const
+
+function stdioError(
+  code: string,
+  message: string,
+  details?: unknown,
+): CoreError {
+  return new CoreError(code, message, {
+    status: 502,
+    retryable: false,
+    details,
+  })
+}
+
+interface StreamState {
+  queue: AgentHostStdioMessage[]
+  notify: (() => void) | null
+  closed: boolean
+  failure: CoreError | null
+}
+
+/**
+ * SDK client for one digest-pinned external Adapter speaking
+ * agent-host-stdio.v1. Every violation (digest mismatch, bad framing,
+ * unknown fields, duplicate terminals, timeout) fails closed and the
+ * detached process tree is always signalled on disposal.
+ */
+export class ExternalStdioAgentHostAdapter implements AgentHostAdapter {
+  readonly hostId: string
+
+  private readonly config: StdioAdapterConfig
+  private child: ChildProcess | null = null
+  private stdoutCarry = ""
+  private stderrTail = ""
+  private sequence = 0
+  private readonly pending = new Map<
+    string,
+    { resolve: (message: AgentHostStdioMessage) => void }
+  >()
+  private readonly streams = new Map<string, StreamState>()
+  private exited = false
+
+  constructor(config: StdioAdapterConfig) {
+    this.config = config
+    this.hostId = config.hostId
+  }
+
+  /** Bounded stderr diagnostics tail; raw stderr is never surfaced unbounded. */
+  diagnosticsTail(): string {
+    return this.stderrTail
+  }
+
+  async probe(): Promise<AgentHostProbeResult> {
+    const message = await this.exchange("probe")
+    return probeResultFromStdioResponse(message, this.hostId)
+  }
+
+  async preflight(request: AgentHostRunRequest): Promise<AgentHostProbeResult> {
+    const payload = validateAgentHostRunRequestWire(this.wirePayload(request))
+    const message = await this.exchange("preflight", payload)
+    return probeResultFromStdioResponse(message, this.hostId)
+  }
+
+  async *run(request: AgentHostRunRequest): AsyncGenerator<AgentHostEvent> {
+    const payload = validateAgentHostRunRequestWire(this.wirePayload(request))
+    const child = await this.ensureChild()
+    const id = this.nextId()
+    const state: StreamState = {
+      queue: [],
+      notify: null,
+      closed: false,
+      failure: null,
+    }
+    this.streams.set(id, state)
+    const timer = setTimeout(() => {
+      this.failStream(id, stdioError(STDIO_CODES.timeout, "stdio run timed out"))
+      void this.cancel(request.runId).catch(() => {})
+      signalAgentHostProcessTree(child, "SIGTERM")
+    }, this.config.timeoutMs)
+    timer.unref?.()
+    try {
+      this.writeLine({
+        protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+        id,
+        kind: "run",
+        payload,
+      })
+      let sawTerminal = false
+      while (true) {
+        const message = await this.nextMessage(id, state)
+        if (message === null) {
+          if (!sawTerminal) {
+            throw stdioError(
+              STDIO_CODES.terminalContractViolated,
+              "stdio run stream closed without a terminal event",
+            )
+          }
+          return
+        }
+        if (message.kind === "event") {
+          if (sawTerminal) {
+            throw stdioError(
+              STDIO_CODES.terminalContractViolated,
+              "stdio adapter emitted an event after the terminal outcome",
+            )
+          }
+          yield validateAgentHostEventWire(message.event)
+          if (
+            message.event.type === "run.completed" ||
+            message.event.type === "run.failed"
+          ) {
+            sawTerminal = true
+          }
+          continue
+        }
+        if (message.kind !== "response") {
+          throw stdioError(
+            STDIO_CODES.streamFailed,
+            "stdio run exchange received an unexpected message",
+          )
+        }
+        if (message.ok !== true) {
+          throw stdioError(
+            STDIO_CODES.hostError,
+            "agent host rejected the stdio run",
+            { code: message.error.code, retryable: message.error.retryable },
+          )
+        }
+        // A success response after the terminal closes the exchange.
+        if (!sawTerminal) {
+          throw stdioError(
+            STDIO_CODES.terminalContractViolated,
+            "stdio run response arrived before any terminal event",
+          )
+        }
+        return
+      }
+    } finally {
+      clearTimeout(timer)
+      this.streams.delete(id)
+    }
+  }
+
+  async cancel(runId: string): Promise<void> {
+    if (this.exited) return
+    const id = this.nextId()
+    try {
+      this.writeLine({
+        protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+        id,
+        kind: "cancel",
+        payload: { runId },
+      })
+    } catch {
+      return
+    }
+  }
+
+  /** Signals the detached process tree and verifies it is gone. */
+  async dispose(): Promise<void> {
+    const child = this.child
+    this.failAllStreams(
+      stdioError(STDIO_CODES.cleanupFailed, "stdio adapter disposed"),
+    )
+    if (!child || child.pid === undefined) {
+      this.exited = true
+      return
+    }
+    signalAgentHostProcessTree(child, "SIGTERM")
+    if (!(await waitForAgentHostProcessTreeExit(child, 2_000))) {
+      signalAgentHostProcessTree(child, "SIGKILL")
+      if (!(await waitForAgentHostProcessTreeExit(child, 2_000))) {
+        throw stdioError(
+          STDIO_CODES.cleanupFailed,
+          "stdio adapter process tree did not exit after SIGTERM and SIGKILL",
+        )
+      }
+    }
+    this.exited = true
+  }
+
+  private wirePayload(request: AgentHostRunRequest): AgentHostRunRequest {
+    const { signal: _runtimeSignal, ...wire } = request
+    return wire
+  }
+
+  private nextId(): string {
+    this.sequence += 1
+    return `${this.hostId}-${this.sequence}`
+  }
+
+  private async exchange(
+    kind: "probe" | "preflight",
+    payload?: AgentHostRunRequest,
+  ): Promise<AgentHostStdioMessage> {
+    await this.ensureChild()
+    const id = this.nextId()
+    const waiter: { resolve: (message: AgentHostStdioMessage) => void } = {
+      resolve: () => {},
+    }
+    const received = new Promise<AgentHostStdioMessage>((resolve) => {
+      waiter.resolve = resolve
+    })
+    this.pending.set(id, waiter)
+    const timer = setTimeout(() => {
+      if (this.pending.delete(id)) {
+        waiter.resolve({
+          protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+          id,
+          kind: "response",
+          ok: false,
+          error: {
+            code: STDIO_CODES.timeout,
+            message: "stdio exchange timed out",
+            retryable: false,
+          },
+        })
+      }
+    }, this.config.timeoutMs)
+    timer.unref?.()
+    try {
+      this.writeLine({
+        protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+        id,
+        kind,
+        ...(payload ? { payload } : {}),
+      })
+      return await received
+    } finally {
+      clearTimeout(timer)
+      this.pending.delete(id)
+    }
+  }
+
+  private writeLine(message: unknown): void {
+    const child = this.child
+    const stdin = child?.stdin
+    if (!child || !stdin || stdin.destroyed || this.exited) {
+      throw stdioError(
+        STDIO_CODES.spawnFailed,
+        "stdio adapter process is not running",
+      )
+    }
+    stdin.write(`${encodeAgentHostStdioLine(message)}\n`)
+  }
+
+  private async ensureChild(): Promise<ChildProcess> {
+    if (this.child && !this.exited && this.child.exitCode === null) {
+      return this.child
+    }
+    let bytes: Buffer
+    try {
+      bytes = await readFile(this.config.executable)
+    } catch {
+      throw stdioError(
+        STDIO_CODES.spawnFailed,
+        "stdio adapter executable is not readable",
+        { hostId: this.hostId },
+      )
+    }
+    const digest = createHash("sha256").update(bytes).digest("hex")
+    if (digest !== this.config.digest.hex) {
+      throw stdioError(
+        STDIO_CODES.digestMismatch,
+        "stdio adapter executable does not match the pinned sha256 digest",
+        { hostId: this.hostId },
+      )
+    }
+    const child = spawn(this.config.executable, [...this.config.args], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: stdioAdapterEnvironment(this.config),
+      cwd:
+        this.config.workingDirectoryPolicy === "config_directory"
+          ? dirname(this.config.executable)
+          : process.cwd(),
+      detached: process.platform !== "win32",
+    })
+    this.child = child
+    this.exited = false
+    child.on("error", () => {
+      this.failAllStreams(
+        stdioError(STDIO_CODES.spawnFailed, "stdio adapter failed to start"),
+      )
+      for (const waiter of this.pending.values()) {
+        waiter.resolve(this.errorResponse("spawn_failed"))
+      }
+      this.pending.clear()
+    })
+    child.on("exit", () => {
+      this.exited = true
+      this.failAllStreams(
+        stdioError(
+          STDIO_CODES.streamFailed,
+          "stdio adapter exited before completing the stream",
+        ),
+      )
+      for (const waiter of this.pending.values()) {
+        waiter.resolve(this.errorResponse("adapter_exited"))
+      }
+      this.pending.clear()
+    })
+    child.stdout?.on("data", (chunk: Buffer) => this.consumeStdout(chunk))
+    child.stderr?.on("data", (chunk: Buffer) => this.consumeStderr(chunk))
+    return child
+  }
+
+  private errorResponse(code: string): AgentHostStdioMessage {
+    return {
+      protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+      id: "runtime",
+      kind: "response",
+      ok: false,
+      error: {
+        code: `${STDIO_CODES.hostError}.${code}`,
+        message: "stdio adapter is unavailable",
+        retryable: false,
+      },
+    }
+  }
+
+  private consumeStdout(chunk: Buffer): void {
+    this.stdoutCarry += chunk.toString("utf8")
+    let newline = this.stdoutCarry.indexOf("\n")
+    while (newline !== -1) {
+      const line = this.stdoutCarry.slice(0, newline)
+      this.stdoutCarry = this.stdoutCarry.slice(newline + 1)
+      this.dispatchLine(line)
+      newline = this.stdoutCarry.indexOf("\n")
+    }
+  }
+
+  private consumeStderr(chunk: Buffer): void {
+    // Bounded diagnostics only; raw stderr is never surfaced to callers.
+    const text = chunk.toString("utf8")
+    this.stderrTail = `${this.stderrTail}${text}`.slice(
+      -this.config.maxStderrBytes,
+    )
+  }
+
+  private dispatchLine(line: string): void {
+    let message: AgentHostStdioMessage
+    try {
+      message = parseAgentHostStdioHostLine(line, this.hostId)
+    } catch (error) {
+      this.failAllStreams(
+        error instanceof CoreError
+          ? error
+          : stdioError(STDIO_CODES.badFraming, "stdio framing failed"),
+      )
+      if (this.child) signalAgentHostProcessTree(this.child, "SIGTERM")
+      return
+    }
+    const waiter = this.pending.get(message.id)
+    if (waiter && message.kind === "response") {
+      this.pending.delete(message.id)
+      waiter.resolve(message)
+      return
+    }
+    const stream = this.streams.get(message.id)
+    if (stream) {
+      stream.queue.push(message)
+      stream.notify?.()
+      return
+    }
+    // Unsolicited traffic from an Adapter is a protocol violation.
+    this.failAllStreams(
+      stdioError(
+        STDIO_CODES.streamFailed,
+        "stdio adapter sent an unsolicited message",
+      ),
+    )
+    if (this.child) signalAgentHostProcessTree(this.child, "SIGTERM")
+  }
+
+  private failStream(id: string, error: CoreError): void {
+    const stream = this.streams.get(id)
+    if (!stream) return
+    stream.failure = stream.failure ?? error
+    stream.closed = true
+    stream.notify?.()
+  }
+
+  private failAllStreams(error: CoreError): void {
+    for (const stream of this.streams.values()) {
+      stream.failure = stream.failure ?? error
+      stream.closed = true
+      stream.notify?.()
+    }
+  }
+
+  private nextMessage(
+    id: string,
+    state: StreamState,
+  ): Promise<AgentHostStdioMessage | null> {
+    if (state.queue.length > 0) {
+      return Promise.resolve(state.queue.shift() ?? null)
+    }
+    if (state.failure) return Promise.reject(state.failure)
+    if (state.closed) return Promise.resolve(null)
+    return new Promise((resolve, reject) => {
+      state.notify = () => {
+        state.notify = null
+        if (state.queue.length > 0) {
+          resolve(state.queue.shift() ?? null)
+        } else if (state.failure) {
+          reject(state.failure)
+        } else {
+          resolve(null)
+        }
+      }
+      void id
+    })
+  }
+}
+
+/**
+ * Builds an explicit AgentHostRegistry registration for one configured
+ * external Adapter. Core assembly carries no vendor switch: the trusted
+ * embedder opts in with exactly this registration.
+ */
+export function createExternalStdioHostRegistration(
+  config: StdioAdapterConfig,
+): AgentHostRegistration {
+  const adapter = new ExternalStdioAgentHostAdapter(config)
+  return {
+    id: config.hostId,
+    probe: () => adapter.probe(),
+    createAdapter: async () => adapter,
+  }
+}

--- a/docs/agent-host-stdio.md
+++ b/docs/agent-host-stdio.md
@@ -1,0 +1,78 @@
+# External stdio Agent Host Adapters (`agent-host-stdio.v1`)
+
+Issue #33 R1 ships one versioned contract for external Agent Hosts. There is
+no plugin marketplace, no auto-discovery, and no remote installer: an operator
+explicitly registers one digest-pinned executable at a time.
+
+## Wire protocol
+
+- Transport: child process stdio, one JSON message per line (JSONL).
+- Envelope: `{protocol: "agent-host-stdio.v1", id, kind, ...}`. `id` is the
+  outer runtime's exchange identifier and is echoed on every reply.
+- Requests (`kind`): `probe`, `preflight`, `run`, `cancel`. `run` and
+  `preflight` carry an `agent-host.v1` run request; `cancel` carries exactly
+  `{runId}`.
+- Replies: `kind: "response"` with `ok: true` + `result`, or `ok: false` +
+  `{code, message, retryable}`; `kind: "event"` carries one validated
+  `agent-host.v1` native event.
+- Stdout carries protocol messages only. Diagnostics go to stderr, bounded,
+  and are never surfaced unbounded to callers.
+- Every unknown protocol version, unknown field, malformed line, oversized
+  line, or unsolicited message fails closed.
+
+A run exchange ends with exactly one terminal event (`run.completed` or
+`run.failed`), followed by a closing success response. Anything after the
+terminal, or a second terminal, is a contract violation.
+
+## Local configuration (`agent-host-stdio-config.v1`)
+
+```json
+{
+  "schema": "agent-host-stdio-config.v1",
+  "hostId": "example-host",
+  "displayName": "Example Host",
+  "executable": "/opt/hosts/example-host",
+  "args": ["serve"],
+  "digest": { "algorithm": "sha256", "hex": "<64 hex chars>" },
+  "envAllowlist": ["PATH"],
+  "workingDirectoryPolicy": "request",
+  "timeoutMs": 30000,
+  "maxStderrBytes": 16384
+}
+```
+
+Rules enforced by `validateStdioAdapterConfig`:
+
+- one explicit literal executable path; no globs, shell expansion or
+  interpolation; pinned by a sha256 digest verified before every spawn;
+- fixed literal arguments; no directory scanning;
+- environment propagation is strictly allowlisted (unique `UPPER_SNAKE`
+  names); nothing else reaches the child;
+- explicit working-directory policy (`request` or `config_directory`);
+- bounded timeout (1s–600s) and bounded stderr diagnostics.
+
+An employee package can never select or ship Adapter executables.
+
+## CLI
+
+```
+digital-employee stdio-host <config.json>            # probe
+digital-employee stdio-host <config.json> --question "..." [--json]
+```
+
+## Reference Adapter
+
+`apps/cli/reference-stdio-host.ts` is the deterministic reference
+implementation. Violation fixtures are selected with `REFERENCE_STDIO_*`
+environment flags (hang, duplicate terminal, event after terminal, unknown
+probe field, missing capability, disallowed tool, leaked process tree) so the
+fail-closed paths are reproducible in CI.
+
+## Qualification
+
+An Adapter cannot be reported as supported on fixture evidence alone: run the
+Issue #30 qualification kit against it to produce an
+`adapter-qualification-record.v1` record
+(`tests/apps/stdio-agent-host.test.ts` shows the integration).
+
+Stdio isolation is a process boundary, not a multi-tenant sandbox.

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -91,6 +91,26 @@ export type {
   QualificationOptions,
 } from "./src/adapter-qualification.js"
 export {
+  AGENT_HOST_STDIO_CONFIG_SCHEMA_VERSION,
+  stdioAdapterEnvironment,
+  validateStdioAdapterConfig,
+} from "./src/agent-host-stdio-config.js"
+export type { StdioAdapterConfig } from "./src/agent-host-stdio-config.js"
+export {
+  AGENT_HOST_STDIO_ERROR_CODES,
+  AGENT_HOST_STDIO_MAX_LINE_BYTES,
+  AGENT_HOST_STDIO_PROTOCOL_VERSION,
+  encodeAgentHostStdioLine,
+  parseAgentHostStdioHostLine,
+  parseAgentHostStdioRequest,
+  probeResultFromStdioResponse,
+} from "./src/agent-host-stdio.js"
+export type {
+  AgentHostStdioMessage,
+  AgentHostStdioRequest,
+  AgentHostStdioRequestKind,
+} from "./src/agent-host-stdio.js"
+export {
   EMPLOYEE_PACKAGE_MANIFEST_NAME,
   EMPLOYEE_PACKAGE_SCHEMA_VERSION,
   deriveEffectiveAgentHostPolicy,

--- a/packages/core/src/agent-host-stdio-config.ts
+++ b/packages/core/src/agent-host-stdio-config.ts
@@ -1,0 +1,184 @@
+import { CoreError } from "./contracts.js"
+
+/**
+ * Explicit local configuration for an external stdio Agent Host Adapter
+ * (Issue #33 REQ-002). The operator pins exactly one executable with a
+ * sha256 digest; the model never scans directories and never lets an
+ * employee package select executable code.
+ */
+export const AGENT_HOST_STDIO_CONFIG_SCHEMA_VERSION =
+  "agent-host-stdio-config.v1" as const
+
+const CONFIG_ERROR = "AGENT_HOST_STDIO_CONFIG_INVALID"
+
+const HOST_ID_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$/
+const HEX_64_PATTERN = /^[0-9a-f]{64}$/
+const ENV_NAME_PATTERN = /^[A-Z_][A-Z0-9_]{0,127}$/
+
+export interface StdioAdapterConfig {
+  schema: typeof AGENT_HOST_STDIO_CONFIG_SCHEMA_VERSION
+  hostId: string
+  displayName: string
+  executable: string
+  args: readonly string[]
+  digest: { algorithm: "sha256"; hex: string }
+  envAllowlist: readonly string[]
+  workingDirectoryPolicy: "request" | "config_directory"
+  timeoutMs: number
+  maxStderrBytes: number
+}
+
+function configError(message: string, details?: unknown): CoreError {
+  return new CoreError(CONFIG_ERROR, message, {
+    status: 400,
+    retryable: false,
+    details,
+  })
+}
+
+function plainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  try {
+    const prototype = Object.getPrototypeOf(value)
+    return prototype === Object.prototype || prototype === null
+  } catch {
+    return false
+  }
+}
+
+function boundedString(value: unknown, maximum: number): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= maximum &&
+    !/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/.test(value)
+  )
+}
+
+const CONFIG_KEYS = Object.freeze([
+  "schema",
+  "hostId",
+  "displayName",
+  "executable",
+  "args",
+  "digest",
+  "envAllowlist",
+  "workingDirectoryPolicy",
+  "timeoutMs",
+  "maxStderrBytes",
+])
+
+function rejectsExpansion(text: string): boolean {
+  // No shell expansion, interpolation or globbing may hide in a pinned value.
+  return !/[$`~*?{}[\]<>|&;]/.test(text)
+}
+
+/**
+ * Validates an explicit Adapter configuration candidate. Directory scanning,
+ * package-selected executables and out-of-allowlist environment propagation
+ * are rejected; only a digest-pinned executable with fixed literal
+ * arguments is accepted.
+ */
+export function validateStdioAdapterConfig(
+  value: unknown,
+): StdioAdapterConfig {
+  if (!plainRecord(value)) {
+    throw configError("stdio adapter config must be an object")
+  }
+  for (const key of Object.keys(value)) {
+    if (!CONFIG_KEYS.includes(key)) {
+      throw configError(`unknown stdio adapter config field: ${key}`)
+    }
+  }
+  if (value.schema !== AGENT_HOST_STDIO_CONFIG_SCHEMA_VERSION) {
+    throw configError(
+      `schema must be ${AGENT_HOST_STDIO_CONFIG_SCHEMA_VERSION}`,
+    )
+  }
+  if (
+    typeof value.hostId !== "string" ||
+    !HOST_ID_PATTERN.test(value.hostId)
+  ) {
+    throw configError("hostId must be a lowercase ASCII identifier")
+  }
+  if (!boundedString(value.displayName, 256)) {
+    throw configError("displayName is required")
+  }
+  if (
+    !boundedString(value.executable, 2048) ||
+    !rejectsExpansion(value.executable)
+  ) {
+    throw configError(
+      "executable must be one explicit literal path without glob or shell expansion",
+    )
+  }
+  if (!Array.isArray(value.args) || value.args.length > 64) {
+    throw configError("args must be a fixed literal array (max 64)")
+  }
+  for (const arg of value.args) {
+    if (!boundedString(arg, 2048) || !rejectsExpansion(arg)) {
+      throw configError("every argument must be a fixed literal string")
+    }
+  }
+  const digest = value.digest
+  if (
+    !plainRecord(digest) ||
+    Object.keys(digest).some((key) => !["algorithm", "hex"].includes(key)) ||
+    digest.algorithm !== "sha256" ||
+    typeof digest.hex !== "string" ||
+    !HEX_64_PATTERN.test(digest.hex)
+  ) {
+    throw configError("digest must pin the executable with a sha256 hex value")
+  }
+  if (!Array.isArray(value.envAllowlist) || value.envAllowlist.length > 128) {
+    throw configError("envAllowlist must be an explicit array (max 128)")
+  }
+  const seen = new Set<string>()
+  for (const name of value.envAllowlist) {
+    if (typeof name !== "string" || !ENV_NAME_PATTERN.test(name) || seen.has(name)) {
+      throw configError(
+        "envAllowlist entries must be unique UPPER_SNAKE names; no wildcard or bulk propagation",
+      )
+    }
+    seen.add(name)
+  }
+  if (
+    value.workingDirectoryPolicy !== "request" &&
+    value.workingDirectoryPolicy !== "config_directory"
+  ) {
+    throw configError("workingDirectoryPolicy must be explicit")
+  }
+  if (
+    typeof value.timeoutMs !== "number" ||
+    !Number.isInteger(value.timeoutMs) ||
+    value.timeoutMs < 1_000 ||
+    value.timeoutMs > 600_000
+  ) {
+    throw configError("timeoutMs must be an integer between 1000 and 600000")
+  }
+  if (
+    typeof value.maxStderrBytes !== "number" ||
+    !Number.isInteger(value.maxStderrBytes) ||
+    value.maxStderrBytes < 1024 ||
+    value.maxStderrBytes > 262_144
+  ) {
+    throw configError("maxStderrBytes must be an integer between 1024 and 262144")
+  }
+  return value as unknown as StdioAdapterConfig
+}
+
+/**
+ * Builds the bounded, allowlist-filtered environment for the Adapter child
+ * process. Nothing outside the allowlist is propagated.
+ */
+export function stdioAdapterEnvironment(
+  config: StdioAdapterConfig,
+  source: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const environment: Record<string, string> = {}
+  for (const name of config.envAllowlist) {
+    const entry = source[name]
+    if (typeof entry === "string") environment[name] = entry
+  }
+  return environment
+}

--- a/packages/core/src/agent-host-stdio.ts
+++ b/packages/core/src/agent-host-stdio.ts
@@ -1,0 +1,308 @@
+import { CoreError } from "./contracts.js"
+import {
+  validateAgentHostEventWire,
+  validateAgentHostProbeWire,
+  validateAgentHostRunRequestWire,
+} from "./agent-host-wire.js"
+import type {
+  AgentHostEvent,
+  AgentHostProbeResult,
+  AgentHostRunRequest,
+} from "./agent-host.js"
+
+/**
+ * Versioned stdio/JSONL protocol for external Agent Host Adapters
+ * (Issue #33 R1 freeze). Stdout carries protocol messages only; diagnostics
+ * go to stderr. Every unknown version or field fails closed.
+ */
+export const AGENT_HOST_STDIO_PROTOCOL_VERSION = "agent-host-stdio.v1"
+
+export const AGENT_HOST_STDIO_MAX_LINE_BYTES = 1_048_576
+
+const STDIO_ERROR_CODES = {
+  badFraming: "agent_host_stdio_bad_framing",
+  protocolMismatch: "agent_host_stdio_protocol_mismatch",
+  unknownMessage: "agent_host_stdio_unknown_message",
+  badResponse: "agent_host_stdio_bad_response",
+  hostError: "agent_host_stdio_host_error",
+} as const
+
+export const AGENT_HOST_STDIO_ERROR_CODES = STDIO_ERROR_CODES
+
+function stdioError(
+  code: string,
+  message: string,
+  details?: unknown,
+): CoreError {
+  return new CoreError(code, message, {
+    status: 400,
+    retryable: false,
+    details,
+  })
+}
+
+function plainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  try {
+    const prototype = Object.getPrototypeOf(value)
+    return prototype === Object.prototype || prototype === null
+  } catch {
+    return false
+  }
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key))
+}
+
+function boundedId(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= 256
+}
+
+export type AgentHostStdioRequestKind = "probe" | "preflight" | "run" | "cancel"
+
+export interface AgentHostStdioRequest {
+  protocol: typeof AGENT_HOST_STDIO_PROTOCOL_VERSION
+  id: string
+  kind: AgentHostStdioRequestKind
+  payload?: AgentHostRunRequest | { runId: string }
+}
+
+export type AgentHostStdioMessage =
+  | AgentHostStdioRequest
+  | {
+      protocol: typeof AGENT_HOST_STDIO_PROTOCOL_VERSION
+      id: string
+      kind: "response"
+      ok: true
+      result?: unknown
+    }
+  | {
+      protocol: typeof AGENT_HOST_STDIO_PROTOCOL_VERSION
+      id: string
+      kind: "response"
+      ok: false
+      error: { code: string; message: string; retryable: boolean }
+    }
+  | {
+      protocol: typeof AGENT_HOST_STDIO_PROTOCOL_VERSION
+      id: string
+      kind: "event"
+      event: AgentHostEvent
+    }
+
+/**
+ * Serializes one protocol message as a single JSONL line. The message must
+ * already be validated; encoding never repairs malformed input.
+ */
+export function encodeAgentHostStdioLine(message: unknown): string {
+  const text = JSON.stringify(message)
+  if (text === undefined) {
+    throw stdioError(
+      STDIO_ERROR_CODES.badFraming,
+      "stdio protocol message is not serializable",
+    )
+  }
+  const bytes = Buffer.byteLength(text, "utf8")
+  if (bytes > AGENT_HOST_STDIO_MAX_LINE_BYTES) {
+    throw stdioError(
+      STDIO_ERROR_CODES.badFraming,
+      "stdio protocol message exceeds the line bound",
+      { bound: AGENT_HOST_STDIO_MAX_LINE_BYTES, bytes },
+    )
+  }
+  return text
+}
+
+function parseLine(line: string): unknown {
+  const text = line.trim()
+  if (text.length === 0) {
+    throw stdioError(
+      STDIO_ERROR_CODES.badFraming,
+      "stdio line must carry exactly one JSON message",
+    )
+  }
+  if (Buffer.byteLength(text, "utf8") > AGENT_HOST_STDIO_MAX_LINE_BYTES) {
+    throw stdioError(
+      STDIO_ERROR_CODES.badFraming,
+      "stdio protocol message exceeds the line bound",
+    )
+  }
+  try {
+    return JSON.parse(text)
+  } catch {
+    throw stdioError(
+      STDIO_ERROR_CODES.badFraming,
+      "stdio line is not valid JSON",
+    )
+  }
+}
+
+function checkEnvelope(value: unknown): Record<string, unknown> {
+  if (
+    !plainRecord(value) ||
+    !exactKeys(value, ["protocol", "id", "kind", "payload", "ok", "result", "error", "event"])
+  ) {
+    throw stdioError(
+      STDIO_ERROR_CODES.unknownMessage,
+      "stdio message carries unknown fields",
+    )
+  }
+  if (value.protocol !== AGENT_HOST_STDIO_PROTOCOL_VERSION) {
+    throw stdioError(
+      STDIO_ERROR_CODES.protocolMismatch,
+      `stdio protocol must be ${AGENT_HOST_STDIO_PROTOCOL_VERSION}`,
+    )
+  }
+  if (!boundedId(value.id)) {
+    throw stdioError(
+      STDIO_ERROR_CODES.unknownMessage,
+      "stdio message id is invalid",
+    )
+  }
+  return value
+}
+
+const REQUEST_KINDS = new Set(["probe", "preflight", "run", "cancel"])
+
+/** Fail-closed parser for one request line spoken by the outer runtime. */
+export function parseAgentHostStdioRequest(line: string): AgentHostStdioRequest {
+  const value = checkEnvelope(parseLine(line))
+  const allowed = ["protocol", "id", "kind", "payload"]
+  if (
+    !exactKeys(value, allowed) ||
+    typeof value.kind !== "string" ||
+    !REQUEST_KINDS.has(value.kind)
+  ) {
+    throw stdioError(
+      STDIO_ERROR_CODES.unknownMessage,
+      "stdio request kind is invalid",
+    )
+  }
+  if (value.kind === "run" || value.kind === "preflight") {
+    validateAgentHostRunRequestWire(value.payload)
+  } else if (value.kind === "cancel") {
+    const payload = value.payload
+    if (
+      !plainRecord(payload) ||
+      !exactKeys(payload, ["runId"]) ||
+      typeof payload.runId !== "string" ||
+      payload.runId.length === 0 ||
+      payload.runId.length > 256
+    ) {
+      throw stdioError(
+        STDIO_ERROR_CODES.unknownMessage,
+        "stdio cancel request must carry exactly one runId",
+      )
+    }
+  } else if (value.payload !== undefined) {
+    throw stdioError(
+      STDIO_ERROR_CODES.unknownMessage,
+      "stdio request payload is not allowed for this kind",
+    )
+  }
+  return value as unknown as AgentHostStdioRequest
+}
+
+/**
+ * Fail-closed parser for one line spoken by an external Adapter. Validates
+ * the envelope and every embedded agent-host.v1 shape (probe result, run
+ * request echo, native event) so a misbehaving Adapter cannot inject
+ * unvalidated wire data.
+ */
+export function parseAgentHostStdioHostLine(
+  line: string,
+  expectedHostId: string,
+): AgentHostStdioMessage {
+  const value = checkEnvelope(parseLine(line))
+  const kind = value.kind
+  if (kind === "event") {
+    if (!exactKeys(value, ["protocol", "id", "kind", "event"])) {
+      throw stdioError(
+        STDIO_ERROR_CODES.unknownMessage,
+        "stdio event message carries unknown fields",
+      )
+    }
+    const event = validateAgentHostEventWire(value.event)
+    return {
+      protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+      id: value.id as string,
+      kind: "event",
+      event,
+    }
+  }
+  if (kind !== "response") {
+    throw stdioError(
+      STDIO_ERROR_CODES.unknownMessage,
+      "stdio host line must be a response or event",
+    )
+  }
+  if (value.ok === true) {
+    if (!exactKeys(value, ["protocol", "id", "kind", "ok", "result"])) {
+      throw stdioError(
+        STDIO_ERROR_CODES.badResponse,
+        "stdio success response carries unknown fields",
+      )
+    }
+    if (value.result !== undefined && !plainRecord(value.result)) {
+      throw stdioError(
+        STDIO_ERROR_CODES.badResponse,
+        "stdio success result must be an object",
+      )
+    }
+    return value as unknown as AgentHostStdioMessage
+  }
+  if (value.ok !== false) {
+    throw stdioError(
+      STDIO_ERROR_CODES.badResponse,
+      "stdio response must carry a boolean ok flag",
+    )
+  }
+  if (!exactKeys(value, ["protocol", "id", "kind", "ok", "error"])) {
+    throw stdioError(
+      STDIO_ERROR_CODES.badResponse,
+      "stdio error response carries unknown fields",
+    )
+  }
+  const error = value.error
+  if (
+    !plainRecord(error) ||
+    !exactKeys(error, ["code", "message", "retryable"]) ||
+    typeof error.code !== "string" ||
+    !/^[a-z0-9][a-z0-9._-]{0,127}$/.test(error.code) ||
+    typeof error.message !== "string" ||
+    error.message.length > 4096 ||
+    typeof error.retryable !== "boolean"
+  ) {
+    throw stdioError(
+      STDIO_ERROR_CODES.badResponse,
+      "stdio error response is malformed",
+    )
+  }
+  return value as unknown as AgentHostStdioMessage
+}
+
+/** Extracts a validated probe result from a success response. */
+export function probeResultFromStdioResponse(
+  message: AgentHostStdioMessage,
+  expectedHostId: string,
+): AgentHostProbeResult {
+  if (message.kind !== "response") {
+    throw stdioError(
+      STDIO_ERROR_CODES.badResponse,
+      "stdio probe exchange expected a response",
+    )
+  }
+  if (message.ok !== true) {
+    const error = message.error
+    throw stdioError(
+      STDIO_ERROR_CODES.hostError,
+      "agent host refused the probe exchange",
+      { code: error.code, retryable: error.retryable },
+    )
+  }
+  return validateAgentHostProbeWire(message.result, expectedHostId)
+}

--- a/tests/apps/stdio-agent-host.test.ts
+++ b/tests/apps/stdio-agent-host.test.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict"
+import { createHash } from "node:crypto"
+import { readFileSync } from "node:fs"
+import { mkdtemp } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+import { createBuiltInAgentHostRegistry } from "../../apps/cli/agent-host-registry.js"
+import { REFERENCE_STDIO_HOST_ID } from "../../apps/cli/reference-stdio-host.js"
+import {
+  ExternalStdioAgentHostAdapter,
+  createExternalStdioHostRegistration,
+} from "../../apps/cli/stdio-agent-host.js"
+import type { AgentHostRunRequest } from "../../packages/core/src/agent-host.js"
+import { runQualificationSuite } from "../../packages/core/src/adapter-qualification.js"
+import {
+  AGENT_HOST_STDIO_CONFIG_SCHEMA_VERSION,
+  validateStdioAdapterConfig,
+} from "../../packages/core/src/agent-host-stdio-config.js"
+import type { StdioAdapterConfig } from "../../packages/core/src/agent-host-stdio-config.js"
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+)
+const tsxBinary = path.join(packageRoot, "node_modules", ".bin", "tsx")
+const referenceHostScript = path.join(
+  packageRoot,
+  "apps",
+  "cli",
+  "reference-stdio-host.ts",
+)
+
+const ENV_FLAGS = [
+  "REFERENCE_STDIO_HANG",
+  "REFERENCE_STDIO_SPAWN_CHILD",
+  "REFERENCE_STDIO_UNKNOWN_FIELD",
+  "REFERENCE_STDIO_DUP_TERMINAL",
+  "REFERENCE_STDIO_AFTER_TERMINAL",
+  "REFERENCE_STDIO_MISSING_CAPABILITY",
+  "REFERENCE_STDIO_DISALLOWED_TOOL",
+  "REFERENCE_STDIO_REFUSE_CANCEL",
+  "REFERENCE_STDIO_HOSTILE_WRITE_OK",
+  "REFERENCE_STDIO_PROBE_ONLY",
+  "REFERENCE_STDIO_NOT_READY",
+]
+
+function referenceConfig(overrides: {
+  digest?: string
+  timeoutMs?: number
+} = {}): StdioAdapterConfig {
+  const digest =
+    overrides.digest ??
+    createHash("sha256").update(readFileSync(tsxBinary)).digest("hex")
+  return validateStdioAdapterConfig({
+    schema: AGENT_HOST_STDIO_CONFIG_SCHEMA_VERSION,
+    hostId: REFERENCE_STDIO_HOST_ID,
+    displayName: "Reference Stdio Host",
+    executable: tsxBinary,
+    args: [referenceHostScript],
+    digest: { algorithm: "sha256", hex: digest },
+    envAllowlist: ["PATH", ...ENV_FLAGS],
+    workingDirectoryPolicy: "request",
+    timeoutMs: overrides.timeoutMs ?? 10_000,
+    maxStderrBytes: 16_384,
+  })
+}
+
+function readOnlyRequest(runId: string): AgentHostRunRequest {
+  return {
+    runId,
+    employeeId: "test-employee",
+    workingDirectory: process.cwd(),
+    prompt: "answer the question",
+    policy: {
+      tools: { default: "deny", allow: [{ name: "noop", mode: "read" }] },
+      filesystem: { read: ["."], write: [] },
+      network: { mode: "deny" },
+      approval: { mode: "never" },
+      maxTurns: 4,
+    },
+  }
+}
+
+function code(error: unknown): string {
+  return error instanceof Error && "code" in error
+    ? String((error as { code: unknown }).code)
+    : ""
+}
+
+async function withFlags(
+  flags: readonly string[],
+  body: () => Promise<void>,
+): Promise<void> {
+  for (const flag of flags) process.env[flag] = "1"
+  try {
+    await body()
+  } finally {
+    for (const flag of flags) delete process.env[flag]
+  }
+}
+
+test("an explicit external adapter completes the full lifecycle through the registry", async () => {
+  await withFlags([], async () => {
+    const registration = createExternalStdioHostRegistration(referenceConfig())
+    const registry = createBuiltInAgentHostRegistry().register(registration)
+    assert.equal(registry.hasAdapter(REFERENCE_STDIO_HOST_ID), true)
+
+    const probe = await registry.probe(REFERENCE_STDIO_HOST_ID)
+    assert.equal(probe.status, "ready")
+    assert.equal(probe.adapterStatus, "runnable")
+
+    const adapter = (await registry.create(
+      REFERENCE_STDIO_HOST_ID,
+    )) as ExternalStdioAgentHostAdapter
+    try {
+      const preflight = await adapter.preflight(readOnlyRequest("preflight-1"))
+      assert.equal(preflight.hostId, REFERENCE_STDIO_HOST_ID)
+
+      await assert.rejects(
+        () =>
+          adapter.preflight({
+            ...readOnlyRequest("preflight-2"),
+            policy: {
+              ...readOnlyRequest("preflight-2").policy,
+              filesystem: { read: ["."], write: ["/etc"] },
+            },
+          }),
+        (error: unknown) => code(error) === "agent_host_stdio_host_error",
+      )
+
+      const events = []
+      for await (const event of adapter.run(readOnlyRequest("run-1"))) {
+        events.push(event)
+      }
+      assert.deepEqual(
+        events.map((event) => event.type),
+        ["run.started", "run.completed"],
+      )
+
+      await adapter.cancel("run-cancel")
+      const cancelled = []
+      for await (const event of adapter.run(readOnlyRequest("run-cancel"))) {
+        cancelled.push(event)
+      }
+      const terminal = cancelled[cancelled.length - 1]
+      assert.equal(terminal.type, "run.failed")
+      assert.equal(
+        terminal.type === "run.failed" && terminal.error.code,
+        "agent_host_cancelled",
+      )
+    } finally {
+      await adapter.dispose()
+    }
+  })
+})
+
+test("violation fixtures fail closed with stable error codes", async () => {
+  const probeFixture = async (flags: string[], expected: string) => {
+    await withFlags(flags, async () => {
+      const adapter = new ExternalStdioAgentHostAdapter(referenceConfig())
+      try {
+        await assert.rejects(
+          () => adapter.probe(),
+          (error: unknown) => code(error) === expected,
+        )
+      } finally {
+        await adapter.dispose()
+      }
+    })
+  }
+  await probeFixture(["REFERENCE_STDIO_UNKNOWN_FIELD"], "AGENT_HOST_PROBE_INVALID")
+  await probeFixture(
+    ["REFERENCE_STDIO_MISSING_CAPABILITY"],
+    "AGENT_HOST_PROBE_INVALID",
+  )
+
+  await withFlags(["REFERENCE_STDIO_DUP_TERMINAL"], async () => {
+    const adapter = new ExternalStdioAgentHostAdapter(referenceConfig())
+    try {
+      const events = []
+      await assert.rejects(async () => {
+        for await (const event of adapter.run(readOnlyRequest("dup-1"))) {
+          events.push(event)
+        }
+      }, (error: unknown) =>
+        code(error) === "agent_host_terminal_contract_violated")
+    } finally {
+      await adapter.dispose()
+    }
+  })
+
+  await withFlags(["REFERENCE_STDIO_AFTER_TERMINAL"], async () => {
+    const adapter = new ExternalStdioAgentHostAdapter(referenceConfig())
+    try {
+      await assert.rejects(async () => {
+        for await (const _event of adapter.run(readOnlyRequest("after-1"))) {
+          // draining; the fixture must fail closed
+        }
+      }, (error: unknown) =>
+        code(error) === "agent_host_terminal_contract_violated")
+    } finally {
+      await adapter.dispose()
+    }
+  })
+
+  const poisoned = new ExternalStdioAgentHostAdapter(
+    referenceConfig({ digest: "b".repeat(64) }),
+  )
+  await assert.rejects(
+    () => poisoned.probe(),
+    (error: unknown) => code(error) === "agent_host_stdio_digest_mismatch",
+  )
+  await poisoned.dispose()
+
+  await withFlags(["REFERENCE_STDIO_HANG"], async () => {
+    const adapter = new ExternalStdioAgentHostAdapter(
+      referenceConfig({ timeoutMs: 1_000 }),
+    )
+    try {
+      await assert.rejects(async () => {
+        for await (const _event of adapter.run(readOnlyRequest("hang-1"))) {
+          // draining; the fixture must time out
+        }
+      }, (error: unknown) => code(error) === "agent_host_stdio_timeout")
+    } finally {
+      await adapter.dispose()
+    }
+  })
+})
+
+test("dispose cleans the detached process tree completely", async () => {
+  await withFlags(["REFERENCE_STDIO_SPAWN_CHILD"], async () => {
+    const adapter = new ExternalStdioAgentHostAdapter(referenceConfig())
+    try {
+      await adapter.probe()
+    } finally {
+      await adapter.dispose()
+    }
+    const match = adapter
+      .diagnosticsTail()
+      .match(/spawned child pid (\d+)/)
+    assert.ok(match, "expected the fixture to report its leaked child pid")
+    const pid = Number(match[1])
+    assert.throws(
+      () => process.kill(pid, 0),
+      (error: unknown) =>
+        error instanceof Error &&
+        (error as NodeJS.ErrnoException).code === "ESRCH",
+    )
+  })
+})
+
+test("the qualification kit issues a fixture-conformant record for the reference adapter", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "stdio-qualification-"))
+  await withFlags([], async () => {
+    const adapter = new ExternalStdioAgentHostAdapter(referenceConfig())
+    try {
+      const record = await runQualificationSuite(adapter, {
+        workingDirectory: directory,
+        generatedAt: "2026-08-06T04:00:00Z",
+      })
+      assert.equal(record.schema, "adapter-qualification-record.v1")
+      assert.equal(record.hostId, REFERENCE_STDIO_HOST_ID)
+      assert.deepEqual(record.axes, {
+        implemented: true,
+        fixtureConformant: true,
+        liveQualified: false,
+      })
+      assert.equal(record.liveEvidence, undefined)
+    } finally {
+      await adapter.dispose()
+    }
+  })
+})

--- a/tests/core/agent-host-stdio.test.ts
+++ b/tests/core/agent-host-stdio.test.ts
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  AGENT_HOST_PROTOCOL_VERSION,
+  createUnknownAgentHostCapabilities,
+} from "../../packages/core/src/agent-host.js"
+import type { AgentHostRunRequest } from "../../packages/core/src/agent-host.js"
+import {
+  AGENT_HOST_STDIO_CONFIG_SCHEMA_VERSION,
+  stdioAdapterEnvironment,
+  validateStdioAdapterConfig,
+} from "../../packages/core/src/agent-host-stdio-config.js"
+import {
+  AGENT_HOST_STDIO_MAX_LINE_BYTES,
+  AGENT_HOST_STDIO_PROTOCOL_VERSION,
+  encodeAgentHostStdioLine,
+  parseAgentHostStdioHostLine,
+  parseAgentHostStdioRequest,
+  probeResultFromStdioResponse,
+} from "../../packages/core/src/agent-host-stdio.js"
+
+const RUN_REQUEST: AgentHostRunRequest = {
+  runId: "run-1",
+  employeeId: "employee-1",
+  workingDirectory: "/tmp/employee",
+  prompt: "hello",
+  policy: {
+    tools: { default: "deny", allow: [{ name: "noop", mode: "read" }] },
+    filesystem: { read: ["."], write: [] },
+    network: { mode: "deny", hosts: [] },
+    approval: { mode: "never" },
+    maxTurns: 4,
+  },
+}
+
+function code(error: unknown): string {
+  return error instanceof Error && "code" in error
+    ? String((error as { code: unknown }).code)
+    : ""
+}
+
+test("run and cancel requests round-trip through the JSONL wire", () => {
+  const runLine = encodeAgentHostStdioLine({
+    protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+    id: "exchange-1",
+    kind: "run",
+    payload: RUN_REQUEST,
+  })
+  const run = parseAgentHostStdioRequest(runLine)
+  assert.equal(run.kind, "run")
+  assert.deepEqual(run.payload, RUN_REQUEST)
+
+  const cancelLine = encodeAgentHostStdioLine({
+    protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+    id: "exchange-2",
+    kind: "cancel",
+    payload: { runId: "run-1" },
+  })
+  const cancel = parseAgentHostStdioRequest(cancelLine)
+  assert.equal(cancel.kind, "cancel")
+  assert.deepEqual(cancel.payload, { runId: "run-1" })
+})
+
+test("probe requests must not carry a payload", () => {
+  const line = encodeAgentHostStdioLine({
+    protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+    id: "exchange-3",
+    kind: "probe",
+    payload: { runId: "unexpected" },
+  })
+  assert.throws(
+    () => parseAgentHostStdioRequest(line),
+    (error: unknown) => code(error) === "agent_host_stdio_unknown_message",
+  )
+})
+
+test("cancel requests require exactly one bounded runId", () => {
+  const line = encodeAgentHostStdioLine({
+    protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+    id: "exchange-4",
+    kind: "cancel",
+    payload: { runId: "run-1", extra: true },
+  })
+  assert.throws(
+    () => parseAgentHostStdioRequest(line),
+    (error: unknown) => code(error) === "agent_host_stdio_unknown_message",
+  )
+})
+
+test("unknown protocol versions and fields fail closed", () => {
+  const wrongVersion = JSON.stringify({
+    protocol: "agent-host-stdio.v2",
+    id: "exchange-5",
+    kind: "probe",
+  })
+  assert.throws(
+    () => parseAgentHostStdioRequest(wrongVersion),
+    (error: unknown) =>
+      code(error) === "agent_host_stdio_protocol_mismatch",
+  )
+  const unknownField = JSON.stringify({
+    protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+    id: "exchange-6",
+    kind: "probe",
+    escalation: true,
+  })
+  assert.throws(
+    () => parseAgentHostStdioRequest(unknownField),
+    (error: unknown) => code(error) === "agent_host_stdio_unknown_message",
+  )
+})
+
+test("malformed framing fails closed", () => {
+  assert.throws(
+    () => parseAgentHostStdioRequest("not-json"),
+    (error: unknown) => code(error) === "agent_host_stdio_bad_framing",
+  )
+  assert.throws(
+    () => parseAgentHostStdioRequest("   "),
+    (error: unknown) => code(error) === "agent_host_stdio_bad_framing",
+  )
+  assert.throws(
+    () =>
+      encodeAgentHostStdioLine({
+        protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+        id: "exchange-7",
+        kind: "run",
+        payload: { prompt: "x".repeat(AGENT_HOST_STDIO_MAX_LINE_BYTES) },
+      }),
+    (error: unknown) => code(error) === "agent_host_stdio_bad_framing",
+  )
+})
+
+test("host events are validated against the agent-host.v1 wire", () => {
+  const good = encodeAgentHostStdioLine({
+    protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+    id: "exchange-8",
+    kind: "event",
+    event: {
+      type: "run.started",
+      runId: "run-1",
+      timestamp: "2026-08-06T03:00:00.000Z",
+    },
+  })
+  const parsed = parseAgentHostStdioHostLine(good, "reference-stdio-host")
+  assert.equal(parsed.kind, "event")
+
+  const malformedEvent = encodeAgentHostStdioLine({
+    protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+    id: "exchange-9",
+    kind: "event",
+    event: {
+      type: "run.started",
+      runId: "run-1",
+      timestamp: "2026-08-06T03:00:00.000Z",
+      secretField: "leak",
+    },
+  })
+  assert.throws(
+    () => parseAgentHostStdioHostLine(malformedEvent, "reference-stdio-host"),
+    (error: unknown) => code(error) === "agent_host_stream_failed",
+  )
+})
+
+test("host responses distinguish success and structured failure", () => {
+  const success = encodeAgentHostStdioLine({
+    protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+    id: "exchange-10",
+    kind: "response",
+    ok: true,
+    result: { hello: true },
+  })
+  assert.equal(
+    parseAgentHostStdioHostLine(success, "reference-stdio-host").kind,
+    "response",
+  )
+  const failure = encodeAgentHostStdioLine({
+    protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+    id: "exchange-11",
+    kind: "response",
+    ok: false,
+    error: {
+      code: "agent_host_preflight_invalid",
+      message: "refused",
+      retryable: false,
+    },
+  })
+  const parsed = parseAgentHostStdioHostLine(failure, "reference-stdio-host")
+  assert.equal(parsed.kind, "response")
+  assert.equal("ok" in parsed && parsed.ok, false)
+
+  const malformed = encodeAgentHostStdioLine({
+    protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+    id: "exchange-12",
+    kind: "response",
+    ok: false,
+    error: { code: "BAD CODE", message: "x", retryable: false },
+  })
+  assert.throws(
+    () => parseAgentHostStdioHostLine(malformed, "reference-stdio-host"),
+    (error: unknown) => code(error) === "agent_host_stdio_bad_response",
+  )
+})
+
+test("probe results are bound to the expected host identity", () => {
+  const capabilities = createUnknownAgentHostCapabilities()
+  const probe = {
+    protocolVersion: AGENT_HOST_PROTOCOL_VERSION,
+    hostId: "reference-stdio-host",
+    displayName: "Reference Stdio Host",
+    status: "ready",
+    available: true,
+    adapterStatus: "runnable",
+    capabilities,
+    capabilitySource: "conformance_test",
+    issues: [],
+  }
+  const response = parseAgentHostStdioHostLine(
+    encodeAgentHostStdioLine({
+      protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+      id: "exchange-13",
+      kind: "response",
+      ok: true,
+      result: probe,
+    }),
+    "reference-stdio-host",
+  )
+  assert.equal(
+    probeResultFromStdioResponse(response, "reference-stdio-host").hostId,
+    "reference-stdio-host",
+  )
+  assert.throws(
+    () => probeResultFromStdioResponse(response, "other-host"),
+    (error: unknown) => code(error) === "AGENT_HOST_PROBE_INVALID",
+  )
+})
+
+const VALID_CONFIG = {
+  schema: AGENT_HOST_STDIO_CONFIG_SCHEMA_VERSION,
+  hostId: "reference-stdio-host",
+  displayName: "Reference Stdio Host",
+  executable: "/opt/hosts/reference-host",
+  args: ["serve", "--protocol", AGENT_HOST_STDIO_PROTOCOL_VERSION],
+  digest: { algorithm: "sha256", hex: "a".repeat(64) },
+  envAllowlist: ["PATH", "HOME"],
+  workingDirectoryPolicy: "request",
+  timeoutMs: 10_000,
+  maxStderrBytes: 16_384,
+}
+
+test("explicit digest-pinned configuration is accepted", () => {
+  const config = validateStdioAdapterConfig(VALID_CONFIG)
+  assert.equal(config.hostId, "reference-stdio-host")
+  assert.deepEqual(config.args, [
+    "serve",
+    "--protocol",
+    AGENT_HOST_STDIO_PROTOCOL_VERSION,
+  ])
+})
+
+test("configuration candidates with scanning or expansion are rejected", () => {
+  const variants: Array<Record<string, unknown>> = [
+    { executable: "/opt/hosts/*" },
+    { executable: "/opt/hosts/$NAME" },
+    { executable: "`whoami`" },
+    { args: ["$(whoami)"] },
+    { args: ["--flag;rm"] },
+    { envAllowlist: ["*"] },
+    { envAllowlist: ["PATH", "PATH"] },
+    { digest: { algorithm: "md5", hex: "a".repeat(64) } },
+    { digest: { algorithm: "sha256", hex: "nothex" } },
+    { workingDirectoryPolicy: "scan" },
+    { timeoutMs: 10 },
+    { maxStderrBytes: 999_999_999 },
+    { schema: "agent-host-stdio-config.v0" },
+    { discoveredFrom: "node_modules" },
+  ]
+  for (const variant of variants) {
+    assert.throws(
+      () => validateStdioAdapterConfig({ ...VALID_CONFIG, ...variant }),
+      (error: unknown) => code(error) === "AGENT_HOST_STDIO_CONFIG_INVALID",
+      JSON.stringify(variant),
+    )
+  }
+})
+
+test("only allowlisted environment variables are propagated", () => {
+  const config = validateStdioAdapterConfig(VALID_CONFIG)
+  const environment = stdioAdapterEnvironment(config, {
+    PATH: "/usr/bin",
+    HOME: "/home/operator",
+    SECRET_TOKEN: "do-not-propagate",
+    path: "lowercase-not-listed",
+  })
+  assert.deepEqual(environment, { PATH: "/usr/bin", HOME: "/home/operator" })
+})


### PR DESCRIPTION
## Summary

Implements Issue #33 R1 (frozen design in the issue body): the `agent-host-stdio.v1` protocol that lets operators run third-party agent hosts as digest-pinned local executables behind a fail-closed JSONL-over-stdio boundary.

- `packages/core/src/agent-host-stdio.ts` — versioned envelope framing (`{protocol, id, kind, ...}`), probe/preflight/run/cancel/response/event parsing, reusing the frozen agent-host.v1 wire validators; unknown versions, unknown fields, oversized lines, and unsolicited messages all fail closed.
- `packages/core/src/agent-host-stdio-config.ts` — `agent-host-stdio-config.v1`: sha256 digest-pinned executable, literal args (glob/shell-expansion characters rejected), env allowlist (unique UPPER_SNAKE only), bounded timeout/stderr limits, no unknown fields.
- `apps/cli/stdio-agent-host.ts` — SDK adapter: digest verified before every spawn, detached POSIX process-group spawn, single-terminal enforcement, cancel delivery, SIGTERM→SIGKILL process-tree cleanup in `dispose()`.
- `apps/cli/reference-stdio-host.ts` — deterministic reference host with env-flag violation fixtures (dup terminal, after-terminal, unknown field, missing capability, hang, leaked child process, hostile write, refuse-cancel…).
- `apps/cli/bin.ts` — `digital-employee stdio-host <config.json>` entry (probe, optional run with read-only deny-all policy).
- `docs/agent-host-stdio.md` — protocol/config/CLI documentation; states explicitly that stdio isolation is a process boundary, not a multi-tenant sandbox.

## Acceptance evidence mapping

- **AC-001** (protocol + adapter + CLI, tests/CI/manual): 15 new tests across `tests/core/agent-host-stdio.test.ts` and `tests/apps/stdio-agent-host.test.ts`; local `npm run check` green (420/420 tests, typecheck, build, security:check); manual CLI probe + full run lifecycle against the reference host both printed the expected JSON.
- **AC-002** (config fail-closed): 14 config rejection variants covered (globs, `$(…)` args, wildcard/duplicate env allowlist, md5 digest, wrong schema version, unknown fields, out-of-range bounds).
- **AC-003** (violation fixtures fail closed): unknown probe field → `AGENT_HOST_PROBE_INVALID`; dup/after-terminal → `agent_host_terminal_contract_violated`; bad digest → `agent_host_stdio_digest_mismatch`; hang → `agent_host_stdio_timeout`; leaked same-group child verified killed after `dispose()`.
- **AC-004** (qualification kit integration): the external reference adapter runs the nine-domain kit and issues an `adapter-qualification-record.v1` with `fixtureConformant: true`, `liveQualified: false` (fail-closed live axis); DEP-001 gate (#30) is already merged.

Closes #33 governance-wise per the requirement-record convention (issue stays OPEN with status:ready until the evidence ledger is posted).

Issue-Revision: R1