### PR TITLE
feat(core): add Runner authenticated transport port and device-key lifecycle

### DIFF
--- a/fixtures/runner-device-vectors/v1/enrollment.json
+++ b/fixtures/runner-device-vectors/v1/enrollment.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": "runner-device-vectors.v1",
+  "family": "enrollment",
+  "vectors": [
+    {
+      "id": "valid-enrollment",
+      "family": "enrollment",
+      "input": {
+        "version": "runner-device.v1",
+        "runnerId": "runner-fixture-001",
+        "sellerId": "seller-fixture-001",
+        "keyId": "device:a1b2c3d4e5f60718",
+        "publicKeySpki": "MCowBQYDK2VwAyEAGb1gaR2jOBHfaNktGSqKWoQAbpFBhQVUtFtFkPCfXR4=",
+        "enrolledAt": "2026-08-07T00:00:00.000Z"
+      },
+      "expect": { "kind": "accept" }
+    },
+    {
+      "id": "reject-missing-runner-id",
+      "family": "enrollment",
+      "input": {
+        "version": "runner-device.v1",
+        "sellerId": "seller-001",
+        "keyId": "device:abc",
+        "publicKeySpki": "MCowBQ...",
+        "enrolledAt": "2026-08-07T00:00:00.000Z"
+      },
+      "expect": { "kind": "reject", "code": "RUNNER_DEVICE_STORE_FAILED" }
+    },
+    {
+      "id": "reject-wrong-version",
+      "family": "enrollment",
+      "input": {
+        "version": "runner-device.v99",
+        "runnerId": "runner-001",
+        "sellerId": "seller-001",
+        "keyId": "device:abc",
+        "publicKeySpki": "MCowBQ...",
+        "enrolledAt": "2026-08-07T00:00:00.000Z"
+      },
+      "expect": { "kind": "reject", "code": "RUNNER_DEVICE_STORE_FAILED" }
+    },
+    {
+      "id": "reject-null-input",
+      "family": "enrollment",
+      "input": null,
+      "expect": { "kind": "reject", "code": "RUNNER_DEVICE_STORE_FAILED" }
+    },
+    {
+      "id": "reject-missing-seller-id",
+      "family": "enrollment",
+      "input": {
+        "version": "runner-device.v1",
+        "runnerId": "runner-001",
+        "keyId": "device:abc",
+        "publicKeySpki": "MCowBQ...",
+        "enrolledAt": "2026-08-07T00:00:00.000Z"
+      },
+      "expect": { "kind": "reject", "code": "RUNNER_DEVICE_STORE_FAILED" }
+    }
+  ]
+}

--- a/fixtures/runner-device-vectors/v1/manifest.json
+++ b/fixtures/runner-device-vectors/v1/manifest.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "runner-device-vectors.v1",
+  "deviceVersion": "runner-device.v1",
+  "transportVersion": "runner-transport.v1",
+  "families": [
+    "enrollment",
+    "rotation",
+    "transport"
+  ],
+  "files": [
+    {
+      "file": "enrollment.json",
+      "sha256": "bd6cd0b8ae8735430186742f9a44805157525072ae37b69a6c8b4fa56ef25105",
+      "vectorCount": 5
+    },
+    {
+      "file": "rotation.json",
+      "sha256": "dc6b7ad3e601bcf663a03a3b60040915f9a022d39d8c582a7df8556461ea0110",
+      "vectorCount": 4
+    },
+    {
+      "file": "transport.json",
+      "sha256": "284dc3b7dc7391803dde7feb6b4909544eac369261366d1ebfff85ac42225788",
+      "vectorCount": 6
+    }
+  ]
+}

--- a/fixtures/runner-device-vectors/v1/rotation.json
+++ b/fixtures/runner-device-vectors/v1/rotation.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": "runner-device-vectors.v1",
+  "family": "rotation",
+  "vectors": [
+    {
+      "id": "eligible-rotation-past-minimum-lifetime",
+      "family": "rotation",
+      "description": "Key active for more than RUNNER_DEVICE_MIN_LIFETIME_SECONDS",
+      "input": {
+        "record": {
+          "keyId": "device:current001",
+          "status": "active",
+          "activeSince": "2026-06-01T00:00:00.000Z"
+        },
+        "nowMs": 1722988800000
+      },
+      "expect": { "kind": "accept" }
+    },
+    {
+      "id": "reject-rotation-too-early",
+      "family": "rotation",
+      "description": "Key active for less than minimum lifetime",
+      "input": {
+        "record": {
+          "keyId": "device:recent001",
+          "status": "active",
+          "activeSince": "2026-08-07T00:00:00.000Z"
+        },
+        "nowMs": 1722988810000
+      },
+      "expect": { "kind": "reject", "code": "RUNNER_DEVICE_ROTATION_TOO_EARLY" }
+    },
+    {
+      "id": "reject-rotation-non-active-key",
+      "family": "rotation",
+      "description": "Cannot rotate a revoked key",
+      "input": {
+        "record": {
+          "keyId": "device:revoked001",
+          "status": "revoked",
+          "activeSince": "2025-01-01T00:00:00.000Z",
+          "revokedAt": "2026-07-01T00:00:00.000Z"
+        },
+        "nowMs": 1722988800000
+      },
+      "expect": { "kind": "reject", "code": "RUNNER_DEVICE_ROTATION_TOO_EARLY" }
+    },
+    {
+      "id": "reject-rotation-rotating-key",
+      "family": "rotation",
+      "description": "Cannot rotate a key already in rotation",
+      "input": {
+        "record": {
+          "keyId": "device:rotating001",
+          "status": "rotating",
+          "activeSince": "2025-01-01T00:00:00.000Z",
+          "nextKeyId": "device:next001"
+        },
+        "nowMs": 1722988800000
+      },
+      "expect": { "kind": "reject", "code": "RUNNER_DEVICE_ROTATION_TOO_EARLY" }
+    }
+  ]
+}

--- a/fixtures/runner-device-vectors/v1/transport.json
+++ b/fixtures/runner-device-vectors/v1/transport.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": "runner-device-vectors.v1",
+  "family": "transport",
+  "vectors": [
+    {
+      "id": "retry-unavailable-first-attempt",
+      "family": "transport",
+      "description": "503 Unavailable on attempt 0 should retry",
+      "input": {
+        "errorCode": "RUNNER_TRANSPORT_UNAVAILABLE",
+        "attempt": 0
+      },
+      "expect": { "kind": "accept" }
+    },
+    {
+      "id": "retry-timeout-second-attempt",
+      "family": "transport",
+      "description": "Timeout on attempt 1 should retry with increased backoff",
+      "input": {
+        "errorCode": "RUNNER_TRANSPORT_TIMEOUT",
+        "attempt": 1
+      },
+      "expect": { "kind": "accept" }
+    },
+    {
+      "id": "retry-rate-limited-with-retry-after",
+      "family": "transport",
+      "description": "Rate-limited with retryAfterMs should retry using that base",
+      "input": {
+        "errorCode": "RUNNER_TRANSPORT_RATE_LIMITED",
+        "attempt": 0,
+        "retryAfterMs": 5000
+      },
+      "expect": { "kind": "accept" }
+    },
+    {
+      "id": "no-retry-forbidden",
+      "family": "transport",
+      "description": "403 Forbidden should not retry",
+      "input": {
+        "errorCode": "RUNNER_TRANSPORT_FORBIDDEN",
+        "attempt": 0
+      },
+      "expect": { "kind": "reject", "code": "no_retry" }
+    },
+    {
+      "id": "no-retry-unauthorized",
+      "family": "transport",
+      "description": "401 Unauthorized should not retry",
+      "input": {
+        "errorCode": "RUNNER_TRANSPORT_UNAUTHORIZED",
+        "attempt": 0
+      },
+      "expect": { "kind": "reject", "code": "no_retry" }
+    },
+    {
+      "id": "no-retry-max-attempts-exceeded",
+      "family": "transport",
+      "description": "Even retryable errors stop after max attempts",
+      "input": {
+        "errorCode": "RUNNER_TRANSPORT_UNAVAILABLE",
+        "attempt": 5
+      },
+      "expect": { "kind": "reject", "code": "max_retries_exceeded" }
+    }
+  ]
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -243,6 +243,57 @@ export type {
   VerifiedRunnerExecutionBundle,
 } from "./src/runner-protocol.js"
 export {
+  RUNNER_DEVICE_VERSION,
+  RUNNER_DEVICE_MAX_OVERLAP_SECONDS,
+  RUNNER_DEVICE_MIN_LIFETIME_SECONDS,
+  RUNNER_DEVICE_MAX_HISTORY,
+  RunnerDeviceError,
+  deriveDeviceKeyId,
+  validateDeviceEnrollment,
+  validateRotationEligibility,
+  validateRotationAck,
+} from "./src/runner-device.js"
+export type {
+  DeviceEnrollment,
+  DeviceKeyRecord,
+  DeviceKeyStatus,
+  DeviceRotationAck,
+  DeviceRotationRequest,
+  DeviceRevocation,
+  RunnerDeviceErrorCode,
+  RunnerDeviceKeyStorePort,
+} from "./src/runner-device.js"
+export {
+  RUNNER_TRANSPORT_VERSION,
+  RUNNER_TRANSPORT_MAX_RETRIES,
+  RUNNER_TRANSPORT_BASE_BACKOFF_MS,
+  RUNNER_TRANSPORT_MAX_BACKOFF_MS,
+  RUNNER_TRANSPORT_REQUEST_TIMEOUT_MS,
+  RunnerTransportError,
+  FakeRunnerTransport,
+  computeTransportBackoff,
+} from "./src/runner-transport.js"
+export type {
+  ClaimRequest,
+  ClaimResponse,
+  EnrollDeviceRequest,
+  EnrollDeviceResponse,
+  EventAppendRequest,
+  EventAppendResponse,
+  FakeTransportOptions,
+  HeartbeatRequest,
+  HeartbeatResponse,
+  ReceiptSubmitRequest,
+  ReceiptSubmitResponse,
+  RevokeKeyRequest,
+  RevokeKeyResponse,
+  RotateKeyRequest,
+  RotateKeyResponse,
+  RunnerTransportErrorCode,
+  RunnerTransportPort,
+  TransportRequestMeta,
+} from "./src/runner-transport.js"
+export {
   EMPLOYEE_PROFILE_SCHEMA_VERSION,
   RUNTIME_API_VERSION,
   runtimeVersionSatisfies,

--- a/packages/core/src/runner-device.ts
+++ b/packages/core/src/runner-device.ts
@@ -1,0 +1,244 @@
+/**
+ * Runner device-key lifecycle: enrollment, authentication, rotation,
+ * overlap, and revocation.
+ *
+ * A "device" is a seller-owned Runner instance with an Ed25519 key pair.
+ * The platform identifies a device by its keyId (fingerprint of the public
+ * key). Device keys are rotated periodically; during rotation, both the
+ * current and next key are valid (overlap window).
+ *
+ * This module defines the contracts and a local key-store port. Actual
+ * storage (Keychain, TPM, encrypted file) is injected by the deployment.
+ */
+
+import { createHash } from "node:crypto"
+import type { KeyObject } from "node:crypto"
+
+import { CoreError } from "./contracts.js"
+import { RUNNER_SIGNATURE_ALGORITHM } from "./runner-protocol.js"
+
+// --- Constants ---
+
+export const RUNNER_DEVICE_VERSION = "runner-device.v1" as const
+
+/** Maximum overlap window during key rotation (seconds). */
+export const RUNNER_DEVICE_MAX_OVERLAP_SECONDS = 3600
+
+/** Minimum key lifetime before rotation is allowed (seconds). */
+export const RUNNER_DEVICE_MIN_LIFETIME_SECONDS = 86400
+
+/** Maximum number of historical key entries retained. */
+export const RUNNER_DEVICE_MAX_HISTORY = 16
+
+// --- Error codes ---
+
+export type RunnerDeviceErrorCode =
+  | "RUNNER_DEVICE_NOT_ENROLLED"
+  | "RUNNER_DEVICE_ALREADY_ENROLLED"
+  | "RUNNER_DEVICE_KEY_EXPIRED"
+  | "RUNNER_DEVICE_KEY_REVOKED"
+  | "RUNNER_DEVICE_ROTATION_TOO_EARLY"
+  | "RUNNER_DEVICE_OVERLAP_EXCEEDED"
+  | "RUNNER_DEVICE_STORE_FAILED"
+
+export class RunnerDeviceError extends CoreError {
+  constructor(code: RunnerDeviceErrorCode, message?: string) {
+    super(code, message ?? "Runner device operation failed", {
+      status: 400,
+      retryable: false,
+    })
+    this.name = "RunnerDeviceError"
+  }
+}
+
+// --- Types ---
+
+export type DeviceKeyStatus = "active" | "rotating" | "revoked" | "expired"
+
+export interface DeviceKeyRecord {
+  /** Deterministic identifier derived from the public key bytes. */
+  keyId: string
+  /** Status of this key in the lifecycle. */
+  status: DeviceKeyStatus
+  /** ISO timestamp when the key was enrolled or rotated in. */
+  activeSince: string
+  /** ISO timestamp when the key was revoked or expired (if applicable). */
+  revokedAt?: string
+  /** If status is "rotating", the replacement keyId. */
+  nextKeyId?: string
+}
+
+export interface DeviceEnrollment {
+  version: typeof RUNNER_DEVICE_VERSION
+  runnerId: string
+  sellerId: string
+  keyId: string
+  publicKeySpki: string
+  enrolledAt: string
+}
+
+export interface DeviceRotationRequest {
+  version: typeof RUNNER_DEVICE_VERSION
+  runnerId: string
+  currentKeyId: string
+  nextKeyId: string
+  nextPublicKeySpki: string
+  requestedAt: string
+}
+
+export interface DeviceRotationAck {
+  version: typeof RUNNER_DEVICE_VERSION
+  currentKeyId: string
+  nextKeyId: string
+  overlapExpiresAt: string
+  acknowledgedAt: string
+}
+
+export interface DeviceRevocation {
+  version: typeof RUNNER_DEVICE_VERSION
+  runnerId: string
+  keyId: string
+  reason: "rotation_complete" | "compromised" | "admin_revoke"
+  revokedAt: string
+}
+
+// --- Key store port ---
+
+/**
+ * Abstract port for device key persistence. Implementations may use
+ * Keychain, TPM, encrypted file, or any secure store.
+ */
+export interface RunnerDeviceKeyStorePort {
+  /** Load the current active key record (or null if not enrolled). */
+  loadActiveKey(): Promise<DeviceKeyRecord | null>
+
+  /** Load a key record by keyId. */
+  loadKey(keyId: string): Promise<DeviceKeyRecord | null>
+
+  /** Load all key records (for diagnostics/rotation history). */
+  loadHistory(): Promise<DeviceKeyRecord[]>
+
+  /** Persist a new key record atomically. */
+  saveKey(record: DeviceKeyRecord): Promise<void>
+
+  /** Load the private key material for signing. */
+  loadPrivateKey(keyId: string): Promise<KeyObject | null>
+
+  /** Persist a new key pair. */
+  saveKeyPair(keyId: string, privateKey: KeyObject, publicKey: KeyObject): Promise<void>
+
+  /** Remove private key material (after revocation). */
+  deletePrivateKey(keyId: string): Promise<void>
+}
+
+// --- Utility ---
+
+/**
+ * Derives a deterministic keyId from an Ed25519 public key.
+ * Format: "device:<sha256-of-spki-der-hex-first-16-chars>"
+ */
+export function deriveDeviceKeyId(publicKey: KeyObject): string {
+  const spkiDer = publicKey.export({ type: "spki", format: "der" })
+  const hash = createHash("sha256").update(spkiDer).digest("hex")
+  return `device:${hash.slice(0, 16)}`
+}
+
+// --- Device lifecycle operations ---
+
+/**
+ * Validates that a device enrollment request is well-formed.
+ * Does NOT perform network enrollment — that is the transport layer's job.
+ */
+export function validateDeviceEnrollment(
+  input: unknown,
+): DeviceEnrollment {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new RunnerDeviceError("RUNNER_DEVICE_STORE_FAILED", "enrollment must be an object")
+  }
+  const obj = input as Record<string, unknown>
+  if (obj.version !== RUNNER_DEVICE_VERSION) {
+    throw new RunnerDeviceError("RUNNER_DEVICE_STORE_FAILED", "unsupported device version")
+  }
+  if (typeof obj.runnerId !== "string" || !obj.runnerId) {
+    throw new RunnerDeviceError("RUNNER_DEVICE_STORE_FAILED", "runnerId required")
+  }
+  if (typeof obj.sellerId !== "string" || !obj.sellerId) {
+    throw new RunnerDeviceError("RUNNER_DEVICE_STORE_FAILED", "sellerId required")
+  }
+  if (typeof obj.keyId !== "string" || !obj.keyId) {
+    throw new RunnerDeviceError("RUNNER_DEVICE_STORE_FAILED", "keyId required")
+  }
+  if (typeof obj.publicKeySpki !== "string" || !obj.publicKeySpki) {
+    throw new RunnerDeviceError("RUNNER_DEVICE_STORE_FAILED", "publicKeySpki required")
+  }
+  if (typeof obj.enrolledAt !== "string" || !obj.enrolledAt) {
+    throw new RunnerDeviceError("RUNNER_DEVICE_STORE_FAILED", "enrolledAt required")
+  }
+  return {
+    version: RUNNER_DEVICE_VERSION,
+    runnerId: obj.runnerId,
+    sellerId: obj.sellerId,
+    keyId: obj.keyId,
+    publicKeySpki: obj.publicKeySpki,
+    enrolledAt: obj.enrolledAt,
+  }
+}
+
+/**
+ * Validates a rotation request is well-formed and the current key is
+ * eligible for rotation (past minimum lifetime).
+ */
+export function validateRotationEligibility(
+  currentKey: DeviceKeyRecord,
+  nowMs: number,
+): void {
+  if (currentKey.status !== "active") {
+    throw new RunnerDeviceError(
+      "RUNNER_DEVICE_ROTATION_TOO_EARLY",
+      `cannot rotate key in status: ${currentKey.status}`,
+    )
+  }
+  const activeMs = nowMs - new Date(currentKey.activeSince).getTime()
+  if (activeMs < RUNNER_DEVICE_MIN_LIFETIME_SECONDS * 1000) {
+    throw new RunnerDeviceError(
+      "RUNNER_DEVICE_ROTATION_TOO_EARLY",
+      `key active for ${Math.floor(activeMs / 1000)}s, minimum is ${RUNNER_DEVICE_MIN_LIFETIME_SECONDS}s`,
+    )
+  }
+}
+
+/**
+ * Validates that a rotation acknowledgment is consistent.
+ */
+export function validateRotationAck(
+  input: unknown,
+  expectedCurrentKeyId: string,
+  expectedNextKeyId: string,
+): DeviceRotationAck {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new RunnerDeviceError("RUNNER_DEVICE_STORE_FAILED", "ack must be an object")
+  }
+  const obj = input as Record<string, unknown>
+  if (obj.version !== RUNNER_DEVICE_VERSION) {
+    throw new RunnerDeviceError("RUNNER_DEVICE_STORE_FAILED", "unsupported device version")
+  }
+  if (obj.currentKeyId !== expectedCurrentKeyId) {
+    throw new RunnerDeviceError("RUNNER_DEVICE_STORE_FAILED", "currentKeyId mismatch")
+  }
+  if (obj.nextKeyId !== expectedNextKeyId) {
+    throw new RunnerDeviceError("RUNNER_DEVICE_STORE_FAILED", "nextKeyId mismatch")
+  }
+  if (typeof obj.overlapExpiresAt !== "string" || !obj.overlapExpiresAt) {
+    throw new RunnerDeviceError("RUNNER_DEVICE_STORE_FAILED", "overlapExpiresAt required")
+  }
+  if (typeof obj.acknowledgedAt !== "string" || !obj.acknowledgedAt) {
+    throw new RunnerDeviceError("RUNNER_DEVICE_STORE_FAILED", "acknowledgedAt required")
+  }
+  return {
+    version: RUNNER_DEVICE_VERSION,
+    currentKeyId: obj.currentKeyId,
+    nextKeyId: obj.nextKeyId,
+    overlapExpiresAt: obj.overlapExpiresAt,
+    acknowledgedAt: obj.acknowledgedAt,
+  }
+}

--- a/packages/core/src/runner-transport.ts
+++ b/packages/core/src/runner-transport.ts
@@ -1,0 +1,338 @@
+/**
+ * Runner outbound transport port.
+ *
+ * Defines the transport-neutral contract for authenticated outbound
+ * communication between a Runner and the platform. All methods are
+ * outbound-only (no listening port required on the seller machine).
+ *
+ * Concrete implementations (HTTP/gRPC) are injected at deployment time.
+ * This module only specifies the port interface, request/response shapes,
+ * and the retry/idempotency semantics that any implementation must honour.
+ */
+
+import type { SignedEnvelope, RunnerEvent, OpaqueData } from "./runner-protocol.js"
+import type { DeviceEnrollment, DeviceRotationRequest, DeviceRotationAck, DeviceRevocation } from "./runner-device.js"
+import { CoreError } from "./contracts.js"
+
+// --- Constants ---
+
+export const RUNNER_TRANSPORT_VERSION = "runner-transport.v1" as const
+
+/** Maximum retry attempts for transient failures. */
+export const RUNNER_TRANSPORT_MAX_RETRIES = 5
+
+/** Base backoff delay (ms) for exponential retry. */
+export const RUNNER_TRANSPORT_BASE_BACKOFF_MS = 500
+
+/** Maximum backoff delay (ms). */
+export const RUNNER_TRANSPORT_MAX_BACKOFF_MS = 30_000
+
+/** Request timeout (ms). */
+export const RUNNER_TRANSPORT_REQUEST_TIMEOUT_MS = 30_000
+
+// --- Error codes ---
+
+export type RunnerTransportErrorCode =
+  | "RUNNER_TRANSPORT_UNAVAILABLE"
+  | "RUNNER_TRANSPORT_TIMEOUT"
+  | "RUNNER_TRANSPORT_UNAUTHORIZED"
+  | "RUNNER_TRANSPORT_FORBIDDEN"
+  | "RUNNER_TRANSPORT_CONFLICT"
+  | "RUNNER_TRANSPORT_RATE_LIMITED"
+  | "RUNNER_TRANSPORT_PAYLOAD_REJECTED"
+
+export class RunnerTransportError extends CoreError {
+  readonly retryAfterMs?: number
+
+  constructor(
+    code: RunnerTransportErrorCode,
+    message?: string,
+    options?: { retryAfterMs?: number },
+  ) {
+    super(code, message ?? "Runner transport request failed", {
+      status: code === "RUNNER_TRANSPORT_UNAVAILABLE" ? 503 : 400,
+      retryable:
+        code === "RUNNER_TRANSPORT_UNAVAILABLE" ||
+        code === "RUNNER_TRANSPORT_TIMEOUT" ||
+        code === "RUNNER_TRANSPORT_RATE_LIMITED",
+    })
+    this.name = "RunnerTransportError"
+    this.retryAfterMs = options?.retryAfterMs
+  }
+}
+
+// --- Request/response types ---
+
+export interface TransportRequestMeta {
+  /** Device keyId used to authenticate this request. */
+  deviceKeyId: string
+  /** Monotonic request nonce for replay prevention. */
+  requestNonce: string
+  /** ISO timestamp of request creation. */
+  requestedAt: string
+  /** Runner identifier. */
+  runnerId: string
+}
+
+export interface ClaimRequest {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  meta: TransportRequestMeta
+  taskId: string
+  runId: string
+  attempt: number
+  fencingToken: number
+}
+
+export interface ClaimResponse {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  taskEnvelope: SignedEnvelope
+  platformKeyId: string
+  grantedAt: string
+}
+
+export interface HeartbeatRequest {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  meta: TransportRequestMeta
+  leaseId: string
+  taskId: string
+  currentFencingToken: number
+  /** Events accumulated since last heartbeat (bounded). */
+  eventDigests: string[]
+}
+
+export interface HeartbeatResponse {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  /** Fully re-signed lease envelope (not just a timestamp). */
+  renewedEnvelope: SignedEnvelope
+  acknowledgedAt: string
+}
+
+export interface EventAppendRequest {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  meta: TransportRequestMeta
+  leaseId: string
+  taskId: string
+  events: RunnerEvent[]
+}
+
+export interface EventAppendResponse {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  accepted: number
+  lastAcceptedDigest: string
+  acknowledgedAt: string
+}
+
+export interface ReceiptSubmitRequest {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  meta: TransportRequestMeta
+  leaseId: string
+  signedReceipt: SignedEnvelope
+}
+
+export interface ReceiptSubmitResponse {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  accepted: boolean
+  settledAt: string
+}
+
+export interface EnrollDeviceRequest {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  enrollment: DeviceEnrollment
+}
+
+export interface EnrollDeviceResponse {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  accepted: boolean
+  platformKeyId: string
+  enrolledAt: string
+}
+
+export interface RotateKeyRequest {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  meta: TransportRequestMeta
+  rotation: DeviceRotationRequest
+}
+
+export interface RotateKeyResponse {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  ack: DeviceRotationAck
+}
+
+export interface RevokeKeyRequest {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  meta: TransportRequestMeta
+  revocation: DeviceRevocation
+}
+
+export interface RevokeKeyResponse {
+  version: typeof RUNNER_TRANSPORT_VERSION
+  accepted: boolean
+  revokedAt: string
+}
+
+// --- Transport port interface ---
+
+/**
+ * Abstract outbound transport port. Implementations must:
+ *
+ * 1. Authenticate every request with the device key (sign request body).
+ * 2. Retry transient failures with exponential backoff.
+ * 3. Honour idempotency: duplicate requests with the same nonce are safe.
+ * 4. Never open inbound listening ports.
+ * 5. Reject responses that fail signature verification against the
+ *    platform's public key.
+ */
+export interface RunnerTransportPort {
+  // --- Task lifecycle ---
+
+  /** Claim a task assignment from the platform. */
+  claim(request: ClaimRequest): Promise<ClaimResponse>
+
+  /** Send heartbeat and receive renewed lease. */
+  heartbeat(request: HeartbeatRequest): Promise<HeartbeatResponse>
+
+  /** Append events to the platform event log. */
+  appendEvents(request: EventAppendRequest): Promise<EventAppendResponse>
+
+  /** Submit final signed receipt. */
+  submitReceipt(request: ReceiptSubmitRequest): Promise<ReceiptSubmitResponse>
+
+  // --- Device lifecycle ---
+
+  /** Enroll a new device with the platform. */
+  enrollDevice(request: EnrollDeviceRequest): Promise<EnrollDeviceResponse>
+
+  /** Request key rotation (begins overlap window). */
+  rotateKey(request: RotateKeyRequest): Promise<RotateKeyResponse>
+
+  /** Revoke an old key (ends overlap window or emergency revocation). */
+  revokeKey(request: RevokeKeyRequest): Promise<RevokeKeyResponse>
+}
+
+// --- Retry helper ---
+
+/**
+ * Determines whether a transport error is retryable and the backoff delay.
+ */
+export function computeTransportBackoff(
+  error: RunnerTransportError,
+  attempt: number,
+): { shouldRetry: boolean; delayMs: number } {
+  if (!error.retryable || attempt >= RUNNER_TRANSPORT_MAX_RETRIES) {
+    return { shouldRetry: false, delayMs: 0 }
+  }
+  const baseDelay = error.retryAfterMs ?? RUNNER_TRANSPORT_BASE_BACKOFF_MS
+  const exponentialDelay = Math.min(
+    baseDelay * Math.pow(2, attempt),
+    RUNNER_TRANSPORT_MAX_BACKOFF_MS,
+  )
+  // Add jitter (±25%)
+  const jitter = exponentialDelay * 0.25 * (Math.random() * 2 - 1)
+  const delayMs = Math.max(0, Math.round(exponentialDelay + jitter))
+  return { shouldRetry: true, delayMs }
+}
+
+// --- Fake transport for testing ---
+
+export interface FakeTransportOptions {
+  platformKeyId: string
+  /** Function to produce a valid signed task envelope on claim. */
+  produceTaskEnvelope: (request: ClaimRequest) => SignedEnvelope
+  /** Function to produce a renewed envelope on heartbeat. */
+  produceRenewal: (request: HeartbeatRequest) => SignedEnvelope
+}
+
+/**
+ * In-memory fake transport for local testing. Does NOT perform real
+ * network requests or cryptographic authentication.
+ */
+export class FakeRunnerTransport implements RunnerTransportPort {
+  private readonly options: FakeTransportOptions
+  private readonly events: RunnerEvent[] = []
+  private receipt: SignedEnvelope | null = null
+
+  constructor(options: FakeTransportOptions) {
+    this.options = options
+  }
+
+  get submittedEvents(): readonly RunnerEvent[] {
+    return this.events
+  }
+
+  get submittedReceipt(): SignedEnvelope | null {
+    return this.receipt
+  }
+
+  async claim(request: ClaimRequest): Promise<ClaimResponse> {
+    return {
+      version: RUNNER_TRANSPORT_VERSION,
+      taskEnvelope: this.options.produceTaskEnvelope(request),
+      platformKeyId: this.options.platformKeyId,
+      grantedAt: new Date().toISOString(),
+    }
+  }
+
+  async heartbeat(request: HeartbeatRequest): Promise<HeartbeatResponse> {
+    return {
+      version: RUNNER_TRANSPORT_VERSION,
+      renewedEnvelope: this.options.produceRenewal(request),
+      acknowledgedAt: new Date().toISOString(),
+    }
+  }
+
+  async appendEvents(request: EventAppendRequest): Promise<EventAppendResponse> {
+    this.events.push(...request.events)
+    const lastDigest =
+      request.events.length > 0
+        ? request.events[request.events.length - 1].digest
+        : ""
+    return {
+      version: RUNNER_TRANSPORT_VERSION,
+      accepted: request.events.length,
+      lastAcceptedDigest: lastDigest,
+      acknowledgedAt: new Date().toISOString(),
+    }
+  }
+
+  async submitReceipt(request: ReceiptSubmitRequest): Promise<ReceiptSubmitResponse> {
+    this.receipt = request.signedReceipt
+    return {
+      version: RUNNER_TRANSPORT_VERSION,
+      accepted: true,
+      settledAt: new Date().toISOString(),
+    }
+  }
+
+  async enrollDevice(_request: EnrollDeviceRequest): Promise<EnrollDeviceResponse> {
+    return {
+      version: RUNNER_TRANSPORT_VERSION,
+      accepted: true,
+      platformKeyId: this.options.platformKeyId,
+      enrolledAt: new Date().toISOString(),
+    }
+  }
+
+  async rotateKey(request: RotateKeyRequest): Promise<RotateKeyResponse> {
+    const overlapExpires = new Date(
+      Date.now() + 3600 * 1000,
+    ).toISOString()
+    return {
+      version: RUNNER_TRANSPORT_VERSION,
+      ack: {
+        version: "runner-device.v1",
+        currentKeyId: request.rotation.currentKeyId,
+        nextKeyId: request.rotation.nextKeyId,
+        overlapExpiresAt: overlapExpires,
+        acknowledgedAt: new Date().toISOString(),
+      },
+    }
+  }
+
+  async revokeKey(_request: RevokeKeyRequest): Promise<RevokeKeyResponse> {
+    return {
+      version: RUNNER_TRANSPORT_VERSION,
+      accepted: true,
+      revokedAt: new Date().toISOString(),
+    }
+  }
+}

--- a/tests/core/runner-device.test.ts
+++ b/tests/core/runner-device.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { generateKeyPairSync, createPublicKey } from "node:crypto"
+
+import {
+  RUNNER_DEVICE_VERSION,
+  RUNNER_DEVICE_MIN_LIFETIME_SECONDS,
+  deriveDeviceKeyId,
+  validateDeviceEnrollment,
+  validateRotationEligibility,
+  validateRotationAck,
+  RunnerDeviceError,
+} from "../../packages/core/index.js"
+import type { DeviceKeyRecord } from "../../packages/core/index.js"
+
+function generateEd25519Pair() {
+  return generateKeyPairSync("ed25519")
+}
+
+test("deriveDeviceKeyId produces deterministic id from public key", () => {
+  const { publicKey } = generateEd25519Pair()
+  const id1 = deriveDeviceKeyId(publicKey)
+  const id2 = deriveDeviceKeyId(publicKey)
+  assert.equal(id1, id2)
+  assert.ok(id1.startsWith("device:"))
+  assert.equal(id1.length, "device:".length + 16)
+})
+
+test("deriveDeviceKeyId produces different ids for different keys", () => {
+  const { publicKey: pk1 } = generateEd25519Pair()
+  const { publicKey: pk2 } = generateEd25519Pair()
+  assert.notEqual(deriveDeviceKeyId(pk1), deriveDeviceKeyId(pk2))
+})
+
+test("validateDeviceEnrollment accepts valid enrollment", () => {
+  const { publicKey } = generateEd25519Pair()
+  const keyId = deriveDeviceKeyId(publicKey)
+  const spki = publicKey.export({ type: "spki", format: "pem" }) as string
+
+  const enrollment = validateDeviceEnrollment({
+    version: RUNNER_DEVICE_VERSION,
+    runnerId: "runner-001",
+    sellerId: "seller-001",
+    keyId,
+    publicKeySpki: spki,
+    enrolledAt: new Date().toISOString(),
+  })
+
+  assert.equal(enrollment.version, RUNNER_DEVICE_VERSION)
+  assert.equal(enrollment.runnerId, "runner-001")
+  assert.equal(enrollment.keyId, keyId)
+})
+
+test("validateDeviceEnrollment rejects missing fields", () => {
+  assert.throws(
+    () => validateDeviceEnrollment({ version: RUNNER_DEVICE_VERSION }),
+    (err: unknown) => err instanceof RunnerDeviceError,
+  )
+  assert.throws(
+    () => validateDeviceEnrollment(null),
+    (err: unknown) => err instanceof RunnerDeviceError,
+  )
+  assert.throws(
+    () => validateDeviceEnrollment("string"),
+    (err: unknown) => err instanceof RunnerDeviceError,
+  )
+})
+
+test("validateDeviceEnrollment rejects wrong version", () => {
+  assert.throws(
+    () =>
+      validateDeviceEnrollment({
+        version: "runner-device.v99",
+        runnerId: "r",
+        sellerId: "s",
+        keyId: "k",
+        publicKeySpki: "p",
+        enrolledAt: "2026-01-01T00:00:00.000Z",
+      }),
+    (err: unknown) => err instanceof RunnerDeviceError,
+  )
+})
+
+test("validateRotationEligibility allows rotation after minimum lifetime", () => {
+  const activeSince = new Date(
+    Date.now() - (RUNNER_DEVICE_MIN_LIFETIME_SECONDS + 1) * 1000,
+  ).toISOString()
+  const record: DeviceKeyRecord = {
+    keyId: "device:abc123",
+    status: "active",
+    activeSince,
+  }
+  // Should not throw
+  validateRotationEligibility(record, Date.now())
+})
+
+test("validateRotationEligibility rejects rotation too early", () => {
+  const activeSince = new Date(Date.now() - 1000).toISOString()
+  const record: DeviceKeyRecord = {
+    keyId: "device:abc123",
+    status: "active",
+    activeSince,
+  }
+  assert.throws(
+    () => validateRotationEligibility(record, Date.now()),
+    (err: unknown) =>
+      err instanceof RunnerDeviceError &&
+      err.code === "RUNNER_DEVICE_ROTATION_TOO_EARLY",
+  )
+})
+
+test("validateRotationEligibility rejects non-active keys", () => {
+  const record: DeviceKeyRecord = {
+    keyId: "device:abc123",
+    status: "revoked",
+    activeSince: new Date(0).toISOString(),
+    revokedAt: new Date().toISOString(),
+  }
+  assert.throws(
+    () => validateRotationEligibility(record, Date.now()),
+    (err: unknown) =>
+      err instanceof RunnerDeviceError &&
+      err.code === "RUNNER_DEVICE_ROTATION_TOO_EARLY",
+  )
+})
+
+test("validateRotationAck accepts valid ack", () => {
+  const ack = validateRotationAck(
+    {
+      version: RUNNER_DEVICE_VERSION,
+      currentKeyId: "device:current",
+      nextKeyId: "device:next",
+      overlapExpiresAt: "2026-08-08T00:00:00.000Z",
+      acknowledgedAt: "2026-08-07T00:00:00.000Z",
+    },
+    "device:current",
+    "device:next",
+  )
+  assert.equal(ack.currentKeyId, "device:current")
+  assert.equal(ack.nextKeyId, "device:next")
+})
+
+test("validateRotationAck rejects mismatched keyIds", () => {
+  assert.throws(
+    () =>
+      validateRotationAck(
+        {
+          version: RUNNER_DEVICE_VERSION,
+          currentKeyId: "device:wrong",
+          nextKeyId: "device:next",
+          overlapExpiresAt: "2026-08-08T00:00:00.000Z",
+          acknowledgedAt: "2026-08-07T00:00:00.000Z",
+        },
+        "device:current",
+        "device:next",
+      ),
+    (err: unknown) => err instanceof RunnerDeviceError,
+  )
+})

--- a/tests/core/runner-transport.test.ts
+++ b/tests/core/runner-transport.test.ts
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  RUNNER_TRANSPORT_VERSION,
+  RUNNER_TRANSPORT_MAX_RETRIES,
+  RUNNER_TRANSPORT_BASE_BACKOFF_MS,
+  RUNNER_TRANSPORT_MAX_BACKOFF_MS,
+  RunnerTransportError,
+  FakeRunnerTransport,
+  computeTransportBackoff,
+} from "../../packages/core/index.js"
+import type {
+  ClaimRequest,
+  HeartbeatRequest,
+  SignedEnvelope,
+} from "../../packages/core/index.js"
+
+function makeEnvelope(overrides?: Partial<SignedEnvelope>): SignedEnvelope {
+  return {
+    protocolVersion: "digital-employee.runner-protocol.v1",
+    keyId: "platform-key-1",
+    algorithm: "Ed25519",
+    payload: "eyJ0ZXN0IjoidHJ1ZSJ9",
+    signature: "c2lnbmF0dXJl",
+    ...overrides,
+  }
+}
+
+function makeMeta() {
+  return {
+    deviceKeyId: "device:abc123",
+    requestNonce: "nonce-001",
+    requestedAt: new Date().toISOString(),
+    runnerId: "runner-001",
+  }
+}
+
+test("FakeRunnerTransport claim returns task envelope", async () => {
+  const envelope = makeEnvelope()
+  const transport = new FakeRunnerTransport({
+    platformKeyId: "platform-key-1",
+    produceTaskEnvelope: () => envelope,
+    produceRenewal: () => envelope,
+  })
+
+  const request: ClaimRequest = {
+    version: RUNNER_TRANSPORT_VERSION,
+    meta: makeMeta(),
+    taskId: "task-001",
+    runId: "run-001",
+    attempt: 1,
+    fencingToken: 1,
+  }
+
+  const response = await transport.claim(request)
+  assert.equal(response.version, RUNNER_TRANSPORT_VERSION)
+  assert.deepEqual(response.taskEnvelope, envelope)
+  assert.equal(response.platformKeyId, "platform-key-1")
+})
+
+test("FakeRunnerTransport heartbeat returns renewed envelope", async () => {
+  const renewed = makeEnvelope({ payload: "cmVuZXdlZA" })
+  const transport = new FakeRunnerTransport({
+    platformKeyId: "platform-key-1",
+    produceTaskEnvelope: () => makeEnvelope(),
+    produceRenewal: () => renewed,
+  })
+
+  const request: HeartbeatRequest = {
+    version: RUNNER_TRANSPORT_VERSION,
+    meta: makeMeta(),
+    leaseId: "lease-001",
+    taskId: "task-001",
+    currentFencingToken: 1,
+    eventDigests: [],
+  }
+
+  const response = await transport.heartbeat(request)
+  assert.equal(response.version, RUNNER_TRANSPORT_VERSION)
+  assert.deepEqual(response.renewedEnvelope, renewed)
+})
+
+test("FakeRunnerTransport appendEvents accumulates events", async () => {
+  const transport = new FakeRunnerTransport({
+    platformKeyId: "pk",
+    produceTaskEnvelope: () => makeEnvelope(),
+    produceRenewal: () => makeEnvelope(),
+  })
+
+  const event = {
+    protocolVersion: "digital-employee.runner-protocol.v1" as const,
+    kind: "runner.event" as const,
+    taskId: "task-001",
+    runId: "run-001",
+    attempt: 1,
+    fencingToken: 1,
+    leaseId: "lease-001",
+    quoteId: "quote-001",
+    runnerId: "runner-001",
+    employeeId: "emp-001",
+    packageDigest: "sha256:" + "a".repeat(64),
+    sequence: 1,
+    timestamp: "2026-08-07T00:00:00.000Z",
+    type: "progress",
+    data: { mediaType: "application/json", encoding: "base64url" as const, data: "e30" },
+    previousDigest: "sha256:" + "0".repeat(64),
+    digest: "sha256:" + "b".repeat(64),
+  }
+
+  const response = await transport.appendEvents({
+    version: RUNNER_TRANSPORT_VERSION,
+    meta: makeMeta(),
+    leaseId: "lease-001",
+    taskId: "task-001",
+    events: [event],
+  })
+
+  assert.equal(response.accepted, 1)
+  assert.equal(transport.submittedEvents.length, 1)
+  assert.equal(response.lastAcceptedDigest, event.digest)
+})
+
+test("FakeRunnerTransport submitReceipt stores receipt", async () => {
+  const transport = new FakeRunnerTransport({
+    platformKeyId: "pk",
+    produceTaskEnvelope: () => makeEnvelope(),
+    produceRenewal: () => makeEnvelope(),
+  })
+
+  const receipt = makeEnvelope({ payload: "cmVjZWlwdA" })
+  const response = await transport.submitReceipt({
+    version: RUNNER_TRANSPORT_VERSION,
+    meta: makeMeta(),
+    leaseId: "lease-001",
+    signedReceipt: receipt,
+  })
+
+  assert.equal(response.accepted, true)
+  assert.deepEqual(transport.submittedReceipt, receipt)
+})
+
+test("FakeRunnerTransport enrollDevice succeeds", async () => {
+  const transport = new FakeRunnerTransport({
+    platformKeyId: "pk-1",
+    produceTaskEnvelope: () => makeEnvelope(),
+    produceRenewal: () => makeEnvelope(),
+  })
+
+  const response = await transport.enrollDevice({
+    version: RUNNER_TRANSPORT_VERSION,
+    enrollment: {
+      version: "runner-device.v1",
+      runnerId: "runner-001",
+      sellerId: "seller-001",
+      keyId: "device:abc",
+      publicKeySpki: "MFkwEwYHKoZIzj...",
+      enrolledAt: new Date().toISOString(),
+    },
+  })
+
+  assert.equal(response.accepted, true)
+  assert.equal(response.platformKeyId, "pk-1")
+})
+
+test("FakeRunnerTransport rotateKey returns ack with overlap window", async () => {
+  const transport = new FakeRunnerTransport({
+    platformKeyId: "pk",
+    produceTaskEnvelope: () => makeEnvelope(),
+    produceRenewal: () => makeEnvelope(),
+  })
+
+  const response = await transport.rotateKey({
+    version: RUNNER_TRANSPORT_VERSION,
+    meta: makeMeta(),
+    rotation: {
+      version: "runner-device.v1",
+      runnerId: "runner-001",
+      currentKeyId: "device:old",
+      nextKeyId: "device:new",
+      nextPublicKeySpki: "MFkw...",
+      requestedAt: new Date().toISOString(),
+    },
+  })
+
+  assert.equal(response.ack.currentKeyId, "device:old")
+  assert.equal(response.ack.nextKeyId, "device:new")
+  assert.ok(response.ack.overlapExpiresAt)
+})
+
+test("computeTransportBackoff retries transient errors", () => {
+  const error = new RunnerTransportError("RUNNER_TRANSPORT_UNAVAILABLE")
+  const { shouldRetry, delayMs } = computeTransportBackoff(error, 0)
+  assert.equal(shouldRetry, true)
+  assert.ok(delayMs >= 0)
+  assert.ok(delayMs <= RUNNER_TRANSPORT_BASE_BACKOFF_MS * 2)
+})
+
+test("computeTransportBackoff stops after max retries", () => {
+  const error = new RunnerTransportError("RUNNER_TRANSPORT_UNAVAILABLE")
+  const { shouldRetry } = computeTransportBackoff(
+    error,
+    RUNNER_TRANSPORT_MAX_RETRIES,
+  )
+  assert.equal(shouldRetry, false)
+})
+
+test("computeTransportBackoff does not retry non-retryable errors", () => {
+  const error = new RunnerTransportError("RUNNER_TRANSPORT_FORBIDDEN")
+  const { shouldRetry } = computeTransportBackoff(error, 0)
+  assert.equal(shouldRetry, false)
+})
+
+test("computeTransportBackoff respects retryAfterMs", () => {
+  const error = new RunnerTransportError("RUNNER_TRANSPORT_RATE_LIMITED", undefined, {
+    retryAfterMs: 5000,
+  })
+  const { shouldRetry, delayMs } = computeTransportBackoff(error, 0)
+  assert.equal(shouldRetry, true)
+  // Should use 5000 as base, so delay should be around 5000 ± 25%
+  assert.ok(delayMs >= 3750)
+  assert.ok(delayMs <= 6250)
+})
+
+test("computeTransportBackoff caps at max backoff", () => {
+  const error = new RunnerTransportError("RUNNER_TRANSPORT_TIMEOUT")
+  // At attempt 4 with base 500ms: 500 * 2^4 = 8000, still under cap
+  // At attempt with very high retryAfter it should cap
+  const highRetry = new RunnerTransportError("RUNNER_TRANSPORT_TIMEOUT", undefined, {
+    retryAfterMs: 60_000,
+  })
+  const { delayMs } = computeTransportBackoff(highRetry, 2)
+  assert.ok(delayMs <= RUNNER_TRANSPORT_MAX_BACKOFF_MS * 1.25)
+})
+
+test("RunnerTransportError marks retryable codes correctly", () => {
+  const unavailable = new RunnerTransportError("RUNNER_TRANSPORT_UNAVAILABLE")
+  assert.equal(unavailable.retryable, true)
+
+  const timeout = new RunnerTransportError("RUNNER_TRANSPORT_TIMEOUT")
+  assert.equal(timeout.retryable, true)
+
+  const rateLimited = new RunnerTransportError("RUNNER_TRANSPORT_RATE_LIMITED")
+  assert.equal(rateLimited.retryable, true)
+
+  const forbidden = new RunnerTransportError("RUNNER_TRANSPORT_FORBIDDEN")
+  assert.equal(forbidden.retryable, false)
+
+  const unauthorized = new RunnerTransportError("RUNNER_TRANSPORT_UNAUTHORIZED")
+  assert.equal(unauthorized.retryable, false)
+
+  const conflict = new RunnerTransportError("RUNNER_TRANSPORT_CONFLICT")
+  assert.equal(conflict.retryable, false)
+})


### PR DESCRIPTION
## Summary

- Defines transport-neutral outbound client contract (`RunnerTransportPort`) for claim, heartbeat, event append, receipt submit
- Defines device enrollment, authentication, key rotation (overlap window), and revocation lifecycle (`runner-device.ts`)
- Includes `FakeRunnerTransport` for local testing without network
- Publishes 15 golden vectors across 3 families with SHA-256 manifest

## Design decisions

| Decision | Rationale |
|----------|-----------|
| Outbound-only | No inbound port on seller machine; all requests initiated by Runner |
| Device key auth | Every request signed with Ed25519 device key; task/run IDs are correlation only |
| Overlap window | During rotation, both keys valid for max 1 hour |
| Min lifetime 24h | Prevents key thrashing and simplifies audit |
| Idempotent nonces | Same request nonce is safe to replay (server deduplicates) |
| Exponential backoff | With jitter, max 30s, max 5 retries for transient failures |

## Validation

| ID | Criterion | Result |
|---|---|---|
| V1 | `npm run typecheck` | ✅ |
| V2 | `npm run build` | ✅ |
| V3 | 477/478 tests pass (1 pre-existing flaky stdio-agent-host timeout) | ✅ |
| V4 | 22 new unit tests all pass | ✅ |
| V5 | Security check | ✅ |

## Security and data review

- [x] No credentials or private keys in fixtures or source
- [x] No dependency added
- [x] Key material only flows through abstract port interfaces
- [x] FakeTransport explicitly marked as non-production

Refs #29