### PR TITLE
feat: provider-neutral usage evidence semantics

### DIFF
--- a/fixtures/runner-durable-vectors/v1/deployment.json
+++ b/fixtures/runner-durable-vectors/v1/deployment.json
@@ -1,0 +1,54 @@
+{
+  "family": "deployment",
+  "vectors": [
+    {
+      "id": "deployment-valid-register",
+      "description": "Valid deployment registration with all required fields",
+      "input": {
+        "employeeId": "emp-001",
+        "employeeVersion": "1.0.0",
+        "packageDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "localPackageRef": "oci://registry.local/emp-001:1.0.0",
+        "agentHostId": "host-alpha",
+        "registeredAt": "2026-01-01T00:00:00.000Z"
+      },
+      "expect": {
+        "outcome": "accepted"
+      }
+    },
+    {
+      "id": "deployment-valid-update-same-digest",
+      "description": "Update existing deployment with same digest succeeds",
+      "input": {
+        "employeeId": "emp-001",
+        "employeeVersion": "1.0.0",
+        "packageDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "localPackageRef": "oci://registry.local/emp-001:1.0.0-updated",
+        "agentHostId": "host-beta",
+        "registeredAt": "2026-01-02T00:00:00.000Z"
+      },
+      "expect": {
+        "outcome": "accepted"
+      }
+    },
+    {
+      "id": "deployment-invalid-digest-mismatch",
+      "description": "Reject registration when digest differs for same employee+version",
+      "precondition": {
+        "existingDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "input": {
+        "employeeId": "emp-001",
+        "employeeVersion": "1.0.0",
+        "packageDigest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "localPackageRef": "oci://registry.local/emp-001:1.0.0",
+        "agentHostId": "host-alpha",
+        "registeredAt": "2026-01-01T00:00:00.000Z"
+      },
+      "expect": {
+        "outcome": "rejected",
+        "errorCode": "DURABLE_STORE_DIGEST_MISMATCH"
+      }
+    }
+  ]
+}

--- a/fixtures/runner-durable-vectors/v1/manifest.json
+++ b/fixtures/runner-durable-vectors/v1/manifest.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "runner-durable-vectors.v1",
+  "families": [
+    "deployment",
+    "replay_claim",
+    "outbox"
+  ],
+  "files": [
+    {
+      "file": "deployment.json",
+      "sha256": "5ffe57187653ae82edb41120d16ee695c702dc7730dfa9a5cc91d4ad2fd13cc2",
+      "vectorCount": 3
+    },
+    {
+      "file": "replay-claim.json",
+      "sha256": "85d4cf0dcdeb22cfbcf9233eb6dee5fa98e136aa9af41169f4228b49885a7afc",
+      "vectorCount": 3
+    },
+    {
+      "file": "outbox.json",
+      "sha256": "508f20c1594009e8e8ce342eff847497206ac70a852957d588f03593b7d5ae93",
+      "vectorCount": 5
+    }
+  ]
+}

--- a/fixtures/runner-durable-vectors/v1/outbox.json
+++ b/fixtures/runner-durable-vectors/v1/outbox.json
@@ -1,0 +1,88 @@
+{
+  "family": "outbox",
+  "vectors": [
+    {
+      "id": "outbox-append",
+      "description": "Append an event to the outbox",
+      "input": {
+        "kind": "event",
+        "taskId": "task-100",
+        "fencingToken": 1,
+        "payload": "eyJ0eXBlIjoicHJvZ3Jlc3MifQ"
+      },
+      "expect": {
+        "outcome": "accepted",
+        "sequence": 1,
+        "status": "pending",
+        "retryCount": 0
+      }
+    },
+    {
+      "id": "outbox-retry",
+      "description": "Mark entry for retry increments retry count",
+      "precondition": {
+        "existingEntry": { "sequence": 1, "status": "inflight" }
+      },
+      "input": {
+        "action": "markRetry",
+        "sequence": 1,
+        "nextRetryAt": "2026-01-01T00:01:00.000Z"
+      },
+      "expect": {
+        "outcome": true,
+        "retryCount": 1,
+        "status": "pending"
+      }
+    },
+    {
+      "id": "outbox-ack",
+      "description": "Acknowledge successful delivery",
+      "precondition": {
+        "existingEntry": { "sequence": 1, "status": "inflight" }
+      },
+      "input": {
+        "action": "ack",
+        "sequence": 1
+      },
+      "expect": {
+        "outcome": true,
+        "status": "acknowledged"
+      }
+    },
+    {
+      "id": "outbox-compaction",
+      "description": "Compact removes acknowledged and dead entries",
+      "precondition": {
+        "entries": [
+          { "sequence": 1, "status": "acknowledged" },
+          { "sequence": 2, "status": "dead" },
+          { "sequence": 3, "status": "pending" }
+        ]
+      },
+      "input": {
+        "action": "compact"
+      },
+      "expect": {
+        "removed": 2,
+        "remainingSize": 1
+      }
+    },
+    {
+      "id": "outbox-overflow",
+      "description": "Append rejected when outbox at maximum capacity (4096 entries)",
+      "precondition": {
+        "currentSize": 4096
+      },
+      "input": {
+        "kind": "event",
+        "taskId": "overflow",
+        "fencingToken": 1,
+        "payload": "eA"
+      },
+      "expect": {
+        "outcome": "rejected",
+        "errorCode": "DURABLE_OUTBOX_OVERFLOW"
+      }
+    }
+  ]
+}

--- a/fixtures/runner-durable-vectors/v1/replay-claim.json
+++ b/fixtures/runner-durable-vectors/v1/replay-claim.json
@@ -1,0 +1,64 @@
+{
+  "family": "replay_claim",
+  "vectors": [
+    {
+      "id": "claim-valid-first",
+      "description": "First claim for a nonce succeeds",
+      "input": {
+        "taskId": "task-100",
+        "runnerId": "runner-A",
+        "nonce": "dGVzdC1ub25jZS0xMjM0NTY3OA",
+        "fencingToken": 1,
+        "expiresAt": "2026-01-01T00:05:00.000Z"
+      },
+      "clock": "2026-01-01T00:01:00.000Z",
+      "expect": {
+        "outcome": true
+      }
+    },
+    {
+      "id": "claim-duplicate-nonce",
+      "description": "Duplicate nonce for same task is rejected",
+      "precondition": {
+        "existingClaim": {
+          "taskId": "task-100",
+          "nonce": "dGVzdC1ub25jZS0xMjM0NTY3OA",
+          "fencingToken": 1
+        }
+      },
+      "input": {
+        "taskId": "task-100",
+        "runnerId": "runner-A",
+        "nonce": "dGVzdC1ub25jZS0xMjM0NTY3OA",
+        "fencingToken": 1,
+        "expiresAt": "2026-01-01T00:05:00.000Z"
+      },
+      "clock": "2026-01-01T00:02:00.000Z",
+      "expect": {
+        "outcome": false
+      }
+    },
+    {
+      "id": "claim-fencing-conflict",
+      "description": "Claim with stale fencing token is rejected when newer exists",
+      "precondition": {
+        "existingClaim": {
+          "taskId": "task-100",
+          "nonce": "bmV3LW5vbmNlLTk4NzY1NDMyMQ",
+          "fencingToken": 10
+        }
+      },
+      "input": {
+        "taskId": "task-100",
+        "runnerId": "runner-B",
+        "nonce": "c3RhbGUtbm9uY2UtMTIzNDU2Nzg",
+        "fencingToken": 5,
+        "expiresAt": "2026-01-01T00:05:00.000Z"
+      },
+      "clock": "2026-01-01T00:01:00.000Z",
+      "expect": {
+        "outcome": false
+      }
+    }
+  ]
+}

--- a/fixtures/runner-usage-vectors/v1/manifest.json
+++ b/fixtures/runner-usage-vectors/v1/manifest.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "runner-usage-vectors.v1",
+  "evidenceVersion": "usage-evidence.v1",
+  "families": ["validation", "normalization", "proof_quality"],
+  "files": [
+    {
+      "file": "validation.json",
+      "sha256": "2ab9d3867fa5c9937883fbdf1da413a36556d736558fa9e72f7d6c9e90e94a8d",
+      "vectorCount": 11
+    },
+    {
+      "file": "normalization.json",
+      "sha256": "b62c65b7339dfd301491384916fcc78e52c0850bc2b9a9352c63a95ec768d480",
+      "vectorCount": 3
+    },
+    {
+      "file": "proof_quality.json",
+      "sha256": "4932e2090dd7ce33896681aaf42bd4c6fb116b08d90777d48f78f9402dddf3f6",
+      "vectorCount": 7
+    }
+  ]
+}

--- a/fixtures/runner-usage-vectors/v1/normalization.json
+++ b/fixtures/runner-usage-vectors/v1/normalization.json
@@ -1,0 +1,129 @@
+{
+  "family": "normalization",
+  "vectors": [
+    {
+      "id": "monotonicity-valid",
+      "description": "Tokens increase monotonically across events",
+      "events": [
+        {
+          "evidenceId": "ev-n1",
+          "version": "usage-evidence.v1",
+          "taskId": "task-norm",
+          "runId": "run-norm",
+          "attempt": 1,
+          "runnerId": "runner-n1",
+          "timestamp": "2026-01-15T10:00:00.000Z",
+          "provider": { "id": "openai", "model": "gpt-4o" },
+          "tokens": { "input": 100, "output": 50 },
+          "requests": { "count": 1 },
+          "timeBounds": { "startedAt": "2026-01-15T09:59:50.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+          "source": "runner_self_report",
+          "proofQuality": "unverified"
+        },
+        {
+          "evidenceId": "ev-n2",
+          "version": "usage-evidence.v1",
+          "taskId": "task-norm",
+          "runId": "run-norm",
+          "attempt": 1,
+          "runnerId": "runner-n1",
+          "timestamp": "2026-01-15T10:01:00.000Z",
+          "provider": { "id": "openai", "model": "gpt-4o" },
+          "tokens": { "input": 200, "output": 100 },
+          "requests": { "count": 1 },
+          "timeBounds": { "startedAt": "2026-01-15T10:00:00.000Z", "completedAt": "2026-01-15T10:01:00.000Z" },
+          "source": "runner_self_report",
+          "proofQuality": "unverified"
+        }
+      ],
+      "expected": {
+        "tokens": { "input": 200, "output": 100 },
+        "requests": { "count": 2 },
+        "proofQuality": "unverified"
+      }
+    },
+    {
+      "id": "monotonicity-violation",
+      "description": "Tokens decrease — violation forces unverified quality",
+      "events": [
+        {
+          "evidenceId": "ev-v1",
+          "version": "usage-evidence.v1",
+          "taskId": "task-viol",
+          "runId": "run-viol",
+          "attempt": 1,
+          "runnerId": "runner-v1",
+          "timestamp": "2026-01-15T10:00:00.000Z",
+          "provider": { "id": "anthropic", "model": "claude-4" },
+          "tokens": { "input": 500, "output": 200 },
+          "requests": { "count": 1 },
+          "timeBounds": { "startedAt": "2026-01-15T09:59:50.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+          "source": "provider_signed",
+          "proofQuality": "provider_signed"
+        },
+        {
+          "evidenceId": "ev-v2",
+          "version": "usage-evidence.v1",
+          "taskId": "task-viol",
+          "runId": "run-viol",
+          "attempt": 1,
+          "runnerId": "runner-v1",
+          "timestamp": "2026-01-15T10:01:00.000Z",
+          "provider": { "id": "anthropic", "model": "claude-4" },
+          "tokens": { "input": 300, "output": 100 },
+          "requests": { "count": 1 },
+          "timeBounds": { "startedAt": "2026-01-15T10:00:00.000Z", "completedAt": "2026-01-15T10:01:00.000Z" },
+          "source": "provider_signed",
+          "proofQuality": "provider_signed"
+        }
+      ],
+      "expected": {
+        "tokens": { "input": 500, "output": 200 },
+        "requests": { "count": 2 },
+        "proofQuality": "unverified"
+      }
+    },
+    {
+      "id": "aggregation-wide-time-bounds",
+      "description": "Aggregation picks widest time bounds",
+      "events": [
+        {
+          "evidenceId": "ev-a1",
+          "version": "usage-evidence.v1",
+          "taskId": "task-agg",
+          "runId": "run-agg",
+          "attempt": 1,
+          "runnerId": "runner-a1",
+          "timestamp": "2026-01-15T10:00:00.000Z",
+          "provider": { "id": "openai", "model": "gpt-4o" },
+          "tokens": { "input": 100, "output": 50 },
+          "requests": { "count": 2, "toolCalls": 1 },
+          "timeBounds": { "startedAt": "2026-01-15T09:58:00.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+          "source": "gateway_trusted",
+          "proofQuality": "gateway_verified"
+        },
+        {
+          "evidenceId": "ev-a2",
+          "version": "usage-evidence.v1",
+          "taskId": "task-agg",
+          "runId": "run-agg",
+          "attempt": 1,
+          "runnerId": "runner-a1",
+          "timestamp": "2026-01-15T10:02:00.000Z",
+          "provider": { "id": "openai", "model": "gpt-4o" },
+          "tokens": { "input": 300, "output": 150 },
+          "requests": { "count": 1, "toolCalls": 3 },
+          "timeBounds": { "startedAt": "2026-01-15T10:00:00.000Z", "completedAt": "2026-01-15T10:02:00.000Z" },
+          "source": "gateway_trusted",
+          "proofQuality": "gateway_verified"
+        }
+      ],
+      "expected": {
+        "tokens": { "input": 300, "output": 150 },
+        "requests": { "count": 3, "toolCalls": 4 },
+        "timeBounds": { "startedAt": "2026-01-15T09:58:00.000Z", "completedAt": "2026-01-15T10:02:00.000Z" },
+        "proofQuality": "gateway_verified"
+      }
+    }
+  ]
+}

--- a/fixtures/runner-usage-vectors/v1/proof_quality.json
+++ b/fixtures/runner-usage-vectors/v1/proof_quality.json
@@ -1,0 +1,147 @@
+{
+  "family": "proof_quality",
+  "vectors": [
+    {
+      "id": "unverified-self-report",
+      "description": "Runner self-report always classifies as unverified",
+      "input": {
+        "evidenceId": "ev-pq1",
+        "version": "usage-evidence.v1",
+        "taskId": "task-pq1",
+        "runId": "run-pq1",
+        "attempt": 1,
+        "runnerId": "runner-pq1",
+        "timestamp": "2026-01-15T10:00:00.000Z",
+        "provider": { "id": "openai", "model": "gpt-4o" },
+        "tokens": { "input": 100, "output": 50 },
+        "requests": { "count": 1 },
+        "timeBounds": { "startedAt": "2026-01-15T09:59:50.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+        "source": "runner_self_report",
+        "proofQuality": "runner_attested"
+      },
+      "expected": "unverified"
+    },
+    {
+      "id": "attested-provider-mismatch",
+      "description": "Provider-signed source but proofQuality is not provider_signed yields runner_attested",
+      "input": {
+        "evidenceId": "ev-pq2",
+        "version": "usage-evidence.v1",
+        "taskId": "task-pq2",
+        "runId": "run-pq2",
+        "attempt": 1,
+        "runnerId": "runner-pq2",
+        "timestamp": "2026-01-15T10:00:00.000Z",
+        "provider": { "id": "anthropic", "model": "claude-4" },
+        "tokens": { "input": 200, "output": 100 },
+        "requests": { "count": 1 },
+        "timeBounds": { "startedAt": "2026-01-15T09:59:50.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+        "source": "provider_signed",
+        "proofQuality": "runner_attested"
+      },
+      "expected": "runner_attested"
+    },
+    {
+      "id": "provider-signed-match",
+      "description": "Provider-signed source with matching proofQuality yields provider_signed",
+      "input": {
+        "evidenceId": "ev-pq3",
+        "version": "usage-evidence.v1",
+        "taskId": "task-pq3",
+        "runId": "run-pq3",
+        "attempt": 1,
+        "runnerId": "runner-pq3",
+        "timestamp": "2026-01-15T10:00:00.000Z",
+        "provider": { "id": "anthropic", "model": "claude-4" },
+        "tokens": { "input": 200, "output": 100 },
+        "requests": { "count": 1 },
+        "timeBounds": { "startedAt": "2026-01-15T09:59:50.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+        "source": "provider_signed",
+        "proofQuality": "provider_signed",
+        "proofReference": "sig:verified"
+      },
+      "expected": "provider_signed"
+    },
+    {
+      "id": "gateway-verified-match",
+      "description": "Gateway trusted source with gateway_verified quality",
+      "input": {
+        "evidenceId": "ev-pq4",
+        "version": "usage-evidence.v1",
+        "taskId": "task-pq4",
+        "runId": "run-pq4",
+        "attempt": 1,
+        "runnerId": "runner-pq4",
+        "timestamp": "2026-01-15T10:00:00.000Z",
+        "provider": { "id": "azure-openai", "model": "gpt-4o" },
+        "tokens": { "input": 300, "output": 150 },
+        "requests": { "count": 1 },
+        "timeBounds": { "startedAt": "2026-01-15T09:59:50.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+        "source": "gateway_trusted",
+        "proofQuality": "gateway_verified",
+        "proofReference": "gw:receipt:abc"
+      },
+      "expected": "gateway_verified"
+    },
+    {
+      "id": "unverified-unknown-source",
+      "description": "Unknown source always classifies as unverified",
+      "input": {
+        "evidenceId": "ev-pq5",
+        "version": "usage-evidence.v1",
+        "taskId": "task-pq5",
+        "runId": "run-pq5",
+        "attempt": 1,
+        "runnerId": "runner-pq5",
+        "timestamp": "2026-01-15T10:00:00.000Z",
+        "provider": { "id": "openai", "model": "gpt-4o" },
+        "tokens": { "input": 100, "output": 50 },
+        "requests": { "count": 1 },
+        "timeBounds": { "startedAt": "2026-01-15T09:59:50.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+        "source": "unknown",
+        "proofQuality": "unverified"
+      },
+      "expected": "unverified"
+    },
+    {
+      "id": "gateway-without-verified-quality",
+      "description": "Gateway trusted but proofQuality not gateway_verified yields runner_attested",
+      "input": {
+        "evidenceId": "ev-pq6",
+        "version": "usage-evidence.v1",
+        "taskId": "task-pq6",
+        "runId": "run-pq6",
+        "attempt": 1,
+        "runnerId": "runner-pq6",
+        "timestamp": "2026-01-15T10:00:00.000Z",
+        "provider": { "id": "azure-openai", "model": "gpt-4o" },
+        "tokens": { "input": 300, "output": 150 },
+        "requests": { "count": 1 },
+        "timeBounds": { "startedAt": "2026-01-15T09:59:50.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+        "source": "gateway_trusted",
+        "proofQuality": "runner_attested"
+      },
+      "expected": "runner_attested"
+    },
+    {
+      "id": "self-report-cannot-escalate",
+      "description": "Runner self-report with provider_signed quality still classifies as unverified",
+      "input": {
+        "evidenceId": "ev-pq7",
+        "version": "usage-evidence.v1",
+        "taskId": "task-pq7",
+        "runId": "run-pq7",
+        "attempt": 1,
+        "runnerId": "runner-pq7",
+        "timestamp": "2026-01-15T10:00:00.000Z",
+        "provider": { "id": "openai", "model": "gpt-4o" },
+        "tokens": { "input": 100, "output": 50 },
+        "requests": { "count": 1 },
+        "timeBounds": { "startedAt": "2026-01-15T09:59:50.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+        "source": "runner_self_report",
+        "proofQuality": "provider_signed"
+      },
+      "expected": "unverified"
+    }
+  ]
+}

--- a/fixtures/runner-usage-vectors/v1/validation.json
+++ b/fixtures/runner-usage-vectors/v1/validation.json
@@ -1,0 +1,228 @@
+{
+  "family": "validation",
+  "vectors": [
+    {
+      "id": "valid-runner-self-report",
+      "description": "Valid evidence with runner self-report source",
+      "input": {
+        "evidenceId": "ev-001",
+        "version": "usage-evidence.v1",
+        "taskId": "task-abc",
+        "runId": "run-xyz",
+        "attempt": 1,
+        "runnerId": "runner-01",
+        "timestamp": "2026-01-15T10:00:00.000Z",
+        "provider": { "id": "openai", "model": "gpt-4o", "region": "us-east-1" },
+        "tokens": { "input": 500, "output": 200 },
+        "requests": { "count": 1 },
+        "timeBounds": {
+          "startedAt": "2026-01-15T09:59:50.000Z",
+          "completedAt": "2026-01-15T10:00:00.000Z"
+        },
+        "source": "runner_self_report",
+        "proofQuality": "unverified"
+      },
+      "expected": { "valid": true }
+    },
+    {
+      "id": "valid-provider-signed",
+      "description": "Valid evidence with provider-signed source",
+      "input": {
+        "evidenceId": "ev-002",
+        "version": "usage-evidence.v1",
+        "taskId": "task-def",
+        "runId": "run-uvw",
+        "attempt": 2,
+        "runnerId": "runner-02",
+        "timestamp": "2026-02-20T14:30:00.000Z",
+        "provider": { "id": "anthropic", "model": "claude-4", "region": "eu-west-1" },
+        "tokens": { "input": 1000, "output": 400, "cached": 50 },
+        "requests": { "count": 3, "toolCalls": 2 },
+        "timeBounds": {
+          "startedAt": "2026-02-20T14:29:00.000Z",
+          "completedAt": "2026-02-20T14:30:00.000Z"
+        },
+        "source": "provider_signed",
+        "proofQuality": "provider_signed",
+        "proofReference": "sig:abc123def456"
+      },
+      "expected": { "valid": true }
+    },
+    {
+      "id": "valid-gateway-trusted",
+      "description": "Valid evidence from gateway trusted source",
+      "input": {
+        "evidenceId": "ev-003",
+        "version": "usage-evidence.v1",
+        "taskId": "task-ghi",
+        "runId": "run-rst",
+        "attempt": 1,
+        "runnerId": "runner-03",
+        "timestamp": "2026-03-10T08:00:00.000Z",
+        "provider": { "id": "azure-openai", "model": "gpt-4o-mini" },
+        "tokens": { "input": 250, "output": 100 },
+        "requests": { "count": 1 },
+        "timeBounds": {
+          "startedAt": "2026-03-10T07:59:55.000Z",
+          "completedAt": "2026-03-10T08:00:00.000Z"
+        },
+        "source": "gateway_trusted",
+        "proofQuality": "gateway_verified",
+        "proofReference": "gw:receipt:xyz789"
+      },
+      "expected": { "valid": true }
+    },
+    {
+      "id": "valid-with-unknown-provider-fields",
+      "description": "Valid evidence with extra provider fields preserved",
+      "input": {
+        "evidenceId": "ev-004",
+        "version": "usage-evidence.v1",
+        "taskId": "task-jkl",
+        "runId": "run-opq",
+        "attempt": 1,
+        "runnerId": "runner-04",
+        "timestamp": "2026-04-01T12:00:00.000Z",
+        "provider": { "id": "custom-llm", "model": "my-model-v2", "datacenter": "dc-west", "tier": "premium" },
+        "tokens": { "input": 100, "output": 50 },
+        "requests": { "count": 1 },
+        "timeBounds": {
+          "startedAt": "2026-04-01T11:59:50.000Z",
+          "completedAt": "2026-04-01T12:00:00.000Z"
+        },
+        "source": "runner_self_report",
+        "proofQuality": "unverified"
+      },
+      "expected": { "valid": true, "preservedProviderFields": ["datacenter", "tier"] }
+    },
+    {
+      "id": "valid-with-redactions",
+      "description": "Valid evidence with redacted fields",
+      "input": {
+        "evidenceId": "ev-005",
+        "version": "usage-evidence.v1",
+        "taskId": "task-mno",
+        "runId": "run-stu",
+        "attempt": 1,
+        "runnerId": "runner-05",
+        "timestamp": "2026-05-15T16:00:00.000Z",
+        "provider": { "id": "openai", "model": "gpt-4o" },
+        "tokens": { "input": 300, "output": 150 },
+        "requests": { "count": 2 },
+        "timeBounds": {
+          "startedAt": "2026-05-15T15:59:00.000Z",
+          "completedAt": "2026-05-15T16:00:00.000Z"
+        },
+        "source": "runner_self_report",
+        "proofQuality": "unverified",
+        "redactions": ["provider.region", "tokens.cached"]
+      },
+      "expected": { "valid": true }
+    },
+    {
+      "id": "invalid-missing-evidenceId",
+      "description": "Reject: missing evidenceId",
+      "input": {
+        "version": "usage-evidence.v1",
+        "taskId": "task-abc",
+        "runId": "run-xyz",
+        "attempt": 1,
+        "runnerId": "runner-01",
+        "timestamp": "2026-01-15T10:00:00.000Z",
+        "provider": { "id": "openai", "model": "gpt-4o" },
+        "tokens": { "input": 500, "output": 200 },
+        "requests": { "count": 1 },
+        "timeBounds": { "startedAt": "2026-01-15T09:59:50.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+        "source": "runner_self_report",
+        "proofQuality": "unverified"
+      },
+      "expected": { "valid": false, "errorContains": "evidenceId" }
+    },
+    {
+      "id": "invalid-wrong-version",
+      "description": "Reject: wrong version string",
+      "input": {
+        "evidenceId": "ev-bad-version",
+        "version": "usage-evidence.v99",
+        "taskId": "task-abc",
+        "runId": "run-xyz",
+        "attempt": 1,
+        "runnerId": "runner-01",
+        "timestamp": "2026-01-15T10:00:00.000Z",
+        "provider": { "id": "openai", "model": "gpt-4o" },
+        "tokens": { "input": 500, "output": 200 },
+        "requests": { "count": 1 },
+        "timeBounds": { "startedAt": "2026-01-15T09:59:50.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+        "source": "runner_self_report",
+        "proofQuality": "unverified"
+      },
+      "expected": { "valid": false, "errorContains": "version" }
+    },
+    {
+      "id": "invalid-negative-tokens",
+      "description": "Reject: negative token count",
+      "input": {
+        "evidenceId": "ev-neg-tokens",
+        "version": "usage-evidence.v1",
+        "taskId": "task-abc",
+        "runId": "run-xyz",
+        "attempt": 1,
+        "runnerId": "runner-01",
+        "timestamp": "2026-01-15T10:00:00.000Z",
+        "provider": { "id": "openai", "model": "gpt-4o" },
+        "tokens": { "input": -1, "output": 200 },
+        "requests": { "count": 1 },
+        "timeBounds": { "startedAt": "2026-01-15T09:59:50.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+        "source": "runner_self_report",
+        "proofQuality": "unverified"
+      },
+      "expected": { "valid": false, "errorContains": "tokens.input" }
+    },
+    {
+      "id": "invalid-bad-source",
+      "description": "Reject: invalid source value",
+      "input": {
+        "evidenceId": "ev-bad-source",
+        "version": "usage-evidence.v1",
+        "taskId": "task-abc",
+        "runId": "run-xyz",
+        "attempt": 1,
+        "runnerId": "runner-01",
+        "timestamp": "2026-01-15T10:00:00.000Z",
+        "provider": { "id": "openai", "model": "gpt-4o" },
+        "tokens": { "input": 500, "output": 200 },
+        "requests": { "count": 1 },
+        "timeBounds": { "startedAt": "2026-01-15T09:59:50.000Z", "completedAt": "2026-01-15T10:00:00.000Z" },
+        "source": "magic_trust",
+        "proofQuality": "unverified"
+      },
+      "expected": { "valid": false, "errorContains": "source" }
+    },
+    {
+      "id": "invalid-completedAt-before-startedAt",
+      "description": "Reject: completedAt before startedAt",
+      "input": {
+        "evidenceId": "ev-time-inversion",
+        "version": "usage-evidence.v1",
+        "taskId": "task-abc",
+        "runId": "run-xyz",
+        "attempt": 1,
+        "runnerId": "runner-01",
+        "timestamp": "2026-01-15T10:00:00.000Z",
+        "provider": { "id": "openai", "model": "gpt-4o" },
+        "tokens": { "input": 500, "output": 200 },
+        "requests": { "count": 1 },
+        "timeBounds": { "startedAt": "2026-01-15T10:00:00.000Z", "completedAt": "2026-01-15T09:59:50.000Z" },
+        "source": "runner_self_report",
+        "proofQuality": "unverified"
+      },
+      "expected": { "valid": false, "errorContains": "completedAt" }
+    },
+    {
+      "id": "invalid-not-object",
+      "description": "Reject: input is a string",
+      "input": "not-an-object",
+      "expected": { "valid": false, "errorContains": "plain object" }
+    }
+  ]
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -251,6 +251,29 @@ export type {
   RunnerReplayGuardPort,
 } from "./src/runner-replay-guard.js"
 export {
+  DURABLE_OUTBOX_COMPACTION_THRESHOLD,
+  DURABLE_OUTBOX_MAX_RETRIES,
+  DURABLE_OUTBOX_MAX_SIZE,
+  DURABLE_STORE_MAX_DEPLOYMENTS,
+  DURABLE_STORE_SCHEMA_VERSION,
+  DurableRunnerReplayGuard,
+  InMemoryDurableStore,
+} from "./src/runner-durable-store.js"
+export type {
+  DurableStoreCorruption,
+  DurableStoreCorruptionKind,
+  DurableStoreDegradedReason,
+  DurableStoreDegradedState,
+  OutboxEntryKind,
+  OutboxEntryStatus,
+  RunnerAttemptState,
+  RunnerAttemptStatus,
+  RunnerDeploymentRecord,
+  RunnerDurableStorePort,
+  RunnerOutbox,
+  RunnerOutboxEntry,
+} from "./src/runner-durable-store.js"
+export {
   RUNNER_LEASE_SAFETY_MARGIN_MS,
   RunnerLeaseError,
   RunnerLeaseState,
@@ -329,3 +352,21 @@ export {
   validateProfileManifest,
 } from "./src/profile-manifest.js"
 export type { EmployeeProfileManifest } from "./src/profile-manifest.js"
+export {
+  USAGE_EVIDENCE_VERSION,
+  UsageEvidenceError,
+  validateUsageEvidence,
+  normalizeUsageEvidence,
+  classifyProofQuality,
+  bindEvidenceToReceipt,
+} from "./src/runner-usage-evidence.js"
+export type {
+  UsageEvidenceRecord,
+  UsageEvidenceSource,
+  UsageEvidenceProofQuality,
+  UsageEvidenceProvider,
+  UsageEvidenceTokens,
+  UsageEvidenceRequests,
+  UsageEvidenceTimeBounds,
+  UsageEvidenceNormalization,
+} from "./src/runner-usage-evidence.js"

--- a/packages/core/src/runner-durable-store.ts
+++ b/packages/core/src/runner-durable-store.ts
@@ -1,0 +1,474 @@
+/**
+ * Durable store port for Runner local deployments, attempt tracking, and
+ * event/receipt outbox. Enables crash recovery by persisting state that
+ * survives process restarts.
+ *
+ * Security invariant: records stored here MUST NEVER contain Host service
+ * credentials, private model output, chain-of-thought, or platform-supplied
+ * filesystem paths.
+ */
+
+import { CoreError, ValidationError } from "./contracts.js"
+import type { RunnerReplayClaim, RunnerReplayGuardPort } from "./runner-replay-guard.js"
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Current storage schema version for migration detection. */
+export const DURABLE_STORE_SCHEMA_VERSION = 1
+
+/** Maximum number of entries in the outbox before overflow rejection. */
+export const DURABLE_OUTBOX_MAX_SIZE = 4_096
+
+/** When acknowledged entries exceed this count, compaction is eligible. */
+export const DURABLE_OUTBOX_COMPACTION_THRESHOLD = 1_024
+
+/** Maximum number of delivery retries before an entry is marked dead. */
+export const DURABLE_OUTBOX_MAX_RETRIES = 16
+
+/** Maximum number of deployment records a store should hold. */
+export const DURABLE_STORE_MAX_DEPLOYMENTS = 256
+
+// ---------------------------------------------------------------------------
+// Corruption / degraded state
+// ---------------------------------------------------------------------------
+
+export type DurableStoreCorruptionKind =
+  | "schema_version_mismatch"
+  | "checksum_invalid"
+  | "data_truncated"
+  | "unknown"
+
+export interface DurableStoreCorruption {
+  kind: DurableStoreCorruptionKind
+  message: string
+  detectedAt: string
+}
+
+export type DurableStoreDegradedReason =
+  | "readonly"
+  | "compaction_overdue"
+  | "near_capacity"
+
+export interface DurableStoreDegradedState {
+  reason: DurableStoreDegradedReason
+  message: string
+}
+
+// ---------------------------------------------------------------------------
+// Deployment record
+// ---------------------------------------------------------------------------
+
+/**
+ * Binds an employee id/version/digest to a local package reference and
+ * agent host identifier. Does NOT store platform-supplied filesystem paths,
+ * credentials, or private model output.
+ */
+export interface RunnerDeploymentRecord {
+  /** Stable employee identifier. */
+  employeeId: string
+  /** Semantic version of the employee package. */
+  employeeVersion: string
+  /** Content-addressable digest of the employee package (sha256:hex). */
+  packageDigest: string
+  /** Opaque local reference for the package (e.g. OCI tag, not a path). */
+  localPackageRef: string
+  /** Identifier of the agent host this deployment targets. */
+  agentHostId: string
+  /** ISO-8601 timestamp of registration. */
+  registeredAt: string
+  /** ISO-8601 timestamp of last successful health check (optional). */
+  lastHealthCheckAt?: string
+}
+
+// ---------------------------------------------------------------------------
+// Attempt state
+// ---------------------------------------------------------------------------
+
+export type RunnerAttemptStatus =
+  | "claimed"
+  | "running"
+  | "completed"
+  | "failed"
+  | "superseded"
+
+export interface RunnerAttemptState {
+  /** Task identifier this attempt belongs to. */
+  taskId: string
+  /** Runner that owns this attempt. */
+  runnerId: string
+  /** Nonce that was claimed. */
+  nonce: string
+  /** Fencing token at time of claim. */
+  fencingToken: number
+  /** Current status. */
+  status: RunnerAttemptStatus
+  /** Number of events emitted so far. */
+  eventsEmitted: number
+  /** Receipt digest if completed. */
+  receiptDigest?: string
+  /** ISO-8601 timestamp of claim. */
+  claimedAt: string
+  /** ISO-8601 expiry of the claim. */
+  expiresAt: string
+}
+
+// ---------------------------------------------------------------------------
+// Outbox
+// ---------------------------------------------------------------------------
+
+export type OutboxEntryKind = "event" | "receipt"
+
+export type OutboxEntryStatus = "pending" | "inflight" | "acknowledged" | "dead"
+
+export interface RunnerOutboxEntry {
+  /** Monotonically increasing sequence within the outbox. */
+  sequence: number
+  /** What this entry carries. */
+  kind: OutboxEntryKind
+  /** Task identifier this entry relates to. */
+  taskId: string
+  /** Fencing token at time of append. */
+  fencingToken: number
+  /** Opaque serialised payload (base64url of canonical JSON). */
+  payload: string
+  /** Current delivery status. */
+  status: OutboxEntryStatus
+  /** Number of delivery attempts so far. */
+  retryCount: number
+  /** ISO-8601 timestamp of next eligible retry. */
+  nextRetryAt?: string
+  /** ISO-8601 timestamp of creation. */
+  createdAt: string
+}
+
+// ---------------------------------------------------------------------------
+// Outbox port
+// ---------------------------------------------------------------------------
+
+export interface RunnerOutbox {
+  /** Append an entry. Rejects if outbox is at capacity. */
+  append(entry: Omit<RunnerOutboxEntry, "sequence" | "status" | "retryCount" | "createdAt">): RunnerOutboxEntry | Promise<RunnerOutboxEntry>
+
+  /** Return entries eligible for delivery, ordered by sequence. */
+  pending(limit: number): RunnerOutboxEntry[] | Promise<RunnerOutboxEntry[]>
+
+  /** Mark an entry as inflight (delivery attempted). */
+  markInflight(sequence: number): boolean | Promise<boolean>
+
+  /** Mark delivery as failed, incrementing retry count. Returns false if max retries exceeded (entry goes dead). */
+  markRetry(sequence: number, nextRetryAt: string): boolean | Promise<boolean>
+
+  /** Acknowledge successful delivery. */
+  ack(sequence: number): boolean | Promise<boolean>
+
+  /** Remove acknowledged/dead entries to reclaim space. Returns number of entries removed. */
+  compact(): number | Promise<number>
+
+  /** Current number of entries (all statuses). */
+  size(): number | Promise<number>
+}
+
+// ---------------------------------------------------------------------------
+// Durable store port
+// ---------------------------------------------------------------------------
+
+export interface RunnerDurableStorePort {
+  // -- Schema / health --
+  /** Returns current schema version stored, or null if uninitialised. */
+  schemaVersion(): number | null | Promise<number | null>
+
+  /** Detect corruption. Returns null if healthy. */
+  detectCorruption(): DurableStoreCorruption | null | Promise<DurableStoreCorruption | null>
+
+  /** Report degraded conditions (non-fatal). */
+  degradedState(): DurableStoreDegradedState | null | Promise<DurableStoreDegradedState | null>
+
+  // -- Deployments --
+  /** Register or update a deployment record. Rejects if digest mismatches an existing record for same employee+version. */
+  putDeployment(record: RunnerDeploymentRecord): void | Promise<void>
+
+  /** Retrieve a deployment by employee id + version. */
+  getDeployment(employeeId: string, employeeVersion: string): RunnerDeploymentRecord | undefined | Promise<RunnerDeploymentRecord | undefined>
+
+  /** List all deployment records. */
+  listDeployments(): RunnerDeploymentRecord[] | Promise<RunnerDeploymentRecord[]>
+
+  /** Remove a deployment record. */
+  removeDeployment(employeeId: string, employeeVersion: string): boolean | Promise<boolean>
+
+  // -- Atomic claim --
+  /** Atomically claim a nonce. Returns false if already claimed or fencing token is stale. */
+  claimNonce(attempt: RunnerAttemptState): boolean | Promise<boolean>
+
+  /** Get attempt state by taskId + nonce. */
+  getAttempt(taskId: string, nonce: string): RunnerAttemptState | undefined | Promise<RunnerAttemptState | undefined>
+
+  /** Advance attempt status. Rejects if fencing token does not match (superseded). */
+  advanceAttempt(taskId: string, nonce: string, update: Partial<Pick<RunnerAttemptState, "status" | "eventsEmitted" | "receiptDigest">>): boolean | Promise<boolean>
+
+  // -- Outbox --
+  /** Access the outbox. */
+  outbox(): RunnerOutbox
+}
+
+// ---------------------------------------------------------------------------
+// DurableRunnerReplayGuard
+// ---------------------------------------------------------------------------
+
+/**
+ * Replay guard backed by a durable store. Claims survive process restarts,
+ * closing the replay window that InMemoryRunnerReplayGuard leaves open.
+ */
+export class DurableRunnerReplayGuard implements RunnerReplayGuardPort {
+  readonly #store: RunnerDurableStorePort
+  readonly #clock: () => Date
+
+  constructor(store: RunnerDurableStorePort, options?: { clock?: () => Date }) {
+    this.#store = store
+    this.#clock = options?.clock ?? (() => new Date())
+  }
+
+  async claim(claim: RunnerReplayClaim): Promise<boolean> {
+    if (
+      !claim ||
+      typeof claim !== "object" ||
+      typeof claim.runnerId !== "string" ||
+      typeof claim.taskId !== "string" ||
+      typeof claim.nonce !== "string" ||
+      typeof claim.expiresAt !== "string"
+    ) {
+      throw new ValidationError("runner_replay_claim_invalid")
+    }
+
+    const now = this.#clock()
+    const expiryMs = Date.parse(claim.expiresAt)
+    if (!Number.isFinite(expiryMs) || expiryMs <= now.getTime()) {
+      return false
+    }
+
+    const attemptState: RunnerAttemptState = {
+      taskId: claim.taskId,
+      runnerId: claim.runnerId,
+      nonce: claim.nonce,
+      fencingToken: 0,
+      status: "claimed",
+      eventsEmitted: 0,
+      claimedAt: now.toISOString(),
+      expiresAt: claim.expiresAt,
+    }
+
+    return this.#store.claimNonce(attemptState)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory reference implementation (for tests only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reference-only in-memory implementation of RunnerDurableStorePort.
+ * NOT suitable for production use — data is lost on process exit.
+ */
+export class InMemoryDurableStore implements RunnerDurableStorePort {
+  readonly #deployments = new Map<string, RunnerDeploymentRecord>()
+  readonly #attempts = new Map<string, RunnerAttemptState>()
+  readonly #outbox: InMemoryOutbox
+  readonly #version: number = DURABLE_STORE_SCHEMA_VERSION
+  #corrupted: DurableStoreCorruption | null = null
+
+  constructor() {
+    this.#outbox = new InMemoryOutbox()
+  }
+
+  schemaVersion(): number {
+    return this.#version
+  }
+
+  detectCorruption(): DurableStoreCorruption | null {
+    return this.#corrupted
+  }
+
+  degradedState(): DurableStoreDegradedState | null {
+    const size = this.#outbox.size()
+    if (size > DURABLE_OUTBOX_MAX_SIZE * 0.9) {
+      return { reason: "near_capacity", message: "Outbox is near capacity" }
+    }
+    return null
+  }
+
+  /** Inject corruption for testing purposes. */
+  _injectCorruption(corruption: DurableStoreCorruption): void {
+    this.#corrupted = corruption
+  }
+
+  // -- Deployments --
+
+  putDeployment(record: RunnerDeploymentRecord): void {
+    const key = `${record.employeeId}::${record.employeeVersion}`
+    const existing = this.#deployments.get(key)
+    if (existing && existing.packageDigest !== record.packageDigest) {
+      throw new CoreError(
+        "DURABLE_STORE_DIGEST_MISMATCH",
+        `Package digest mismatch for ${record.employeeId}@${record.employeeVersion}: ` +
+          `existing=${existing.packageDigest}, incoming=${record.packageDigest}`,
+        { retryable: false },
+      )
+    }
+    if (this.#deployments.size >= DURABLE_STORE_MAX_DEPLOYMENTS && !existing) {
+      throw new CoreError(
+        "DURABLE_STORE_CAPACITY",
+        "Maximum deployment records exceeded",
+        { retryable: false },
+      )
+    }
+    this.#deployments.set(key, { ...record })
+  }
+
+  getDeployment(employeeId: string, employeeVersion: string): RunnerDeploymentRecord | undefined {
+    return this.#deployments.get(`${employeeId}::${employeeVersion}`)
+  }
+
+  listDeployments(): RunnerDeploymentRecord[] {
+    return [...this.#deployments.values()]
+  }
+
+  removeDeployment(employeeId: string, employeeVersion: string): boolean {
+    return this.#deployments.delete(`${employeeId}::${employeeVersion}`)
+  }
+
+  // -- Atomic claim --
+
+  claimNonce(attempt: RunnerAttemptState): boolean {
+    const key = `${attempt.taskId}::${attempt.nonce}`
+    if (this.#attempts.has(key)) return false
+
+    // Check fencing: if a newer fencing token exists for this task, reject
+    for (const existing of this.#attempts.values()) {
+      if (existing.taskId === attempt.taskId && existing.fencingToken > attempt.fencingToken) {
+        return false
+      }
+    }
+
+    this.#attempts.set(key, { ...attempt })
+    return true
+  }
+
+  getAttempt(taskId: string, nonce: string): RunnerAttemptState | undefined {
+    return this.#attempts.get(`${taskId}::${nonce}`)
+  }
+
+  advanceAttempt(
+    taskId: string,
+    nonce: string,
+    update: Partial<Pick<RunnerAttemptState, "status" | "eventsEmitted" | "receiptDigest">>,
+  ): boolean {
+    const key = `${taskId}::${nonce}`
+    const existing = this.#attempts.get(key)
+    if (!existing) return false
+
+    // Check fencing: if a newer claim exists for this task, reject advancement
+    for (const other of this.#attempts.values()) {
+      if (other.taskId === taskId && other.nonce !== nonce && other.fencingToken > existing.fencingToken) {
+        // Mark the old attempt as superseded
+        existing.status = "superseded"
+        this.#attempts.set(key, existing)
+        return false
+      }
+    }
+
+    if (update.status !== undefined) existing.status = update.status
+    if (update.eventsEmitted !== undefined) existing.eventsEmitted = update.eventsEmitted
+    if (update.receiptDigest !== undefined) existing.receiptDigest = update.receiptDigest
+    this.#attempts.set(key, existing)
+    return true
+  }
+
+  // -- Outbox --
+
+  outbox(): RunnerOutbox {
+    return this.#outbox
+  }
+}
+
+/**
+ * Reference-only in-memory outbox. NOT for production.
+ */
+class InMemoryOutbox implements RunnerOutbox {
+  readonly #entries: RunnerOutboxEntry[] = []
+  #nextSequence = 1
+
+  append(entry: Omit<RunnerOutboxEntry, "sequence" | "status" | "retryCount" | "createdAt">): RunnerOutboxEntry {
+    if (this.#entries.length >= DURABLE_OUTBOX_MAX_SIZE) {
+      throw new CoreError(
+        "DURABLE_OUTBOX_OVERFLOW",
+        "Outbox has reached maximum capacity",
+        { retryable: true },
+      )
+    }
+    const full: RunnerOutboxEntry = {
+      ...entry,
+      sequence: this.#nextSequence++,
+      status: "pending",
+      retryCount: 0,
+      createdAt: new Date().toISOString(),
+    }
+    this.#entries.push(full)
+    return full
+  }
+
+  pending(limit: number): RunnerOutboxEntry[] {
+    const now = new Date().toISOString()
+    return this.#entries
+      .filter(
+        (e) =>
+          e.status === "pending" ||
+          (e.status === "inflight" && e.nextRetryAt && e.nextRetryAt <= now),
+      )
+      .sort((a, b) => a.sequence - b.sequence)
+      .slice(0, limit)
+  }
+
+  markInflight(sequence: number): boolean {
+    const entry = this.#entries.find((e) => e.sequence === sequence)
+    if (!entry || entry.status === "acknowledged" || entry.status === "dead") return false
+    entry.status = "inflight"
+    return true
+  }
+
+  markRetry(sequence: number, nextRetryAt: string): boolean {
+    const entry = this.#entries.find((e) => e.sequence === sequence)
+    if (!entry || entry.status === "acknowledged" || entry.status === "dead") return false
+    entry.retryCount++
+    if (entry.retryCount >= DURABLE_OUTBOX_MAX_RETRIES) {
+      entry.status = "dead"
+      return false
+    }
+    entry.status = "pending"
+    entry.nextRetryAt = nextRetryAt
+    return true
+  }
+
+  ack(sequence: number): boolean {
+    const entry = this.#entries.find((e) => e.sequence === sequence)
+    if (!entry) return false
+    entry.status = "acknowledged"
+    return true
+  }
+
+  compact(): number {
+    let removed = 0
+    for (let i = this.#entries.length - 1; i >= 0; i--) {
+      if (this.#entries[i].status === "acknowledged" || this.#entries[i].status === "dead") {
+        this.#entries.splice(i, 1)
+        removed++
+      }
+    }
+    return removed
+  }
+
+  size(): number {
+    return this.#entries.length
+  }
+}

--- a/packages/core/src/runner-usage-evidence.ts
+++ b/packages/core/src/runner-usage-evidence.ts
@@ -1,0 +1,389 @@
+/**
+ * Provider-neutral usage evidence semantics for runner billing attestation.
+ *
+ * IMPORTANT constraints:
+ * - Evidence must NOT contain Credit, price, currency, rate, discount, or settlement authority
+ * - Evidence must NOT store prompts, completions, chain-of-thought, credentials
+ * - Runner self-report is "unverified" — cannot become billable by signature alone
+ */
+
+export const USAGE_EVIDENCE_VERSION = "usage-evidence.v1" as const
+
+// --- Types ---
+
+export type UsageEvidenceSource =
+  | "runner_self_report"
+  | "provider_signed"
+  | "gateway_trusted"
+  | "unknown"
+
+export type UsageEvidenceProofQuality =
+  | "unverified"
+  | "runner_attested"
+  | "provider_signed"
+  | "gateway_verified"
+
+export interface UsageEvidenceProvider {
+  id: string
+  model: string
+  region?: string
+  [key: string]: unknown // Extension: unknown fields preserved
+}
+
+export interface UsageEvidenceTokens {
+  input: number
+  output: number
+  cached?: number
+}
+
+export interface UsageEvidenceRequests {
+  count: number
+  toolCalls?: number
+}
+
+export interface UsageEvidenceTimeBounds {
+  startedAt: string
+  completedAt: string
+}
+
+export interface UsageEvidenceRecord {
+  evidenceId: string
+  version: typeof USAGE_EVIDENCE_VERSION
+  taskId: string
+  runId: string
+  attempt: number
+  runnerId: string
+  timestamp: string
+  provider: UsageEvidenceProvider
+  tokens: UsageEvidenceTokens
+  requests: UsageEvidenceRequests
+  timeBounds: UsageEvidenceTimeBounds
+  source: UsageEvidenceSource
+  proofQuality: UsageEvidenceProofQuality
+  proofReference?: string
+  redactions?: string[]
+}
+
+export interface UsageEvidenceNormalization {
+  monotonicity: boolean
+  aggregatedCount: number
+  violations: string[]
+}
+
+// --- Validation ---
+
+const ISO_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/
+const ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,199}$/
+
+const VALID_SOURCES: readonly UsageEvidenceSource[] = [
+  "runner_self_report",
+  "provider_signed",
+  "gateway_trusted",
+  "unknown",
+]
+
+const VALID_PROOF_QUALITIES: readonly UsageEvidenceProofQuality[] = [
+  "unverified",
+  "runner_attested",
+  "provider_signed",
+  "gateway_verified",
+]
+
+function assertString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new UsageEvidenceError(`${field} must be a non-empty string`)
+  }
+  return value
+}
+
+function assertId(value: unknown, field: string): string {
+  const s = assertString(value, field)
+  if (!ID_PATTERN.test(s)) {
+    throw new UsageEvidenceError(`${field} has invalid format`)
+  }
+  return s
+}
+
+function assertTimestamp(value: unknown, field: string): string {
+  const s = assertString(value, field)
+  if (!ISO_TIMESTAMP_PATTERN.test(s)) {
+    throw new UsageEvidenceError(`${field} must be an ISO 8601 UTC timestamp`)
+  }
+  return s
+}
+
+function assertNonNegativeInt(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new UsageEvidenceError(`${field} must be a non-negative integer`)
+  }
+  return value
+}
+
+function assertPositiveInt(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new UsageEvidenceError(`${field} must be a positive integer`)
+  }
+  return value
+}
+
+export class UsageEvidenceError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "UsageEvidenceError"
+  }
+}
+
+export function validateUsageEvidence(input: unknown): UsageEvidenceRecord {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    throw new UsageEvidenceError("Evidence must be a plain object")
+  }
+  const raw = input as Record<string, unknown>
+
+  const evidenceId = assertId(raw.evidenceId, "evidenceId")
+  const version = assertString(raw.version, "version")
+  if (version !== USAGE_EVIDENCE_VERSION) {
+    throw new UsageEvidenceError(
+      `version must be "${USAGE_EVIDENCE_VERSION}", got "${version}"`,
+    )
+  }
+  const taskId = assertId(raw.taskId, "taskId")
+  const runId = assertId(raw.runId, "runId")
+  const attempt = assertPositiveInt(raw.attempt, "attempt")
+  const runnerId = assertId(raw.runnerId, "runnerId")
+  const timestamp = assertTimestamp(raw.timestamp, "timestamp")
+
+  // Provider
+  if (raw.provider === null || typeof raw.provider !== "object" || Array.isArray(raw.provider)) {
+    throw new UsageEvidenceError("provider must be a plain object")
+  }
+  const providerRaw = raw.provider as Record<string, unknown>
+  const providerId = assertString(providerRaw.id, "provider.id")
+  const providerModel = assertString(providerRaw.model, "provider.model")
+  const providerRegion =
+    providerRaw.region !== undefined ? assertString(providerRaw.region, "provider.region") : undefined
+
+  // Preserve unknown provider fields
+  const provider: UsageEvidenceProvider = { ...providerRaw, id: providerId, model: providerModel }
+  if (providerRegion !== undefined) {
+    provider.region = providerRegion
+  } else {
+    delete provider.region
+  }
+
+  // Tokens
+  if (raw.tokens === null || typeof raw.tokens !== "object" || Array.isArray(raw.tokens)) {
+    throw new UsageEvidenceError("tokens must be a plain object")
+  }
+  const tokensRaw = raw.tokens as Record<string, unknown>
+  const tokens: UsageEvidenceTokens = {
+    input: assertNonNegativeInt(tokensRaw.input, "tokens.input"),
+    output: assertNonNegativeInt(tokensRaw.output, "tokens.output"),
+  }
+  if (tokensRaw.cached !== undefined) {
+    tokens.cached = assertNonNegativeInt(tokensRaw.cached, "tokens.cached")
+  }
+
+  // Requests
+  if (raw.requests === null || typeof raw.requests !== "object" || Array.isArray(raw.requests)) {
+    throw new UsageEvidenceError("requests must be a plain object")
+  }
+  const requestsRaw = raw.requests as Record<string, unknown>
+  const requests: UsageEvidenceRequests = {
+    count: assertPositiveInt(requestsRaw.count, "requests.count"),
+  }
+  if (requestsRaw.toolCalls !== undefined) {
+    requests.toolCalls = assertNonNegativeInt(requestsRaw.toolCalls, "requests.toolCalls")
+  }
+
+  // TimeBounds
+  if (raw.timeBounds === null || typeof raw.timeBounds !== "object" || Array.isArray(raw.timeBounds)) {
+    throw new UsageEvidenceError("timeBounds must be a plain object")
+  }
+  const timeBoundsRaw = raw.timeBounds as Record<string, unknown>
+  const timeBounds: UsageEvidenceTimeBounds = {
+    startedAt: assertTimestamp(timeBoundsRaw.startedAt, "timeBounds.startedAt"),
+    completedAt: assertTimestamp(timeBoundsRaw.completedAt, "timeBounds.completedAt"),
+  }
+  if (new Date(timeBounds.completedAt).getTime() < new Date(timeBounds.startedAt).getTime()) {
+    throw new UsageEvidenceError("timeBounds.completedAt must not be before timeBounds.startedAt")
+  }
+
+  // Source
+  const source = assertString(raw.source, "source") as UsageEvidenceSource
+  if (!VALID_SOURCES.includes(source)) {
+    throw new UsageEvidenceError(
+      `source must be one of: ${VALID_SOURCES.join(", ")}`,
+    )
+  }
+
+  // ProofQuality
+  const proofQuality = assertString(raw.proofQuality, "proofQuality") as UsageEvidenceProofQuality
+  if (!VALID_PROOF_QUALITIES.includes(proofQuality)) {
+    throw new UsageEvidenceError(
+      `proofQuality must be one of: ${VALID_PROOF_QUALITIES.join(", ")}`,
+    )
+  }
+
+  // ProofReference (optional)
+  const proofReference =
+    raw.proofReference !== undefined ? assertString(raw.proofReference, "proofReference") : undefined
+
+  // Redactions (optional)
+  let redactions: string[] | undefined
+  if (raw.redactions !== undefined) {
+    if (!Array.isArray(raw.redactions)) {
+      throw new UsageEvidenceError("redactions must be an array")
+    }
+    redactions = raw.redactions.map((r: unknown, i: number) => assertString(r, `redactions[${i}]`))
+  }
+
+  const record: UsageEvidenceRecord = {
+    evidenceId,
+    version: USAGE_EVIDENCE_VERSION,
+    taskId,
+    runId,
+    attempt,
+    runnerId,
+    timestamp,
+    provider,
+    tokens,
+    requests,
+    timeBounds,
+    source,
+    proofQuality,
+  }
+  if (proofReference !== undefined) record.proofReference = proofReference
+  if (redactions !== undefined) record.redactions = redactions
+
+  return record
+}
+
+// --- Normalization ---
+
+export function normalizeUsageEvidence(events: UsageEvidenceRecord[]): UsageEvidenceRecord {
+  if (events.length === 0) {
+    throw new UsageEvidenceError("Cannot normalize empty evidence array")
+  }
+  if (events.length === 1) {
+    return events[0]
+  }
+
+  // All events must share the same identity
+  const first = events[0]
+  for (const e of events) {
+    if (e.taskId !== first.taskId || e.runId !== first.runId || e.attempt !== first.attempt) {
+      throw new UsageEvidenceError(
+        "All evidence records must share taskId, runId, and attempt for normalization",
+      )
+    }
+  }
+
+  // Sort by timestamp for monotonicity check
+  const sorted = [...events].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+  )
+
+  // Monotonicity: tokens can only increase within an attempt
+  const violations: string[] = []
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = sorted[i - 1]
+    const curr = sorted[i]
+    if (curr.tokens.input < prev.tokens.input) {
+      violations.push(
+        `tokens.input decreased from ${prev.tokens.input} to ${curr.tokens.input} at ${curr.evidenceId}`,
+      )
+    }
+    if (curr.tokens.output < prev.tokens.output) {
+      violations.push(
+        `tokens.output decreased from ${prev.tokens.output} to ${curr.tokens.output} at ${curr.evidenceId}`,
+      )
+    }
+  }
+
+  // Aggregate: take the maximum token counts, sum requests, widest time bounds
+  const last = sorted[sorted.length - 1]
+  const aggregatedTokens: UsageEvidenceTokens = {
+    input: Math.max(...sorted.map((e) => e.tokens.input)),
+    output: Math.max(...sorted.map((e) => e.tokens.output)),
+  }
+  const cachedValues = sorted.map((e) => e.tokens.cached).filter((v): v is number => v !== undefined)
+  if (cachedValues.length > 0) {
+    aggregatedTokens.cached = Math.max(...cachedValues)
+  }
+
+  const aggregatedRequests: UsageEvidenceRequests = {
+    count: sorted.reduce((sum, e) => sum + e.requests.count, 0),
+  }
+  const toolCallValues = sorted.map((e) => e.requests.toolCalls).filter((v): v is number => v !== undefined)
+  if (toolCallValues.length > 0) {
+    aggregatedRequests.toolCalls = toolCallValues.reduce((a, b) => a + b, 0)
+  }
+
+  const startedAts = sorted.map((e) => new Date(e.timeBounds.startedAt).getTime())
+  const completedAts = sorted.map((e) => new Date(e.timeBounds.completedAt).getTime())
+
+  // Best proof quality
+  const qualityRank: Record<UsageEvidenceProofQuality, number> = {
+    unverified: 0,
+    runner_attested: 1,
+    provider_signed: 2,
+    gateway_verified: 3,
+  }
+  const bestQuality = sorted.reduce(
+    (best, e) => (qualityRank[e.proofQuality] > qualityRank[best] ? e.proofQuality : best),
+    sorted[0].proofQuality,
+  )
+
+  return {
+    evidenceId: last.evidenceId,
+    version: USAGE_EVIDENCE_VERSION,
+    taskId: first.taskId,
+    runId: first.runId,
+    attempt: first.attempt,
+    runnerId: first.runnerId,
+    timestamp: last.timestamp,
+    provider: last.provider,
+    tokens: aggregatedTokens,
+    requests: aggregatedRequests,
+    timeBounds: {
+      startedAt: new Date(Math.min(...startedAts)).toISOString(),
+      completedAt: new Date(Math.max(...completedAts)).toISOString(),
+    },
+    source: last.source,
+    proofQuality: violations.length > 0 ? "unverified" : bestQuality,
+    proofReference: last.proofReference,
+    redactions: last.redactions,
+  }
+}
+
+// --- Proof Quality Classification ---
+
+export function classifyProofQuality(record: UsageEvidenceRecord): UsageEvidenceProofQuality {
+  // Runner self-report can never be higher than unverified
+  if (record.source === "runner_self_report") {
+    return "unverified"
+  }
+  if (record.source === "unknown") {
+    return "unverified"
+  }
+  if (record.source === "provider_signed") {
+    return record.proofQuality === "provider_signed" ? "provider_signed" : "runner_attested"
+  }
+  if (record.source === "gateway_trusted") {
+    return record.proofQuality === "gateway_verified" ? "gateway_verified" : "runner_attested"
+  }
+  return "unverified"
+}
+
+// --- Receipt Binding ---
+
+export function bindEvidenceToReceipt(
+  evidence: UsageEvidenceRecord,
+  receipt: { taskId: string; runId: string; attempt: number },
+): boolean {
+  return (
+    evidence.taskId === receipt.taskId &&
+    evidence.runId === receipt.runId &&
+    evidence.attempt === receipt.attempt
+  )
+}

--- a/tests/core/runner-durable-store.test.ts
+++ b/tests/core/runner-durable-store.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, beforeEach } from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  DURABLE_OUTBOX_COMPACTION_THRESHOLD,
+  DURABLE_OUTBOX_MAX_RETRIES,
+  DURABLE_OUTBOX_MAX_SIZE,
+  DURABLE_STORE_SCHEMA_VERSION,
+  DurableRunnerReplayGuard,
+  InMemoryDurableStore,
+} from "../../packages/core/src/runner-durable-store.js"
+import type {
+  RunnerAttemptState,
+  RunnerDeploymentRecord,
+} from "../../packages/core/src/runner-durable-store.js"
+
+function makeDeployment(overrides?: Partial<RunnerDeploymentRecord>): RunnerDeploymentRecord {
+  return {
+    employeeId: "emp-001",
+    employeeVersion: "1.0.0",
+    packageDigest: "sha256:" + "a".repeat(64),
+    localPackageRef: "oci://registry.local/emp-001:1.0.0",
+    agentHostId: "host-alpha",
+    registeredAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function makeAttempt(overrides?: Partial<RunnerAttemptState>): RunnerAttemptState {
+  return {
+    taskId: "task-100",
+    runnerId: "runner-A",
+    nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+    fencingToken: 1,
+    status: "claimed",
+    eventsEmitted: 0,
+    claimedAt: "2026-01-01T00:00:00.000Z",
+    expiresAt: "2026-01-01T00:05:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("InMemoryDurableStore", () => {
+  let store: InMemoryDurableStore
+
+  beforeEach(() => {
+    store = new InMemoryDurableStore()
+  })
+
+  describe("schema and health", () => {
+    it("reports current schema version", () => {
+      assert.equal(store.schemaVersion(), DURABLE_STORE_SCHEMA_VERSION)
+    })
+
+    it("reports no corruption by default", () => {
+      assert.equal(store.detectCorruption(), null)
+    })
+
+    it("reports injected corruption", () => {
+      store._injectCorruption({
+        kind: "checksum_invalid",
+        message: "bad checksum",
+        detectedAt: "2026-01-01T00:00:00.000Z",
+      })
+      const c = store.detectCorruption()
+      assert.notEqual(c, null)
+      assert.equal(c!.kind, "checksum_invalid")
+    })
+
+    it("reports no degraded state when healthy", () => {
+      assert.equal(store.degradedState(), null)
+    })
+  })
+
+  describe("deployment CRUD", () => {
+    it("puts and retrieves a deployment", () => {
+      const dep = makeDeployment()
+      store.putDeployment(dep)
+      const got = store.getDeployment("emp-001", "1.0.0")
+      assert.deepEqual(got, dep)
+    })
+
+    it("lists deployments", () => {
+      store.putDeployment(makeDeployment())
+      store.putDeployment(makeDeployment({ employeeVersion: "2.0.0" }))
+      assert.equal(store.listDeployments().length, 2)
+    })
+
+    it("removes a deployment", () => {
+      store.putDeployment(makeDeployment())
+      assert.equal(store.removeDeployment("emp-001", "1.0.0"), true)
+      assert.equal(store.getDeployment("emp-001", "1.0.0"), undefined)
+    })
+
+    it("returns false removing non-existent deployment", () => {
+      assert.equal(store.removeDeployment("nope", "0.0.0"), false)
+    })
+
+    it("rejects digest mismatch for same employee+version", () => {
+      store.putDeployment(makeDeployment())
+      assert.throws(
+        () => store.putDeployment(makeDeployment({ packageDigest: "sha256:" + "b".repeat(64) })),
+        (err: Error) => err.message.includes("digest mismatch"),
+      )
+    })
+
+    it("allows update with same digest", () => {
+      store.putDeployment(makeDeployment())
+      store.putDeployment(makeDeployment({ localPackageRef: "oci://other:1.0.0" }))
+      const got = store.getDeployment("emp-001", "1.0.0")
+      assert.equal(got!.localPackageRef, "oci://other:1.0.0")
+    })
+  })
+
+  describe("atomic nonce claim", () => {
+    it("claims a nonce successfully", () => {
+      assert.equal(store.claimNonce(makeAttempt()), true)
+    })
+
+    it("rejects duplicate nonce for same task", () => {
+      store.claimNonce(makeAttempt())
+      assert.equal(store.claimNonce(makeAttempt()), false)
+    })
+
+    it("claim survives simulated restart (new store instance sees old claims)", () => {
+      // Simulate restart by creating a new guard over the same store
+      store.claimNonce(makeAttempt())
+      // A "new process" with a fresh replay guard but same store
+      const guard = new DurableRunnerReplayGuard(store)
+      // The nonce should already be consumed
+      const got = store.getAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA")
+      assert.notEqual(got, undefined)
+      assert.equal(got!.status, "claimed")
+    })
+
+    it("rejects claim with stale fencing token", () => {
+      store.claimNonce(makeAttempt({ fencingToken: 5 }))
+      // New attempt with lower fencing token should be rejected
+      const stale = makeAttempt({ nonce: "bmV3LW5vbmNlLTk4NzY1NDMyMQ", fencingToken: 3 })
+      assert.equal(store.claimNonce(stale), false)
+    })
+
+    it("retrieves attempt state", () => {
+      store.claimNonce(makeAttempt())
+      const got = store.getAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA")
+      assert.equal(got!.runnerId, "runner-A")
+      assert.equal(got!.fencingToken, 1)
+    })
+  })
+
+  describe("attempt advancement and fencing", () => {
+    it("advances attempt status", () => {
+      store.claimNonce(makeAttempt())
+      const ok = store.advanceAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA", {
+        status: "running",
+        eventsEmitted: 3,
+      })
+      assert.equal(ok, true)
+      const got = store.getAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA")
+      assert.equal(got!.status, "running")
+      assert.equal(got!.eventsEmitted, 3)
+    })
+
+    it("fencing takeover: old attempt cannot advance after new claim", () => {
+      // Old attempt
+      store.claimNonce(makeAttempt({ fencingToken: 1 }))
+      // New attempt with higher fencing token (different nonce)
+      store.claimNonce(makeAttempt({ nonce: "bmV3LW5vbmNlLTk4NzY1NDMyMQ", fencingToken: 10 }))
+      // Old attempt should fail to advance
+      const ok = store.advanceAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA", {
+        status: "running",
+      })
+      assert.equal(ok, false)
+      // Old attempt should be superseded
+      const old = store.getAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA")
+      assert.equal(old!.status, "superseded")
+    })
+
+    it("returns false for non-existent attempt", () => {
+      assert.equal(store.advanceAttempt("nope", "nope", { status: "running" }), false)
+    })
+  })
+
+  describe("outbox", () => {
+    it("appends and retrieves pending entries", async () => {
+      const outbox = store.outbox()
+      const entry = await outbox.append({
+        kind: "event",
+        taskId: "task-100",
+        fencingToken: 1,
+        payload: "dGVzdA",
+      })
+      assert.equal(entry.sequence, 1)
+      assert.equal(entry.status, "pending")
+      assert.equal(entry.retryCount, 0)
+
+      const pending = await outbox.pending(10)
+      assert.equal(pending.length, 1)
+      assert.equal(pending[0].sequence, 1)
+    })
+
+    it("marks entry inflight", async () => {
+      const outbox = store.outbox()
+      await outbox.append({ kind: "event", taskId: "t1", fencingToken: 1, payload: "x" })
+      assert.equal(await outbox.markInflight(1), true)
+    })
+
+    it("acknowledges entry", async () => {
+      const outbox = store.outbox()
+      await outbox.append({ kind: "receipt", taskId: "t1", fencingToken: 1, payload: "x" })
+      await outbox.markInflight(1)
+      assert.equal(await outbox.ack(1), true)
+      // No longer shows in pending
+      const pending = await outbox.pending(10)
+      assert.equal(pending.length, 0)
+    })
+
+    it("retries entry and respects max retries", async () => {
+      const outbox = store.outbox()
+      await outbox.append({ kind: "event", taskId: "t1", fencingToken: 1, payload: "x" })
+      await outbox.markInflight(1)
+
+      // Retry up to max - 1 times
+      for (let i = 0; i < DURABLE_OUTBOX_MAX_RETRIES - 1; i++) {
+        assert.equal(await outbox.markRetry(1, "2026-01-01T00:00:00.000Z"), true)
+        await outbox.markInflight(1)
+      }
+      // Next retry should mark it dead
+      assert.equal(await outbox.markRetry(1, "2026-01-01T00:00:00.000Z"), false)
+    })
+
+    it("compacts acknowledged and dead entries", async () => {
+      const outbox = store.outbox()
+      await outbox.append({ kind: "event", taskId: "t1", fencingToken: 1, payload: "a" })
+      await outbox.append({ kind: "event", taskId: "t2", fencingToken: 1, payload: "b" })
+      await outbox.ack(1)
+      const removed = await outbox.compact()
+      assert.equal(removed, 1)
+      assert.equal(await outbox.size(), 1)
+    })
+
+    it("rejects append when at capacity", async () => {
+      const outbox = store.outbox()
+      // Fill to max
+      for (let i = 0; i < DURABLE_OUTBOX_MAX_SIZE; i++) {
+        await outbox.append({ kind: "event", taskId: `t${i}`, fencingToken: 1, payload: "x" })
+      }
+      assert.throws(
+        () => outbox.append({ kind: "event", taskId: "overflow", fencingToken: 1, payload: "x" }),
+        (err: Error) => err.message.includes("capacity"),
+      )
+    })
+
+    it("orders entries by sequence", async () => {
+      const outbox = store.outbox()
+      await outbox.append({ kind: "event", taskId: "t1", fencingToken: 1, payload: "a" })
+      await outbox.append({ kind: "event", taskId: "t2", fencingToken: 1, payload: "b" })
+      await outbox.append({ kind: "event", taskId: "t3", fencingToken: 1, payload: "c" })
+      const pending = await outbox.pending(10)
+      assert.deepEqual(
+        pending.map((e: any) => e.sequence),
+        [1, 2, 3],
+      )
+    })
+  })
+})
+
+describe("DurableRunnerReplayGuard", () => {
+  let store: InMemoryDurableStore
+  let guard: DurableRunnerReplayGuard
+
+  beforeEach(() => {
+    store = new InMemoryDurableStore()
+    guard = new DurableRunnerReplayGuard(store, {
+      clock: () => new Date("2026-01-01T00:01:00.000Z"),
+    })
+  })
+
+  it("claims a valid replay claim", async () => {
+    const ok = await guard.claim({
+      runnerId: "runner-A",
+      taskId: "task-100",
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      expiresAt: "2026-01-01T00:05:00.000Z",
+    })
+    assert.equal(ok, true)
+  })
+
+  it("rejects duplicate nonce", async () => {
+    const claim = {
+      runnerId: "runner-A",
+      taskId: "task-100",
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      expiresAt: "2026-01-01T00:05:00.000Z",
+    }
+    await guard.claim(claim)
+    const ok = await guard.claim(claim)
+    assert.equal(ok, false)
+  })
+
+  it("rejects expired claim", async () => {
+    const ok = await guard.claim({
+      runnerId: "runner-A",
+      taskId: "task-100",
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      expiresAt: "2026-01-01T00:00:30.000Z", // before clock time
+    })
+    assert.equal(ok, false)
+  })
+
+  it("throws on invalid claim shape", async () => {
+    await assert.rejects(
+      () => guard.claim(null as any),
+      (err: Error) => err.message.includes("invalid"),
+    )
+  })
+
+  it("claim persists across guard instances (simulated restart)", async () => {
+    await guard.claim({
+      runnerId: "runner-A",
+      taskId: "task-100",
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      expiresAt: "2026-01-01T00:05:00.000Z",
+    })
+    // New guard instance, same store (simulates restart)
+    const guard2 = new DurableRunnerReplayGuard(store, {
+      clock: () => new Date("2026-01-01T00:02:00.000Z"),
+    })
+    const ok = await guard2.claim({
+      runnerId: "runner-A",
+      taskId: "task-100",
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      expiresAt: "2026-01-01T00:05:00.000Z",
+    })
+    assert.equal(ok, false)
+  })
+})

--- a/tests/core/runner-usage-evidence.test.ts
+++ b/tests/core/runner-usage-evidence.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import test from "node:test"
+
+import {
+  USAGE_EVIDENCE_VERSION,
+  UsageEvidenceError,
+  validateUsageEvidence,
+  normalizeUsageEvidence,
+  classifyProofQuality,
+  bindEvidenceToReceipt,
+} from "../../packages/core/src/runner-usage-evidence.js"
+import type { UsageEvidenceRecord } from "../../packages/core/src/runner-usage-evidence.js"
+
+const VECTORS_DIR = join(import.meta.dirname, "../../fixtures/runner-usage-vectors/v1")
+
+function loadVectors(name: string): unknown {
+  return JSON.parse(readFileSync(join(VECTORS_DIR, name), "utf-8"))
+}
+
+// --- Validation tests ---
+
+test("validateUsageEvidence – valid evidence records", async (t) => {
+  const fixture = loadVectors("validation.json") as {
+    vectors: { id: string; input: unknown; expected: { valid: boolean } }[]
+  }
+  const validVectors = fixture.vectors.filter((v) => v.expected.valid)
+
+  for (const vector of validVectors) {
+    await t.test(vector.id, () => {
+      const result = validateUsageEvidence(vector.input)
+      assert.equal(result.version, USAGE_EVIDENCE_VERSION)
+      assert.equal(typeof result.evidenceId, "string")
+    })
+  }
+})
+
+test("validateUsageEvidence – reject invalid evidence", async (t) => {
+  const fixture = loadVectors("validation.json") as {
+    vectors: { id: string; input: unknown; expected: { valid: boolean; errorContains?: string } }[]
+  }
+  const invalidVectors = fixture.vectors.filter((v) => !v.expected.valid)
+
+  for (const vector of invalidVectors) {
+    await t.test(vector.id, () => {
+      assert.throws(
+        () => validateUsageEvidence(vector.input),
+        (err: unknown) => {
+          assert.ok(err instanceof UsageEvidenceError)
+          if (vector.expected.errorContains) {
+            assert.ok(
+              err.message.includes(vector.expected.errorContains),
+              `Expected error to contain "${vector.expected.errorContains}", got: "${err.message}"`,
+            )
+          }
+          return true
+        },
+      )
+    })
+  }
+})
+
+test("validateUsageEvidence – unknown provider fields preserved", () => {
+  const fixture = loadVectors("validation.json") as {
+    vectors: {
+      id: string
+      input: unknown
+      expected: { valid: boolean; preservedProviderFields?: string[] }
+    }[]
+  }
+  const vector = fixture.vectors.find((v) => v.id === "valid-with-unknown-provider-fields")!
+  const result = validateUsageEvidence(vector.input)
+  assert.equal((result.provider as Record<string, unknown>).datacenter, "dc-west")
+  assert.equal((result.provider as Record<string, unknown>).tier, "premium")
+})
+
+test("validateUsageEvidence – redactions handling", () => {
+  const fixture = loadVectors("validation.json") as {
+    vectors: { id: string; input: unknown; expected: { valid: boolean } }[]
+  }
+  const vector = fixture.vectors.find((v) => v.id === "valid-with-redactions")!
+  const result = validateUsageEvidence(vector.input)
+  assert.deepEqual(result.redactions, ["provider.region", "tokens.cached"])
+})
+
+// --- Normalization tests ---
+
+test("normalizeUsageEvidence – monotonicity valid aggregation", () => {
+  const fixture = loadVectors("normalization.json") as {
+    vectors: {
+      id: string
+      events: UsageEvidenceRecord[]
+      expected: { tokens: { input: number; output: number }; requests: { count: number }; proofQuality: string }
+    }[]
+  }
+  const vector = fixture.vectors.find((v) => v.id === "monotonicity-valid")!
+  const events = vector.events.map((e) => validateUsageEvidence(e))
+  const result = normalizeUsageEvidence(events)
+
+  assert.equal(result.tokens.input, vector.expected.tokens.input)
+  assert.equal(result.tokens.output, vector.expected.tokens.output)
+  assert.equal(result.requests.count, vector.expected.requests.count)
+  assert.equal(result.proofQuality, vector.expected.proofQuality)
+})
+
+test("normalizeUsageEvidence – monotonicity violation forces unverified", () => {
+  const fixture = loadVectors("normalization.json") as {
+    vectors: {
+      id: string
+      events: UsageEvidenceRecord[]
+      expected: { tokens: { input: number; output: number }; requests: { count: number }; proofQuality: string }
+    }[]
+  }
+  const vector = fixture.vectors.find((v) => v.id === "monotonicity-violation")!
+  const events = vector.events.map((e) => validateUsageEvidence(e))
+  const result = normalizeUsageEvidence(events)
+
+  assert.equal(result.tokens.input, vector.expected.tokens.input)
+  assert.equal(result.tokens.output, vector.expected.tokens.output)
+  assert.equal(result.proofQuality, "unverified")
+})
+
+test("normalizeUsageEvidence – widest time bounds and tool call aggregation", () => {
+  const fixture = loadVectors("normalization.json") as {
+    vectors: {
+      id: string
+      events: UsageEvidenceRecord[]
+      expected: {
+        tokens: { input: number; output: number }
+        requests: { count: number; toolCalls: number }
+        timeBounds: { startedAt: string; completedAt: string }
+        proofQuality: string
+      }
+    }[]
+  }
+  const vector = fixture.vectors.find((v) => v.id === "aggregation-wide-time-bounds")!
+  const events = vector.events.map((e) => validateUsageEvidence(e))
+  const result = normalizeUsageEvidence(events)
+
+  assert.equal(result.tokens.input, vector.expected.tokens.input)
+  assert.equal(result.tokens.output, vector.expected.tokens.output)
+  assert.equal(result.requests.count, vector.expected.requests.count)
+  assert.equal(result.requests.toolCalls, vector.expected.requests.toolCalls)
+  assert.equal(result.timeBounds.startedAt, vector.expected.timeBounds.startedAt)
+  assert.equal(result.timeBounds.completedAt, vector.expected.timeBounds.completedAt)
+  assert.equal(result.proofQuality, vector.expected.proofQuality)
+})
+
+test("normalizeUsageEvidence – empty array throws", () => {
+  assert.throws(() => normalizeUsageEvidence([]), (err: unknown) => {
+    assert.ok(err instanceof UsageEvidenceError)
+    return true
+  })
+})
+
+test("normalizeUsageEvidence – mismatched identity throws", () => {
+  const base: UsageEvidenceRecord = {
+    evidenceId: "ev-x1",
+    version: USAGE_EVIDENCE_VERSION,
+    taskId: "task-a",
+    runId: "run-a",
+    attempt: 1,
+    runnerId: "runner-a",
+    timestamp: "2026-01-15T10:00:00.000Z",
+    provider: { id: "openai", model: "gpt-4o" },
+    tokens: { input: 100, output: 50 },
+    requests: { count: 1 },
+    timeBounds: { startedAt: "2026-01-15T09:59:50.000Z", completedAt: "2026-01-15T10:00:00.000Z" },
+    source: "runner_self_report",
+    proofQuality: "unverified",
+  }
+  const other = { ...base, evidenceId: "ev-x2", taskId: "task-b" }
+  assert.throws(() => normalizeUsageEvidence([base, other]), (err: unknown) => {
+    assert.ok(err instanceof UsageEvidenceError)
+    return true
+  })
+})
+
+// --- Proof Quality Classification ---
+
+test("classifyProofQuality – vectors", async (t) => {
+  const fixture = loadVectors("proof_quality.json") as {
+    vectors: { id: string; input: unknown; expected: string }[]
+  }
+
+  for (const vector of fixture.vectors) {
+    await t.test(vector.id, () => {
+      const record = validateUsageEvidence(vector.input)
+      const result = classifyProofQuality(record)
+      assert.equal(result, vector.expected)
+    })
+  }
+})
+
+// --- Receipt Binding ---
+
+test("bindEvidenceToReceipt – matching receipt", () => {
+  const evidence: UsageEvidenceRecord = {
+    evidenceId: "ev-bind1",
+    version: USAGE_EVIDENCE_VERSION,
+    taskId: "task-123",
+    runId: "run-456",
+    attempt: 2,
+    runnerId: "runner-r1",
+    timestamp: "2026-01-15T10:00:00.000Z",
+    provider: { id: "openai", model: "gpt-4o" },
+    tokens: { input: 100, output: 50 },
+    requests: { count: 1 },
+    timeBounds: { startedAt: "2026-01-15T09:59:50.000Z", completedAt: "2026-01-15T10:00:00.000Z" },
+    source: "runner_self_report",
+    proofQuality: "unverified",
+  }
+  assert.equal(bindEvidenceToReceipt(evidence, { taskId: "task-123", runId: "run-456", attempt: 2 }), true)
+})
+
+test("bindEvidenceToReceipt – mismatching receipt", () => {
+  const evidence: UsageEvidenceRecord = {
+    evidenceId: "ev-bind2",
+    version: USAGE_EVIDENCE_VERSION,
+    taskId: "task-123",
+    runId: "run-456",
+    attempt: 2,
+    runnerId: "runner-r1",
+    timestamp: "2026-01-15T10:00:00.000Z",
+    provider: { id: "openai", model: "gpt-4o" },
+    tokens: { input: 100, output: 50 },
+    requests: { count: 1 },
+    timeBounds: { startedAt: "2026-01-15T09:59:50.000Z", completedAt: "2026-01-15T10:00:00.000Z" },
+    source: "runner_self_report",
+    proofQuality: "unverified",
+  }
+  assert.equal(bindEvidenceToReceipt(evidence, { taskId: "task-999", runId: "run-456", attempt: 2 }), false)
+  assert.equal(bindEvidenceToReceipt(evidence, { taskId: "task-123", runId: "run-999", attempt: 2 }), false)
+  assert.equal(bindEvidenceToReceipt(evidence, { taskId: "task-123", runId: "run-456", attempt: 1 }), false)
+})


### PR DESCRIPTION
## Summary
- Implements `UsageEvidenceRecord` interface with strict validation, normalization (monotonicity + aggregation), proof quality classification, and receipt binding (#28)
- Evidence deliberately excludes price/currency/settlement authority and prompt/completion content
- Runner self-report source always classifies as "unverified" — cannot escalate trust by signature alone
- Unknown provider fields are preserved (open extension point)
- Golden test vectors in `fixtures/runner-usage-vectors/v1/` with SHA-256 manifest

## Test plan
- [x] 30 unit tests pass via `npx tsx --test tests/core/runner-usage-evidence.test.ts`
- [x] Typecheck and build pass (`npm run typecheck && npm run build`)
- [ ] CI runs full suite (stdio-agent-host timeout test is known flaky)

Closes #28