### PR TITLE
fix: harden npm release gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,16 @@ jobs:
       - run: npm run test:coverage
       - run: npm audit --omit=dev --audit-level=high
       - run: npm run release:check -- --tag "$GITHUB_REF_NAME"
-      - run: npm pack --dry-run
-      - run: npm --prefix packages/core pack --dry-run
+      - name: Verify npm package archives
+        run: |
+          pack_destination="$RUNNER_TEMP/release-pack"
+          mkdir -p "$pack_destination"
+          npm pack --json --pack-destination "$pack_destination" > "$RUNNER_TEMP/root-pack.json"
+          npm pack ./packages/core --json --pack-destination "$pack_destination" > "$RUNNER_TEMP/core-pack.json"
+          node ./scripts/release-pack-check.js \
+            "$pack_destination" \
+            "$RUNNER_TEMP/root-pack.json" \
+            "$RUNNER_TEMP/core-pack.json"
       - id: package
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
@@ -69,7 +77,7 @@ jobs:
               --title "Digital Employee $GITHUB_REF_NAME"
           fi
 
-  npm:
+  npm-root:
     needs: verify
     runs-on: ubuntu-latest
     permissions:
@@ -85,16 +93,8 @@ jobs:
       - name: Install npm with trusted publishing support
         run: npm install --global npm@11.18.0
       - run: npm ci
-      - name: Publish npm package
+      - name: Publish root npm package
         run: |
-          core_name="$(node -p "require('./packages/core/package.json').name")"
-          core_version="$(node -p "require('./packages/core/package.json').version")"
-          if npm view "$core_name@$core_version" version >/dev/null 2>&1; then
-            echo "$core_name@$core_version is already published"
-          else
-            npm publish ./packages/core --access public
-          fi
-
           package_name="$(node -p "require('./package.json').name")"
           package_version="$(node -p "require('./package.json').version")"
           if npm view "$package_name@$package_version" version >/dev/null 2>&1; then
@@ -102,6 +102,32 @@ jobs:
             exit 0
           fi
           npm publish --access public
+
+  npm-core:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
+      - name: Install npm with trusted publishing support
+        run: npm install --global npm@11.18.0
+      - run: npm ci
+      - name: Publish core npm package
+        run: |
+          package_name="$(node -p "require('./packages/core/package.json').name")"
+          package_version="$(node -p "require('./packages/core/package.json').version")"
+          if npm view "$package_name@$package_version" version >/dev/null 2>&1; then
+            echo "$package_name@$package_version is already published"
+            exit 0
+          fi
+          npm publish ./packages/core --access public
 
   ghcr:
     needs: verify

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,10 @@
   "version": "0.3.0",
   "description": "Dependency-free package, Agent-host, and compatibility primitives for digital employees.",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fullstack-ai-infra/digital-employee.git"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/scripts/release-check.js
+++ b/scripts/release-check.js
@@ -3,6 +3,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
 
 const STABLE_SEMVER = /^\d+\.\d+\.\d+$/;
 
@@ -51,6 +52,9 @@ export function validateRelease({
   }
   if (coreManifest.version !== version) {
     errors.push("core and root package versions must match");
+  }
+  if (!isDeepStrictEqual(coreManifest.repository, manifest.repository)) {
+    errors.push("core repository must match root repository");
   }
   if (coreManifest.private === true) {
     errors.push("core package must be publishable");

--- a/scripts/release-pack-check.js
+++ b/scripts/release-pack-check.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_SPECS = [
+  {
+    label: "root",
+    manifestPath: "package.json",
+    requiredFiles: [
+      "package.json",
+      "dist/apps/cli/bin.js",
+      "dist/packages/core/index.js",
+      "dist/packages/core/index.d.ts"
+    ],
+    allowedFiles: ["package.json", "LICENSE", "NOTICE"],
+    allowedPrefixes: ["dist/"],
+    allowedPatterns: [/^README[^/]*\.md$/]
+  },
+  {
+    label: "core",
+    manifestPath: "packages/core/package.json",
+    requiredFiles: ["package.json", "dist/index.js", "dist/index.d.ts"],
+    allowedFiles: ["package.json"],
+    allowedPrefixes: ["dist/"],
+    allowedPatterns: []
+  }
+];
+
+function expectedFilename(manifest) {
+  const packageSlug = String(manifest.name || "")
+    .replace(/^@/, "")
+    .replaceAll("/", "-");
+  return `${packageSlug}-${manifest.version}.tgz`;
+}
+
+export function validatePackOutput({
+  label,
+  manifest,
+  output,
+  requiredFiles,
+  allowedFiles,
+  allowedPrefixes,
+  allowedPatterns
+}) {
+  if (!Array.isArray(output) || output.length !== 1) {
+    return [`${label} npm pack output must contain exactly one package`];
+  }
+
+  const errors = [];
+  const [pack] = output;
+  if (pack?.name !== manifest.name) {
+    errors.push(`${label} npm pack name must match package.json`);
+  }
+  if (pack?.version !== manifest.version) {
+    errors.push(`${label} npm pack version must match package.json`);
+  }
+  if (pack?.filename !== expectedFilename(manifest)) {
+    errors.push(`${label} npm pack filename is unexpected`);
+  }
+
+  if (!Array.isArray(pack?.files) || pack.files.some((file) =>
+    typeof file?.path !== "string"
+  )) {
+    errors.push(`${label} npm pack files must contain path entries`);
+    return errors;
+  }
+
+  const packedFiles = new Set(pack.files.map((file) => file.path));
+  for (const requiredFile of requiredFiles) {
+    if (!packedFiles.has(requiredFile)) {
+      errors.push(`${label} npm pack is missing ${requiredFile}`);
+    }
+  }
+  for (const packedFile of packedFiles) {
+    const allowed = allowedFiles.includes(packedFile) ||
+      allowedPrefixes.some((prefix) => packedFile.startsWith(prefix)) ||
+      allowedPatterns.some((pattern) => pattern.test(packedFile));
+    if (!allowed) {
+      errors.push(`${label} npm pack includes unexpected ${packedFile}`);
+    }
+  }
+  return errors;
+}
+
+async function validateArchive({ label, manifest, packDestination }) {
+  try {
+    const archive = await stat(
+      path.join(packDestination, expectedFilename(manifest))
+    );
+    if (archive.isFile() && archive.size > 0) return [];
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  return [`${label} npm pack archive is missing or empty`];
+}
+
+async function main() {
+  const [packDestination, ...outputPaths] = process.argv.slice(2);
+  if (!packDestination || outputPaths.length !== PACKAGE_SPECS.length) {
+    throw new TypeError(
+      "usage: release-pack-check.js <pack-directory> <root-pack.json> <core-pack.json>"
+    );
+  }
+
+  const repositoryRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    ".."
+  );
+  const errors = [];
+  for (const [index, spec] of PACKAGE_SPECS.entries()) {
+    const [manifestText, outputText] = await Promise.all([
+      readFile(path.join(repositoryRoot, spec.manifestPath), "utf8"),
+      readFile(outputPaths[index], "utf8")
+    ]);
+    const manifest = JSON.parse(manifestText);
+    const output = JSON.parse(outputText);
+    errors.push(...validatePackOutput({
+      label: spec.label,
+      manifest,
+      output,
+      requiredFiles: spec.requiredFiles,
+      allowedFiles: spec.allowedFiles,
+      allowedPrefixes: spec.allowedPrefixes,
+      allowedPatterns: spec.allowedPatterns
+    }));
+    errors.push(...await validateArchive({
+      label: spec.label,
+      manifest,
+      packDestination
+    }));
+  }
+
+  if (errors.length) {
+    process.stderr.write(
+      `release-pack-check failed:\n${errors.map((error) => `- ${error}`).join("\n")}\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write("release-pack-check passed for root and core packages\n");
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(
+      `release-pack-check: ${error?.message || "unexpected_error"}\n`
+    );
+    process.exitCode = 2;
+  });
+}

--- a/tests/scripts/release-check.test.ts
+++ b/tests/scripts/release-check.test.ts
@@ -3,6 +3,8 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import YAML from "yaml";
+import { validatePackOutput } from "../../scripts/release-pack-check.js";
 import { validateRelease } from "../../scripts/release-check.js";
 
 const repositoryRoot = path.resolve(
@@ -13,6 +15,10 @@ const repositoryRoot = path.resolve(
 const manifest = {
   name: "@fullstack-ai-infra/digital-employee",
   version: "0.1.0",
+  repository: {
+    type: "git",
+    url: "git+https://github.com/fullstack-ai-infra/digital-employee.git"
+  },
   publishConfig: { access: "public" },
   bin: { "digital-employee": "./dist/apps/cli/bin.js" },
   types: "./dist/packages/core/index.d.ts",
@@ -22,7 +28,9 @@ const manifest = {
   files: ["dist", "README.md", "LICENSE"]
 };
 const coreManifest = {
+  name: "@fullstack-ai-infra/digital-employee-core",
   version: "0.1.0",
+  repository: manifest.repository,
   publishConfig: { access: "public" },
   main: "./dist/index.js",
   types: "./dist/index.d.ts",
@@ -63,6 +71,23 @@ test("release check rejects a mismatched tag and package versions", () => {
     "release tag v0.2.0 does not match package version v0.1.0",
     "core and root package versions must match"
   ]);
+});
+
+test("release check rejects core repository drift", () => {
+  const errors = validateRelease({
+    manifest,
+    coreManifest: {
+      ...coreManifest,
+      repository: {
+        type: "git",
+        url: "git+https://github.com/example/fork.git"
+      }
+    },
+    lockfile,
+    changelog,
+    tag: "v0.1.0"
+  });
+  assert.deepEqual(errors, ["core repository must match root repository"]);
 });
 
 test("release check rejects private or incomplete packages", () => {
@@ -116,23 +141,159 @@ test("release check rejects package-lock version drift", () => {
   ]);
 });
 
+test("pack check accepts root and core package metadata", () => {
+  assert.deepEqual(validatePackOutput({
+    label: "root",
+    manifest,
+    output: [{
+      name: manifest.name,
+      version: manifest.version,
+      filename: "fullstack-ai-infra-digital-employee-0.1.0.tgz",
+      files: [
+        { path: "package.json" },
+        { path: "dist/apps/cli/bin.js" },
+        { path: "dist/packages/core/index.js" },
+        { path: "dist/packages/core/index.d.ts" }
+      ]
+    }],
+    requiredFiles: [
+      "package.json",
+      "dist/apps/cli/bin.js",
+      "dist/packages/core/index.js",
+      "dist/packages/core/index.d.ts"
+    ],
+    allowedFiles: ["package.json", "LICENSE", "NOTICE"],
+    allowedPrefixes: ["dist/"],
+    allowedPatterns: [/^README[^/]*\.md$/]
+  }), []);
+
+  assert.deepEqual(validatePackOutput({
+    label: "core",
+    manifest: coreManifest,
+    output: [{
+      name: coreManifest.name,
+      version: coreManifest.version,
+      filename: "fullstack-ai-infra-digital-employee-core-0.1.0.tgz",
+      files: [
+        { path: "package.json" },
+        { path: "dist/index.js" },
+        { path: "dist/index.d.ts" }
+      ]
+    }],
+    requiredFiles: ["package.json", "dist/index.js", "dist/index.d.ts"],
+    allowedFiles: ["package.json"],
+    allowedPrefixes: ["dist/"],
+    allowedPatterns: []
+  }), []);
+});
+
+test("pack check rejects mismatched identity and missing files", () => {
+  assert.deepEqual(validatePackOutput({
+    label: "core",
+    manifest: coreManifest,
+    output: [{
+      name: manifest.name,
+      version: "0.0.9",
+      filename: "wrong.tgz",
+      files: [{ path: "package.json" }]
+    }],
+    requiredFiles: ["package.json", "dist/index.js", "dist/index.d.ts"],
+    allowedFiles: ["package.json"],
+    allowedPrefixes: ["dist/"],
+    allowedPatterns: []
+  }), [
+    "core npm pack name must match package.json",
+    "core npm pack version must match package.json",
+    "core npm pack filename is unexpected",
+    "core npm pack is missing dist/index.js",
+    "core npm pack is missing dist/index.d.ts"
+  ]);
+  assert.deepEqual(validatePackOutput({
+    label: "core",
+    manifest: coreManifest,
+    output: [],
+    requiredFiles: [],
+    allowedFiles: [],
+    allowedPrefixes: [],
+    allowedPatterns: []
+  }), ["core npm pack output must contain exactly one package"]);
+});
+
+test("pack check rejects unexpected source paths", () => {
+  assert.deepEqual(validatePackOutput({
+    label: "root",
+    manifest,
+    output: [{
+      name: manifest.name,
+      version: manifest.version,
+      filename: "fullstack-ai-infra-digital-employee-0.1.0.tgz",
+      files: [
+        { path: "package.json" },
+        { path: "dist/apps/cli/bin.js" },
+        { path: "dist/packages/core/index.js" },
+        { path: "dist/packages/core/index.d.ts" },
+        { path: "packages/core/index.ts" }
+      ]
+    }],
+    requiredFiles: [
+      "package.json",
+      "dist/apps/cli/bin.js",
+      "dist/packages/core/index.js",
+      "dist/packages/core/index.d.ts"
+    ],
+    allowedFiles: ["package.json", "LICENSE", "NOTICE"],
+    allowedPrefixes: ["dist/"],
+    allowedPatterns: [/^README[^/]*\.md$/]
+  }), ["root npm pack includes unexpected packages/core/index.ts"]);
+});
+
 test("release workflow has independently scoped jobs for all channels", async () => {
-  const workflow = await readFile(
+  const workflowText = await readFile(
     path.join(repositoryRoot, ".github/workflows/release.yml"),
     "utf8"
   );
-  assert.match(workflow, /^\s{2}github-release:$/m);
-  assert.match(workflow, /^\s{2}npm:$/m);
-  assert.match(workflow, /^\s{2}ghcr:$/m);
-  assert.match(workflow, /^\s{6}id-token: write$/m);
-  assert.match(workflow, /npm install --global npm@11\.18\.0/);
-  assert.match(workflow, /npm run test:coverage/);
-  assert.match(workflow, /npm --prefix packages\/core pack --dry-run/);
-  assert.match(workflow, /npm publish \.\/packages\/core --access public/);
-  assert.match(workflow, /npm publish --access public/);
-  assert.doesNotMatch(workflow, /NPM_TOKEN|NODE_AUTH_TOKEN/);
-  assert.match(workflow, /actions\/checkout@v6/);
-  assert.match(workflow, /actions\/setup-node@v6/);
-  assert.match(workflow, /gh release (?:create|upload)/);
-  assert.match(workflow, /docker push/);
+  const workflow = YAML.parse(workflowText);
+  const npmRoot = workflow.jobs["npm-root"];
+  const npmCore = workflow.jobs["npm-core"];
+  for (const job of [npmRoot, npmCore]) {
+    assert.equal(job.needs, "verify");
+    assert.equal(job["runs-on"], "ubuntu-latest");
+    assert.deepEqual(job.permissions, {
+      contents: "read",
+      "id-token": "write"
+    });
+    assert.ok(job.steps.some((step: { uses?: string }) =>
+      step.uses === "actions/checkout@v6"
+    ));
+    assert.ok(job.steps.some((step: { uses?: string }) =>
+      step.uses === "actions/setup-node@v6"
+    ));
+    assert.ok(job.steps.some((step: { run?: string }) =>
+      step.run === "npm install --global npm@11.18.0"
+    ));
+  }
+
+  const rootPublish = npmRoot.steps.at(-1).run;
+  const corePublish = npmCore.steps.at(-1).run;
+  assert.match(rootPublish, /npm publish --access public/);
+  assert.doesNotMatch(rootPublish, /packages\/core/);
+  assert.match(corePublish, /npm publish \.\/packages\/core --access public/);
+  assert.doesNotMatch(workflowText, /NPM_TOKEN|NODE_AUTH_TOKEN/);
+  assert.match(workflowText, /mkdir -p "\$pack_destination"/);
+  assert.match(
+    workflowText,
+    /npm pack --json --pack-destination "\$pack_destination"/
+  );
+  assert.match(
+    workflowText,
+    /npm pack \.\/packages\/core --json --pack-destination "\$pack_destination"/
+  );
+  assert.doesNotMatch(workflowText, /npm pack[^\n]*--dry-run/);
+  assert.doesNotMatch(workflowText, /npm --prefix packages\/core pack/);
+  assert.match(workflowText, /release-pack-check\.js/);
+  assert.match(workflowText, /npm run test:coverage/);
+  assert.ok(workflow.jobs["github-release"]);
+  assert.ok(workflow.jobs.ghcr);
+  assert.match(workflowText, /gh release (?:create|upload)/);
+  assert.match(workflowText, /docker push/);
 });


### PR DESCRIPTION
## What and why

Issue #26 found that `npm --prefix packages/core pack --dry-run` was packing the root package, so CI could report success without ever inspecting the core artifact. Core also lacked the exact repository metadata required by npm Trusted Publishing.

This change makes the two npm artifacts explicit, verifiable, and independently publishable through GitHub Actions OIDC.

## Scope

- Build real root and core tarballs with package-specific commands.
- Verify package identity, version, filename, required files, archive boundaries, and non-empty tgz output.
- Enforce repository metadata parity between root and core.
- Split root and core OIDC publish jobs so first-time core bootstrap cannot block the existing root publisher.
- No long-lived npm token is added.
- Non-goal: create the core package on npm; its first publish still requires one-time npm-side bootstrap.

## Validation

| ID | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|
| V1 | Full repository checks pass | `npm run check` | macOS, Node 24 | All checks pass | 440/440 tests and security check passed | ✅ |
| V2 | Production dependency audit is clean | `npm audit --omit=dev --audit-level=high` | npm registry | No high/critical findings | 0 vulnerabilities | ✅ |
| V3 | Both npm archives are real and correctly bounded | root/core `npm pack` plus `scripts/release-pack-check.js` | local workspace | Both validators pass | Root and core passed | ✅ |
| V4 | Workflow syntax is valid | `actionlint .github/workflows/release.yml` | actionlint 1.7.12 | No diagnostics | No diagnostics | ✅ |

## Security and data review

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access is explicitly allowlisted.
- [x] Logs redact content, identities, and credential-bearing URLs.
- [x] New dependencies and licenses were reviewed; no dependency was added.
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass.

## Risk and rollback

Risk is limited to release automation and package manifests. Root publishing keeps its existing trusted-publisher identity; core is isolated in a separate job. If a release gate is too strict, revert this commit before creating a release tag.

Refs #26