### PR TITLE
feat(core): freeze employee-package compatibility semantics and golden vectors

### DIFF
--- a/fixtures/employee-package-vectors/v1/compatibility.json
+++ b/fixtures/employee-package-vectors/v1/compatibility.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": "employee-package-vectors.v1",
+  "family": "compatibility",
+  "vectors": [
+    {
+      "id": "accept-current-version",
+      "family": "compatibility",
+      "description": "Current schema version is accepted",
+      "input": { "schemaVersion": "employee-package.v1alpha1" },
+      "expect": { "kind": "accept" }
+    },
+    {
+      "id": "reject-future-version",
+      "family": "compatibility",
+      "description": "Future version in same family is rejected (no downgrade)",
+      "input": { "schemaVersion": "employee-package.v2" },
+      "expect": { "kind": "reject", "code": "unknown_version_no_downgrade" }
+    },
+    {
+      "id": "reject-unrecognised-family",
+      "family": "compatibility",
+      "description": "Completely unrecognised schema family is rejected",
+      "input": { "schemaVersion": "something-else.v1" },
+      "expect": { "kind": "reject", "code": "unknown_version_unrecognised" }
+    },
+    {
+      "id": "reject-missing-version",
+      "family": "compatibility",
+      "description": "Missing schema version is rejected",
+      "input": {},
+      "expect": { "kind": "reject", "code": "schema_version_missing" }
+    },
+    {
+      "id": "reject-null-version",
+      "family": "compatibility",
+      "description": "Null schema version is rejected",
+      "input": { "schemaVersion": null },
+      "expect": { "kind": "reject", "code": "schema_version_missing" }
+    },
+    {
+      "id": "reject-numeric-version",
+      "family": "compatibility",
+      "description": "Numeric schema version is rejected",
+      "input": { "schemaVersion": 1 },
+      "expect": { "kind": "reject", "code": "schema_version_missing" }
+    }
+  ]
+}

--- a/fixtures/employee-package-vectors/v1/cross_field.json
+++ b/fixtures/employee-package-vectors/v1/cross_field.json
@@ -1,0 +1,98 @@
+{
+  "schemaVersion": "employee-package-vectors.v1",
+  "family": "cross_field",
+  "vectors": [
+    {
+      "id": "reject-read-only-with-write-paths",
+      "family": "cross_field",
+      "description": "read_only mode cannot declare write filesystem paths",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "cross-field-write",
+        "version": "1.0.0",
+        "description": "Read-only with write paths",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": ["tool_allowlist", "filesystem_scope"] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": {
+          "mode": "read_only",
+          "network": "deny",
+          "filesystem": { "read": ["./data"], "write": ["./output"] },
+          "mcpTools": []
+        },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "read_only_employee_cannot_request_write_paths" }
+    },
+    {
+      "id": "reject-read-only-with-write-mcp",
+      "family": "cross_field",
+      "description": "read_only mode cannot request write MCP tools",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "cross-field-mcp",
+        "version": "1.0.0",
+        "description": "Read-only with write MCP tools",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": ["tool_allowlist", "mcp"] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json", "mcp": "./mcp.json" },
+        "policy": {
+          "mode": "read_only",
+          "network": "deny",
+          "filesystem": { "read": [], "write": [] },
+          "mcpTools": [{ "name": "dangerous-tool", "requestedMode": "write" }]
+        },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "read_only_employee_cannot_request_write_mcp_tools" }
+    },
+    {
+      "id": "reject-mcp-tools-without-entrypoint",
+      "family": "cross_field",
+      "description": "mcpTools requires mcp entrypoint to be declared",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "cross-field-mcp-no-entry",
+        "version": "1.0.0",
+        "description": "MCP tools without MCP entrypoint",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": ["tool_allowlist", "mcp"] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": {
+          "mode": "approval_required",
+          "network": "deny",
+          "filesystem": { "read": [], "write": [] },
+          "mcpTools": [{ "name": "some-tool", "requestedMode": "read" }]
+        },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "mcp_tools_require_mcp_entrypoint" }
+    },
+    {
+      "id": "valid-approval-with-writes",
+      "family": "cross_field",
+      "description": "approval_required mode can declare write paths and write MCP tools",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "approval-writes",
+        "version": "1.0.0",
+        "description": "Approval mode with all write access",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": ["tool_allowlist", "filesystem_scope", "mcp", "approval_callback", "network_policy"] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json", "mcp": "./mcp.json" },
+        "policy": {
+          "mode": "approval_required",
+          "network": "deny",
+          "filesystem": { "read": ["./data"], "write": ["./output"] },
+          "mcpTools": [{ "name": "writer", "requestedMode": "write" }]
+        },
+        "assets": []
+      },
+      "expect": { "kind": "accept" }
+    }
+  ]
+}

--- a/fixtures/employee-package-vectors/v1/digest.json
+++ b/fixtures/employee-package-vectors/v1/digest.json
@@ -1,0 +1,83 @@
+{
+  "schemaVersion": "employee-package-vectors.v1",
+  "family": "digest",
+  "vectors": [
+    {
+      "id": "accept-single-file-digest",
+      "family": "digest",
+      "description": "Single file produces a valid sha256 digest",
+      "input": {
+        "entries": [
+          { "path": "./hello.txt", "bytesHex": "48656c6c6f" }
+        ]
+      },
+      "expect": { "kind": "accept" }
+    },
+    {
+      "id": "accept-multiple-files-sorted",
+      "family": "digest",
+      "description": "Multiple files are sorted by path before hashing",
+      "input": {
+        "entries": [
+          { "path": "./z-last.txt", "bytesHex": "7a" },
+          { "path": "./a-first.txt", "bytesHex": "61" }
+        ]
+      },
+      "expect": { "kind": "accept" }
+    },
+    {
+      "id": "reject-empty-entries",
+      "family": "digest",
+      "description": "Empty entries array is rejected",
+      "input": {
+        "entries": []
+      },
+      "expect": { "kind": "reject", "code": "employee_package_digest_input_invalid" }
+    },
+    {
+      "id": "reject-path-without-dot-slash",
+      "family": "digest",
+      "description": "Path must start with ./",
+      "input": {
+        "entries": [
+          { "path": "no-prefix.txt", "bytesHex": "00" }
+        ]
+      },
+      "expect": { "kind": "reject", "code": "employee_package_digest_input_invalid" }
+    },
+    {
+      "id": "reject-path-with-backslash",
+      "family": "digest",
+      "description": "Path must not contain backslash",
+      "input": {
+        "entries": [
+          { "path": ".\\windows\\path.txt", "bytesHex": "00" }
+        ]
+      },
+      "expect": { "kind": "reject", "code": "employee_package_digest_input_invalid" }
+    },
+    {
+      "id": "reject-path-traversal",
+      "family": "digest",
+      "description": "Path must not contain .. segments",
+      "input": {
+        "entries": [
+          { "path": "./../escape.txt", "bytesHex": "00" }
+        ]
+      },
+      "expect": { "kind": "reject", "code": "employee_package_digest_input_invalid" }
+    },
+    {
+      "id": "reject-duplicate-paths",
+      "family": "digest",
+      "description": "Duplicate paths are rejected",
+      "input": {
+        "entries": [
+          { "path": "./file.txt", "bytesHex": "61" },
+          { "path": "./file.txt", "bytesHex": "62" }
+        ]
+      },
+      "expect": { "kind": "reject", "code": "employee_package_digest_input_invalid" }
+    }
+  ]
+}

--- a/fixtures/employee-package-vectors/v1/field_constraints.json
+++ b/fixtures/employee-package-vectors/v1/field_constraints.json
@@ -1,0 +1,132 @@
+{
+  "schemaVersion": "employee-package-vectors.v1",
+  "family": "field_constraints",
+  "vectors": [
+    {
+      "id": "reject-name-uppercase",
+      "family": "field_constraints",
+      "description": "Package name must be lowercase kebab-case",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "Invalid-Name",
+        "version": "1.0.0",
+        "description": "Name with uppercase",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": [] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [] },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "employee_package_invalid_field" }
+    },
+    {
+      "id": "reject-version-not-semver",
+      "family": "field_constraints",
+      "description": "Version must be valid semver",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "bad-version",
+        "version": "not.a.version.at.all",
+        "description": "Invalid semver",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": [] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [] },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "employee_package_invalid_field" }
+    },
+    {
+      "id": "reject-empty-authors",
+      "family": "field_constraints",
+      "description": "Authors array must have at least one entry",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "empty-authors",
+        "version": "1.0.0",
+        "description": "No authors",
+        "license": "MIT",
+        "authors": [],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": [] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [] },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "employee_package_invalid_field" }
+    },
+    {
+      "id": "reject-path-backslash",
+      "family": "field_constraints",
+      "description": "Paths must not contain backslashes",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "bad-path",
+        "version": "1.0.0",
+        "description": "Backslash in path",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": [] },
+        "entrypoints": { "skill": ".\\SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [] },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "employee_package_invalid_field" }
+    },
+    {
+      "id": "reject-path-traversal",
+      "family": "field_constraints",
+      "description": "Paths must not contain .. traversal",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "traversal",
+        "version": "1.0.0",
+        "description": "Path traversal attempt",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": [] },
+        "entrypoints": { "skill": "./../etc/passwd", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [] },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "employee_package_invalid_field" }
+    },
+    {
+      "id": "reject-duplicate-assets",
+      "family": "field_constraints",
+      "description": "Assets list must not contain duplicates",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "dup-assets",
+        "version": "1.0.0",
+        "description": "Duplicate assets",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": [] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [] },
+        "assets": ["./SKILL.md", "./SKILL.md"]
+      },
+      "expect": { "kind": "reject", "code": "employee_package_duplicate_value" }
+    },
+    {
+      "id": "reject-unknown-capability",
+      "family": "field_constraints",
+      "description": "Host capabilities must be from the known set",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "bad-cap",
+        "version": "1.0.0",
+        "description": "Unknown capability",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": ["quantum_teleport"] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [] },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "employee_package_unknown_host_capability" }
+    }
+  ]
+}

--- a/fixtures/employee-package-vectors/v1/manifest.json
+++ b/fixtures/employee-package-vectors/v1/manifest.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": "employee-package-vectors.v1",
+  "packageSchemaVersion": "employee-package.v1alpha1",
+  "families": [
+    "schema_validation",
+    "field_constraints",
+    "cross_field",
+    "unknown_fields",
+    "compatibility",
+    "digest"
+  ],
+  "files": [
+    {
+      "file": "schema_validation.json",
+      "sha256": "5c8e41f613905c35c004f08c81236cac1d1f273c97f425e3ca8d6339a8242a2c",
+      "vectorCount": 6
+    },
+    {
+      "file": "field_constraints.json",
+      "sha256": "ba968e6db5672c92defd9b021ed2f0eca686c66c4d747bde2eb8b0e72852a039",
+      "vectorCount": 7
+    },
+    {
+      "file": "cross_field.json",
+      "sha256": "f226f39087a8214e4e04653d8afa83c3007d093597142c80a923adc9e1b8959c",
+      "vectorCount": 4
+    },
+    {
+      "file": "unknown_fields.json",
+      "sha256": "28b259356cbb869b3238b7871d035fb11873106e89fc3970463bf0e45455f8b9",
+      "vectorCount": 4
+    },
+    {
+      "file": "compatibility.json",
+      "sha256": "b78329648c06fd841fe0bcc7576f89d47aded7fdd514e0e0a3639a417f571c8e",
+      "vectorCount": 6
+    },
+    {
+      "file": "digest.json",
+      "sha256": "df66452640b0dfbca3b33fd20e512de4dad897a36358127a76b770baceaed8dd",
+      "vectorCount": 7
+    }
+  ]
+}

--- a/fixtures/employee-package-vectors/v1/schema_validation.json
+++ b/fixtures/employee-package-vectors/v1/schema_validation.json
@@ -1,0 +1,133 @@
+{
+  "schemaVersion": "employee-package-vectors.v1",
+  "family": "schema_validation",
+  "vectors": [
+    {
+      "id": "valid-minimal-read-only",
+      "family": "schema_validation",
+      "description": "Minimal valid manifest with read-only policy and network deny",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "minimal-answer",
+        "version": "1.0.0",
+        "description": "A minimal read-only employee",
+        "license": "MIT",
+        "authors": ["Test Author"],
+        "host": {
+          "protocol": "agent-host.v1",
+          "requiredCapabilities": ["tool_allowlist"]
+        },
+        "entrypoints": {
+          "skill": "./SKILL.md",
+          "inputSchema": "./schemas/input.schema.json",
+          "outputSchema": "./schemas/output.schema.json"
+        },
+        "policy": {
+          "mode": "read_only",
+          "network": "deny",
+          "filesystem": { "read": [], "write": [] },
+          "mcpTools": []
+        },
+        "assets": ["./SKILL.md", "./schemas/input.schema.json", "./schemas/output.schema.json"]
+      },
+      "expect": { "kind": "accept" }
+    },
+    {
+      "id": "valid-full-featured",
+      "family": "schema_validation",
+      "description": "Full-featured manifest with MCP, filesystem, and approval required",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "structured-action",
+        "version": "2.1.0-beta.1",
+        "description": "An employee that performs structured file operations with MCP tools",
+        "license": "Apache-2.0",
+        "authors": ["Engineering Team", "QA Team"],
+        "host": {
+          "protocol": "agent-host.v1",
+          "requiredCapabilities": ["tool_allowlist", "filesystem_scope", "mcp", "approval_callback", "network_policy"]
+        },
+        "entrypoints": {
+          "skill": "./SKILL.md",
+          "inputSchema": "./schemas/input.schema.json",
+          "outputSchema": "./schemas/output.schema.json",
+          "mcp": "./mcp.json"
+        },
+        "policy": {
+          "mode": "approval_required",
+          "network": "deny",
+          "filesystem": {
+            "read": ["./data/input"],
+            "write": ["./data/output"]
+          },
+          "mcpTools": [
+            { "name": "file-reader", "requestedMode": "read" },
+            { "name": "file-writer", "requestedMode": "write" }
+          ]
+        },
+        "assets": ["./SKILL.md", "./schemas/input.schema.json", "./schemas/output.schema.json", "./mcp.json"]
+      },
+      "expect": { "kind": "accept" }
+    },
+    {
+      "id": "reject-missing-schema-version",
+      "family": "schema_validation",
+      "description": "Reject manifest without schemaVersion",
+      "input": {
+        "name": "missing-schema",
+        "version": "1.0.0",
+        "description": "Missing schemaVersion field",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": [] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [] },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "unsupported_employee_package_schema" }
+    },
+    {
+      "id": "reject-wrong-schema-version",
+      "family": "schema_validation",
+      "description": "Reject manifest with unrecognised schemaVersion",
+      "input": {
+        "schemaVersion": "employee-package.v99",
+        "name": "future-schema",
+        "version": "1.0.0",
+        "description": "Future version not supported",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": [] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [] },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "unsupported_employee_package_schema" }
+    },
+    {
+      "id": "reject-wrong-host-protocol",
+      "family": "schema_validation",
+      "description": "Reject manifest with wrong host protocol version",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "wrong-protocol",
+        "version": "1.0.0",
+        "description": "Wrong host protocol",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v2", "requiredCapabilities": [] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [] },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "unsupported_agent_host_protocol" }
+    },
+    {
+      "id": "reject-not-an-object",
+      "family": "schema_validation",
+      "description": "Reject non-object input",
+      "input": "this is a string",
+      "expect": { "kind": "reject", "code": "manifest must be a plain object" }
+    }
+  ]
+}

--- a/fixtures/employee-package-vectors/v1/unknown_fields.json
+++ b/fixtures/employee-package-vectors/v1/unknown_fields.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": "employee-package-vectors.v1",
+  "family": "unknown_fields",
+  "vectors": [
+    {
+      "id": "reject-unknown-top-level-field",
+      "family": "unknown_fields",
+      "description": "Unknown top-level field is rejected (fail-closed)",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "unknown-top",
+        "version": "1.0.0",
+        "description": "Has unknown top-level field",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": [] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [] },
+        "assets": [],
+        "futureField": "should be rejected"
+      },
+      "expect": { "kind": "reject", "code": "employee_package_unknown_field" }
+    },
+    {
+      "id": "reject-unknown-host-field",
+      "family": "unknown_fields",
+      "description": "Unknown field in host object is rejected",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "unknown-host",
+        "version": "1.0.0",
+        "description": "Unknown host field",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": [], "vendor": "custom" },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [] },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "employee_package_unknown_field" }
+    },
+    {
+      "id": "reject-unknown-policy-field",
+      "family": "unknown_fields",
+      "description": "Unknown field in policy object is rejected",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "unknown-policy",
+        "version": "1.0.0",
+        "description": "Unknown policy field",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": [] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [], "sandbox": true },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "employee_package_unknown_field" }
+    },
+    {
+      "id": "reject-unknown-entrypoints-field",
+      "family": "unknown_fields",
+      "description": "Unknown field in entrypoints object is rejected",
+      "input": {
+        "schemaVersion": "employee-package.v1alpha1",
+        "name": "unknown-entry",
+        "version": "1.0.0",
+        "description": "Unknown entrypoints field",
+        "license": "MIT",
+        "authors": ["Test"],
+        "host": { "protocol": "agent-host.v1", "requiredCapabilities": [] },
+        "entrypoints": { "skill": "./SKILL.md", "inputSchema": "./in.json", "outputSchema": "./out.json", "hooks": "./hooks.json" },
+        "policy": { "mode": "read_only", "network": "deny", "filesystem": { "read": [], "write": [] }, "mcpTools": [] },
+        "assets": []
+      },
+      "expect": { "kind": "reject", "code": "employee_package_unknown_field" }
+    }
+  ]
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -158,6 +158,35 @@ export {
 } from "./src/employee-package-digest.js"
 export type { EmployeePackageDigestEntry } from "./src/employee-package-digest.js"
 export {
+  EMPLOYEE_PACKAGE_SCHEMA_VERSIONS,
+  EMPLOYEE_PACKAGE_DIGEST_RULES,
+  EMPLOYEE_PACKAGE_KNOWN_FIELDS,
+  classifySchemaCompatibility,
+  detectUnknownManifestFields,
+  isDowngradeRequired,
+} from "./src/employee-package-compat.js"
+export type { CompatAction, CompatDecision } from "./src/employee-package-compat.js"
+export {
+  EMPLOYEE_PACKAGE_VECTOR_SCHEMA_VERSION,
+  EMPLOYEE_PACKAGE_VECTOR_RESULT_SCHEMA_VERSION,
+  EMPLOYEE_PACKAGE_VECTOR_FAMILIES,
+  classifyEmployeePackageVector,
+  parseEmployeePackageVectorFile,
+  parseEmployeePackageVectorManifest,
+  runEmployeePackageVectorCorpus,
+} from "./src/employee-package-vectors.js"
+export type {
+  EmployeePackageVector,
+  EmployeePackageVectorClassification,
+  EmployeePackageVectorExpectation,
+  EmployeePackageVectorFailure,
+  EmployeePackageVectorFamily,
+  EmployeePackageVectorFile,
+  EmployeePackageVectorManifest,
+  EmployeePackageVectorManifestEntry,
+  EmployeePackageVectorResult,
+} from "./src/employee-package-vectors.js"
+export {
   EMPLOYEE_MCP_SCHEMA_VERSION,
   validateEmployeeMcpManifest,
 } from "./src/employee-mcp.js"

--- a/packages/core/src/employee-package-compat.ts
+++ b/packages/core/src/employee-package-compat.ts
@@ -1,0 +1,191 @@
+/**
+ * Employee-package compatibility semantics.
+ *
+ * This module codifies the frozen compatibility rules for the employee-package
+ * format, covering schema version negotiation, unknown-field handling,
+ * downgrade prevention, and migration from v1alpha1 to the stable line.
+ */
+
+import { ValidationError } from "./contracts.js"
+import { EMPLOYEE_PACKAGE_SCHEMA_VERSION } from "./employee-package.js"
+
+// --- Schema version registry ---
+
+/**
+ * Ordered schema versions from oldest to newest.
+ * A consumer MUST reject any version it does not recognise.
+ */
+export const EMPLOYEE_PACKAGE_SCHEMA_VERSIONS = Object.freeze([
+  "employee-package.v1alpha1",
+] as const)
+
+export type EmployeePackageSchemaVersion =
+  (typeof EMPLOYEE_PACKAGE_SCHEMA_VERSIONS)[number]
+
+// --- Compatibility classification ---
+
+export type CompatAction = "accept" | "migrate" | "reject"
+
+export interface CompatDecision {
+  action: CompatAction
+  reason: string
+  /** If action is "migrate", the source version. */
+  sourceVersion?: string
+  /** If action is "migrate", the target version. */
+  targetVersion?: string
+}
+
+/**
+ * Compatibility rules (frozen at design freeze):
+ *
+ * 1. EXACT MATCH: If the document schemaVersion matches the consumer's
+ *    supported version, accept.
+ * 2. FORWARD COMPAT (unknown fields): A consumer MUST reject unknown
+ *    top-level and nested fields. This is fail-closed by design — employee
+ *    packages are security boundaries and silent field drops could weaken
+ *    policy enforcement.
+ * 3. DOWNGRADE PREVENTION: A consumer MUST NOT process a document whose
+ *    schemaVersion is newer than the consumer's newest supported version.
+ * 4. MIGRATION: A consumer MAY migrate from an older recognised version to
+ *    its current version using deterministic transforms. The consumer MUST
+ *    NOT alter the original artifact; migration produces a new in-memory
+ *    representation only.
+ * 5. UNKNOWN VERSION: A consumer MUST reject any schemaVersion it does not
+ *    recognise (not in its EMPLOYEE_PACKAGE_SCHEMA_VERSIONS list).
+ */
+export function classifySchemaCompatibility(
+  documentVersion: unknown,
+  consumerVersions: readonly string[] = EMPLOYEE_PACKAGE_SCHEMA_VERSIONS,
+): CompatDecision {
+  if (typeof documentVersion !== "string" || !documentVersion) {
+    return { action: "reject", reason: "schema_version_missing" }
+  }
+
+  const consumerCurrent = consumerVersions[consumerVersions.length - 1]
+
+  // Exact match — accept
+  if (documentVersion === consumerCurrent) {
+    return { action: "accept", reason: "exact_match" }
+  }
+
+  // Known older version — migrate
+  const docIndex = consumerVersions.indexOf(documentVersion)
+  if (docIndex >= 0 && docIndex < consumerVersions.length - 1) {
+    return {
+      action: "migrate",
+      reason: "known_older_version",
+      sourceVersion: documentVersion,
+      targetVersion: consumerCurrent,
+    }
+  }
+
+  // Unknown version — reject (covers both newer and unrecognised)
+  if (docIndex === -1) {
+    // Check if it looks like a newer version in the same family
+    if (documentVersion.startsWith("employee-package.")) {
+      return { action: "reject", reason: "unknown_version_no_downgrade" }
+    }
+    return { action: "reject", reason: "unknown_version_unrecognised" }
+  }
+
+  return { action: "reject", reason: "unknown_version_unrecognised" }
+}
+
+// --- Unknown field rejection ---
+
+export interface UnknownFieldResult {
+  valid: boolean
+  unknownFields: string[]
+}
+
+/** Known fields at each object level of the employee-package manifest. */
+export const EMPLOYEE_PACKAGE_KNOWN_FIELDS = Object.freeze({
+  manifest: [
+    "$schema",
+    "schemaVersion",
+    "name",
+    "version",
+    "description",
+    "license",
+    "authors",
+    "host",
+    "entrypoints",
+    "policy",
+    "assets",
+  ],
+  host: ["protocol", "requiredCapabilities"],
+  entrypoints: ["skill", "inputSchema", "outputSchema", "mcp"],
+  policy: ["mode", "network", "filesystem", "mcpTools"],
+  "policy.filesystem": ["read", "write"],
+  "policy.mcpTools[]": ["name", "requestedMode"],
+} as const)
+
+/**
+ * Detects unknown fields at the manifest top level.
+ * Full recursive detection is handled by validateEmployeePackageManifest
+ * (which throws on any unknown field). This function is the language-neutral
+ * specification of which fields are allowed.
+ */
+export function detectUnknownManifestFields(
+  input: unknown,
+): UnknownFieldResult {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return { valid: false, unknownFields: [] }
+  }
+  const unknownFields: string[] = []
+  const allowed: readonly string[] = EMPLOYEE_PACKAGE_KNOWN_FIELDS.manifest
+  for (const key of Object.keys(input)) {
+    if (!allowed.includes(key)) {
+      unknownFields.push(key)
+    }
+  }
+  return { valid: unknownFields.length === 0, unknownFields }
+}
+
+// --- Downgrade guard ---
+
+/**
+ * Returns true if `documentVersion` is strictly newer than any version in
+ * `consumerVersions` (meaning the consumer would need to downgrade to
+ * process it, which is forbidden).
+ */
+export function isDowngradeRequired(
+  documentVersion: string,
+  consumerVersions: readonly string[] = EMPLOYEE_PACKAGE_SCHEMA_VERSIONS,
+): boolean {
+  const decision = classifySchemaCompatibility(
+    documentVersion,
+    consumerVersions,
+  )
+  return decision.reason === "unknown_version_no_downgrade"
+}
+
+// --- Digest canonical input stability ---
+
+/**
+ * The digest domain is frozen. Changing it would break all existing digests.
+ * This constant is re-exported here for vector completeness.
+ */
+export { EMPLOYEE_PACKAGE_DIGEST_DOMAIN } from "./employee-package-digest.js"
+
+/**
+ * Digest canonical input rules (frozen):
+ *
+ * 1. Only portable file paths (./relative, no backslash, no control chars)
+ *    and their exact byte contents are hashed.
+ * 2. Entries are sorted lexicographically by UTF-8 path bytes before hashing.
+ * 3. Domain separation: hash is prefixed with the frozen domain string.
+ * 4. Max 513 entries, max 20 MiB + 256 KiB total.
+ * 5. Duplicate paths, unsafe paths, proxy objects, and accessor properties
+ *    are rejected.
+ * 6. Output format: "sha256:<hex>"
+ */
+export const EMPLOYEE_PACKAGE_DIGEST_RULES = Object.freeze({
+  domain: "digital-employee.employee-package.v1",
+  algorithm: "sha256",
+  maxEntries: 513,
+  maxTotalBytes: 20 * 1024 * 1024 + 256 * 1024,
+  maxPathLength: 1024,
+  outputFormat: "sha256:<hex>",
+  sortOrder: "utf8_lexicographic",
+} as const)

--- a/packages/core/src/employee-package-vectors.ts
+++ b/packages/core/src/employee-package-vectors.ts
@@ -1,0 +1,352 @@
+/**
+ * Employee-package golden vector corpus runner.
+ *
+ * Mirrors the agent-host-vectors pattern: language-neutral JSON vectors are
+ * parsed and classified against frozen validation rules, producing a stable
+ * machine-readable result.
+ */
+
+import { CoreError } from "./contracts.js"
+import {
+  EMPLOYEE_PACKAGE_SCHEMA_VERSION,
+  validateEmployeePackageManifest,
+} from "./employee-package.js"
+import { computeEmployeePackageDigest } from "./employee-package-digest.js"
+import type { EmployeePackageDigestEntry } from "./employee-package-digest.js"
+import {
+  classifySchemaCompatibility,
+  detectUnknownManifestFields,
+} from "./employee-package-compat.js"
+
+// --- Schema constants ---
+
+export const EMPLOYEE_PACKAGE_VECTOR_SCHEMA_VERSION =
+  "employee-package-vectors.v1"
+export const EMPLOYEE_PACKAGE_VECTOR_RESULT_SCHEMA_VERSION =
+  "employee-package-vectors-result.v1"
+
+export const EMPLOYEE_PACKAGE_VECTOR_FAMILIES = Object.freeze([
+  "schema_validation",
+  "field_constraints",
+  "cross_field",
+  "unknown_fields",
+  "compatibility",
+  "digest",
+] as const)
+
+export type EmployeePackageVectorFamily =
+  (typeof EMPLOYEE_PACKAGE_VECTOR_FAMILIES)[number]
+
+// --- Vector types ---
+
+export interface EmployeePackageVectorExpectation {
+  kind: "accept" | "reject"
+  code?: string
+}
+
+export interface EmployeePackageVector {
+  id: string
+  family: EmployeePackageVectorFamily
+  description?: string
+  input: unknown
+  expect: EmployeePackageVectorExpectation
+}
+
+export interface EmployeePackageVectorFile {
+  schemaVersion: string
+  family: EmployeePackageVectorFamily
+  vectors: EmployeePackageVector[]
+}
+
+export interface EmployeePackageVectorManifestEntry {
+  file: string
+  sha256: string
+  vectorCount: number
+}
+
+export interface EmployeePackageVectorManifest {
+  schemaVersion: string
+  packageSchemaVersion: string
+  families: readonly string[]
+  files: EmployeePackageVectorManifestEntry[]
+}
+
+export interface EmployeePackageVectorClassification {
+  kind: "accept" | "reject"
+  code?: string
+}
+
+export interface EmployeePackageVectorFailure {
+  id: string
+  family: EmployeePackageVectorFamily
+  expected: EmployeePackageVectorExpectation
+  actual: EmployeePackageVectorClassification
+}
+
+export interface EmployeePackageVectorResult {
+  schemaVersion: string
+  corpusVersion: string
+  packageSchemaVersion: string
+  total: number
+  passed: number
+  failed: EmployeePackageVectorFailure[]
+  result: "PASS" | "FAIL"
+}
+
+// --- Parsing ---
+
+function vectorError(message: string): CoreError {
+  return new CoreError("EMPLOYEE_PACKAGE_VECTORS_INVALID", message, {
+    status: 400,
+    retryable: false,
+  })
+}
+
+function plainRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+const VECTOR_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+function parseVector(
+  value: unknown,
+  family: EmployeePackageVectorFamily,
+): EmployeePackageVector {
+  if (
+    !plainRecord(value) ||
+    typeof value.id !== "string" ||
+    !VECTOR_ID_PATTERN.test(value.id) ||
+    value.family !== family ||
+    value.input === undefined ||
+    !plainRecord(value.expect) ||
+    (value.expect.kind !== "accept" && value.expect.kind !== "reject") ||
+    (value.expect.kind === "reject" && typeof value.expect.code !== "string")
+  ) {
+    throw vectorError("vector entry is malformed")
+  }
+  return {
+    id: value.id,
+    family,
+    ...(typeof value.description === "string"
+      ? { description: value.description }
+      : {}),
+    input: value.input,
+    expect: {
+      kind: value.expect.kind,
+      ...(value.expect.kind === "reject"
+        ? { code: value.expect.code as string }
+        : {}),
+    },
+  }
+}
+
+export function parseEmployeePackageVectorFile(
+  value: unknown,
+  expectedFamily: EmployeePackageVectorFamily,
+): EmployeePackageVectorFile {
+  if (
+    !plainRecord(value) ||
+    value.schemaVersion !== EMPLOYEE_PACKAGE_VECTOR_SCHEMA_VERSION ||
+    value.family !== expectedFamily ||
+    !Array.isArray(value.vectors)
+  ) {
+    throw vectorError(
+      `vector file for family ${expectedFamily} is malformed`,
+    )
+  }
+  const seen = new Set<string>()
+  const vectors = value.vectors.map((entry) => {
+    const vector = parseVector(entry, expectedFamily)
+    if (seen.has(vector.id))
+      throw vectorError(`duplicate vector id ${vector.id}`)
+    seen.add(vector.id)
+    return vector
+  })
+  return {
+    schemaVersion: EMPLOYEE_PACKAGE_VECTOR_SCHEMA_VERSION,
+    family: expectedFamily,
+    vectors,
+  }
+}
+
+export function parseEmployeePackageVectorManifest(
+  value: unknown,
+): EmployeePackageVectorManifest {
+  if (
+    !plainRecord(value) ||
+    value.schemaVersion !== EMPLOYEE_PACKAGE_VECTOR_SCHEMA_VERSION ||
+    value.packageSchemaVersion !== EMPLOYEE_PACKAGE_SCHEMA_VERSION ||
+    !Array.isArray(value.families) ||
+    value.families.length !== EMPLOYEE_PACKAGE_VECTOR_FAMILIES.length ||
+    !EMPLOYEE_PACKAGE_VECTOR_FAMILIES.every((family) =>
+      (value.families as unknown[]).includes(family),
+    ) ||
+    !Array.isArray(value.files) ||
+    value.files.length !== EMPLOYEE_PACKAGE_VECTOR_FAMILIES.length ||
+    !value.files.every(
+      (entry) =>
+        plainRecord(entry) &&
+        typeof entry.file === "string" &&
+        /^[a-z0-9_]+\.json$/.test(entry.file) &&
+        typeof entry.sha256 === "string" &&
+        /^[0-9a-f]{64}$/.test(entry.sha256) &&
+        typeof entry.vectorCount === "number" &&
+        Number.isInteger(entry.vectorCount) &&
+        entry.vectorCount > 0,
+    )
+  ) {
+    throw vectorError("vector manifest is malformed")
+  }
+  return value as unknown as EmployeePackageVectorManifest
+}
+
+// --- Classification ---
+
+function classifySchemaValidation(
+  input: unknown,
+): EmployeePackageVectorClassification {
+  try {
+    validateEmployeePackageManifest(input)
+    return { kind: "accept" }
+  } catch (error) {
+    const code =
+      error instanceof Error ? error.message.split(":")[0] : "unknown"
+    return { kind: "reject", code }
+  }
+}
+
+function classifyFieldConstraints(
+  input: unknown,
+): EmployeePackageVectorClassification {
+  return classifySchemaValidation(input)
+}
+
+function classifyCrossField(
+  input: unknown,
+): EmployeePackageVectorClassification {
+  return classifySchemaValidation(input)
+}
+
+function classifyUnknownFields(
+  input: unknown,
+): EmployeePackageVectorClassification {
+  // Unknown-field vectors test that the validator rejects unknown fields.
+  try {
+    validateEmployeePackageManifest(input)
+    return { kind: "accept" }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : ""
+    if (message.startsWith("employee_package_unknown_field")) {
+      return { kind: "reject", code: "employee_package_unknown_field" }
+    }
+    // Other validation errors
+    const code = message.split(":")[0] || "unknown"
+    return { kind: "reject", code }
+  }
+}
+
+function classifyCompatibility(
+  input: unknown,
+): EmployeePackageVectorClassification {
+  if (!plainRecord(input)) {
+    return { kind: "reject", code: "schema_version_missing" }
+  }
+  const decision = classifySchemaCompatibility(input.schemaVersion)
+  if (decision.action === "accept" || decision.action === "migrate") {
+    return { kind: "accept" }
+  }
+  return { kind: "reject", code: decision.reason }
+}
+
+function classifyDigest(
+  input: unknown,
+): EmployeePackageVectorClassification {
+  if (!plainRecord(input) || !Array.isArray(input.entries)) {
+    return { kind: "reject", code: "employee_package_digest_input_invalid" }
+  }
+  try {
+    const entries: EmployeePackageDigestEntry[] = input.entries.map(
+      (entry: unknown) => {
+        if (!plainRecord(entry)) throw new Error("invalid entry")
+        const path = entry.path as string
+        // Vectors encode bytes as hex strings for language neutrality
+        const hexBytes = entry.bytesHex as string
+        const bytes = Buffer.from(hexBytes, "hex")
+        return { path, bytes }
+      },
+    )
+    const digest = computeEmployeePackageDigest(entries)
+    // If an expected digest is provided, verify it matches
+    if (typeof input.expectedDigest === "string") {
+      if (digest !== input.expectedDigest) {
+        return { kind: "reject", code: "employee_package_digest_mismatch" }
+      }
+    }
+    return { kind: "accept" }
+  } catch {
+    return { kind: "reject", code: "employee_package_digest_input_invalid" }
+  }
+}
+
+/** Classifies one vector against the frozen employee-package rules. */
+export function classifyEmployeePackageVector(
+  vector: EmployeePackageVector,
+): EmployeePackageVectorClassification {
+  switch (vector.family) {
+    case "schema_validation":
+      return classifySchemaValidation(vector.input)
+    case "field_constraints":
+      return classifyFieldConstraints(vector.input)
+    case "cross_field":
+      return classifyCrossField(vector.input)
+    case "unknown_fields":
+      return classifyUnknownFields(vector.input)
+    case "compatibility":
+      return classifyCompatibility(vector.input)
+    case "digest":
+      return classifyDigest(vector.input)
+    default:
+      return { kind: "reject", code: "unknown_family" }
+  }
+}
+
+// --- Corpus runner ---
+
+function expectationsMatch(
+  expected: EmployeePackageVectorExpectation,
+  actual: EmployeePackageVectorClassification,
+): boolean {
+  if (expected.kind === "accept") return actual.kind === "accept"
+  return actual.kind === "reject" && actual.code === expected.code
+}
+
+/** Runs a parsed corpus and produces the stable machine result. */
+export function runEmployeePackageVectorCorpus(
+  files: readonly EmployeePackageVectorFile[],
+): EmployeePackageVectorResult {
+  const failures: EmployeePackageVectorFailure[] = []
+  let total = 0
+  for (const file of files) {
+    for (const vector of file.vectors) {
+      total += 1
+      const actual = classifyEmployeePackageVector(vector)
+      if (!expectationsMatch(vector.expect, actual)) {
+        failures.push({
+          id: vector.id,
+          family: vector.family,
+          expected: vector.expect,
+          actual,
+        })
+      }
+    }
+  }
+  return {
+    schemaVersion: EMPLOYEE_PACKAGE_VECTOR_RESULT_SCHEMA_VERSION,
+    corpusVersion: EMPLOYEE_PACKAGE_VECTOR_SCHEMA_VERSION,
+    packageSchemaVersion: EMPLOYEE_PACKAGE_SCHEMA_VERSION,
+    total,
+    passed: total - failures.length,
+    failed: failures,
+    result: failures.length === 0 ? "PASS" : "FAIL",
+  }
+}

--- a/tests/core/employee-package-compat.test.ts
+++ b/tests/core/employee-package-compat.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  classifySchemaCompatibility,
+  detectUnknownManifestFields,
+  isDowngradeRequired,
+  EMPLOYEE_PACKAGE_SCHEMA_VERSIONS,
+  EMPLOYEE_PACKAGE_KNOWN_FIELDS,
+  EMPLOYEE_PACKAGE_DIGEST_RULES,
+} from "../../packages/core/index.js"
+
+test("classifySchemaCompatibility — accepts current version", () => {
+  const result = classifySchemaCompatibility("employee-package.v1alpha1")
+  assert.equal(result.action, "accept")
+  assert.equal(result.reason, "exact_match")
+})
+
+test("classifySchemaCompatibility — rejects missing version", () => {
+  const result = classifySchemaCompatibility(undefined)
+  assert.equal(result.action, "reject")
+  assert.equal(result.reason, "schema_version_missing")
+})
+
+test("classifySchemaCompatibility — rejects empty string", () => {
+  const result = classifySchemaCompatibility("")
+  assert.equal(result.action, "reject")
+  assert.equal(result.reason, "schema_version_missing")
+})
+
+test("classifySchemaCompatibility — rejects future version (no downgrade)", () => {
+  const result = classifySchemaCompatibility("employee-package.v2")
+  assert.equal(result.action, "reject")
+  assert.equal(result.reason, "unknown_version_no_downgrade")
+})
+
+test("classifySchemaCompatibility — rejects unrecognised family", () => {
+  const result = classifySchemaCompatibility("something-else.v1")
+  assert.equal(result.action, "reject")
+  assert.equal(result.reason, "unknown_version_unrecognised")
+})
+
+test("classifySchemaCompatibility — migrates from older known version", () => {
+  const consumerVersions = [
+    "employee-package.v1alpha1",
+    "employee-package.v1",
+  ]
+  const result = classifySchemaCompatibility(
+    "employee-package.v1alpha1",
+    consumerVersions,
+  )
+  assert.equal(result.action, "migrate")
+  assert.equal(result.reason, "known_older_version")
+  assert.equal(result.sourceVersion, "employee-package.v1alpha1")
+  assert.equal(result.targetVersion, "employee-package.v1")
+})
+
+test("detectUnknownManifestFields — valid with known fields", () => {
+  const result = detectUnknownManifestFields({
+    schemaVersion: "employee-package.v1alpha1",
+    name: "test",
+    version: "1.0.0",
+    description: "test",
+    license: "MIT",
+    authors: [],
+    host: {},
+    entrypoints: {},
+    policy: {},
+    assets: [],
+  })
+  assert.equal(result.valid, true)
+  assert.deepEqual(result.unknownFields, [])
+})
+
+test("detectUnknownManifestFields — detects unknown fields", () => {
+  const result = detectUnknownManifestFields({
+    schemaVersion: "employee-package.v1alpha1",
+    name: "test",
+    extra: "unknown",
+    anotherExtra: 42,
+  })
+  assert.equal(result.valid, false)
+  assert.ok(result.unknownFields.includes("extra"))
+  assert.ok(result.unknownFields.includes("anotherExtra"))
+})
+
+test("detectUnknownManifestFields — rejects non-object", () => {
+  assert.equal(detectUnknownManifestFields(null).valid, false)
+  assert.equal(detectUnknownManifestFields("string").valid, false)
+  assert.equal(detectUnknownManifestFields([]).valid, false)
+})
+
+test("isDowngradeRequired — true for newer versions", () => {
+  assert.equal(isDowngradeRequired("employee-package.v2"), true)
+})
+
+test("isDowngradeRequired — false for current version", () => {
+  assert.equal(isDowngradeRequired("employee-package.v1alpha1"), false)
+})
+
+test("isDowngradeRequired — false for unrecognised family", () => {
+  assert.equal(isDowngradeRequired("other.v1"), false)
+})
+
+test("frozen constants — schema versions", () => {
+  assert.ok(Object.isFrozen(EMPLOYEE_PACKAGE_SCHEMA_VERSIONS))
+  assert.deepEqual([...EMPLOYEE_PACKAGE_SCHEMA_VERSIONS], [
+    "employee-package.v1alpha1",
+  ])
+})
+
+test("frozen constants — known fields registry", () => {
+  assert.ok(EMPLOYEE_PACKAGE_KNOWN_FIELDS.manifest.includes("schemaVersion"))
+  assert.ok(EMPLOYEE_PACKAGE_KNOWN_FIELDS.host.includes("protocol"))
+  assert.ok(EMPLOYEE_PACKAGE_KNOWN_FIELDS.entrypoints.includes("skill"))
+  assert.ok(EMPLOYEE_PACKAGE_KNOWN_FIELDS.policy.includes("mode"))
+  assert.ok(
+    EMPLOYEE_PACKAGE_KNOWN_FIELDS["policy.filesystem"].includes("read"),
+  )
+  assert.ok(
+    EMPLOYEE_PACKAGE_KNOWN_FIELDS["policy.mcpTools[]"].includes("name"),
+  )
+})
+
+test("frozen constants — digest rules", () => {
+  assert.ok(Object.isFrozen(EMPLOYEE_PACKAGE_DIGEST_RULES))
+  assert.equal(
+    EMPLOYEE_PACKAGE_DIGEST_RULES.domain,
+    "digital-employee.employee-package.v1",
+  )
+  assert.equal(EMPLOYEE_PACKAGE_DIGEST_RULES.algorithm, "sha256")
+  assert.equal(EMPLOYEE_PACKAGE_DIGEST_RULES.maxEntries, 513)
+  assert.equal(EMPLOYEE_PACKAGE_DIGEST_RULES.outputFormat, "sha256:<hex>")
+})

--- a/tests/core/employee-package-vectors.test.ts
+++ b/tests/core/employee-package-vectors.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { readFileSync } from "node:fs"
+import { resolve, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import { createHash } from "node:crypto"
+
+import {
+  EMPLOYEE_PACKAGE_VECTOR_FAMILIES,
+  EMPLOYEE_PACKAGE_VECTOR_SCHEMA_VERSION,
+  parseEmployeePackageVectorFile,
+  parseEmployeePackageVectorManifest,
+  runEmployeePackageVectorCorpus,
+} from "../../packages/core/index.js"
+import type {
+  EmployeePackageVectorFamily,
+  EmployeePackageVectorFile,
+} from "../../packages/core/index.js"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const FIXTURES_DIR = resolve(
+  __dirname,
+  "../../fixtures/employee-package-vectors/v1",
+)
+
+function readFixture(filename: string): Buffer {
+  return readFileSync(resolve(FIXTURES_DIR, filename))
+}
+
+test("manifest declares all families", () => {
+  const manifest = parseEmployeePackageVectorManifest(
+    JSON.parse(readFixture("manifest.json").toString()),
+  )
+  assert.deepEqual([...manifest.families], [...EMPLOYEE_PACKAGE_VECTOR_FAMILIES])
+})
+
+test("manifest has one file entry per family", () => {
+  const manifest = parseEmployeePackageVectorManifest(
+    JSON.parse(readFixture("manifest.json").toString()),
+  )
+  assert.equal(manifest.files.length, EMPLOYEE_PACKAGE_VECTOR_FAMILIES.length)
+})
+
+const manifestData = JSON.parse(readFixture("manifest.json").toString())
+for (const entry of manifestData.files as Array<{
+  file: string
+  sha256: string
+  vectorCount: number
+}>) {
+  test(`${entry.file} SHA-256 matches manifest`, () => {
+    const content = readFixture(entry.file)
+    const hash = createHash("sha256").update(content).digest("hex")
+    assert.equal(hash, entry.sha256)
+  })
+
+  test(`${entry.file} vector count matches manifest`, () => {
+    const data = JSON.parse(readFixture(entry.file).toString())
+    assert.equal(data.vectors.length, entry.vectorCount)
+  })
+}
+
+test("corpus runner — all vectors pass", () => {
+  const files: EmployeePackageVectorFile[] = []
+  for (const family of EMPLOYEE_PACKAGE_VECTOR_FAMILIES) {
+    const filename = `${family}.json`
+    const data = JSON.parse(readFixture(filename).toString())
+    files.push(
+      parseEmployeePackageVectorFile(
+        data,
+        family as EmployeePackageVectorFamily,
+      ),
+    )
+  }
+  const result = runEmployeePackageVectorCorpus(files)
+  if (result.failed.length > 0) {
+    const details = result.failed
+      .map(
+        (f) =>
+          `  ${f.id}: expected ${f.expected.kind}${f.expected.code ? `:${f.expected.code}` : ""}, got ${f.actual.kind}${f.actual.code ? `:${f.actual.code}` : ""}`,
+      )
+      .join("\n")
+    assert.fail(
+      `${result.failed.length}/${result.total} vectors failed:\n${details}`,
+    )
+  }
+  assert.equal(result.result, "PASS")
+  assert.equal(result.total, 34)
+  assert.equal(result.passed, 34)
+})
+
+test("corpus runner — result schema is correct", () => {
+  const files: EmployeePackageVectorFile[] = []
+  for (const family of EMPLOYEE_PACKAGE_VECTOR_FAMILIES) {
+    const filename = `${family}.json`
+    const data = JSON.parse(readFixture(filename).toString())
+    files.push(
+      parseEmployeePackageVectorFile(
+        data,
+        family as EmployeePackageVectorFamily,
+      ),
+    )
+  }
+  const result = runEmployeePackageVectorCorpus(files)
+  assert.equal(result.schemaVersion, "employee-package-vectors-result.v1")
+  assert.equal(result.corpusVersion, EMPLOYEE_PACKAGE_VECTOR_SCHEMA_VERSION)
+  assert.equal(result.packageSchemaVersion, "employee-package.v1alpha1")
+})


### PR DESCRIPTION
## Summary

- Codifies frozen compatibility rules for the employee-package format: schema version negotiation, unknown-field rejection (fail-closed), downgrade prevention, and v1alpha1→stable migration semantics
- Publishes 34 language-neutral golden vectors across 6 families (`schema_validation`, `field_constraints`, `cross_field`, `unknown_fields`, `compatibility`, `digest`) with SHA-256 integrity manifest
- Adds `runEmployeePackageVectorCorpus()` runner for cross-language conformance verification

## Design decisions (frozen at this PR)

1. **Unknown fields**: REJECT (fail-closed) — employee packages are security boundaries; silent field drops could weaken policy enforcement
2. **Downgrade prevention**: consumer MUST NOT process documents with newer schema versions
3. **Migration**: deterministic in-memory transforms only; original artifact is never mutated
4. **Digest stability**: domain, algorithm, sort order, limits all frozen as constants

## Validation

| ID | Criterion | Result |
|---|---|---|
| V1 | `npm run check` (typecheck + build + 487 tests + security) | ✅ |
| V2 | All 34 golden vectors pass against frozen rules | ✅ |
| V3 | Manifest SHA-256 integrity verified for all vector files | ✅ |

## Security and data review

- [x] No credentials, personal identifiers, or internal URLs included
- [x] No dependency added
- [x] `npm run check` and security scan pass

Refs #39