### PR TITLE
feat: durable replay guard, outbox, and deployment store

### DIFF
--- a/fixtures/runner-durable-vectors/v1/deployment.json
+++ b/fixtures/runner-durable-vectors/v1/deployment.json
@@ -1,0 +1,54 @@
+{
+  "family": "deployment",
+  "vectors": [
+    {
+      "id": "deployment-valid-register",
+      "description": "Valid deployment registration with all required fields",
+      "input": {
+        "employeeId": "emp-001",
+        "employeeVersion": "1.0.0",
+        "packageDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "localPackageRef": "oci://registry.local/emp-001:1.0.0",
+        "agentHostId": "host-alpha",
+        "registeredAt": "2026-01-01T00:00:00.000Z"
+      },
+      "expect": {
+        "outcome": "accepted"
+      }
+    },
+    {
+      "id": "deployment-valid-update-same-digest",
+      "description": "Update existing deployment with same digest succeeds",
+      "input": {
+        "employeeId": "emp-001",
+        "employeeVersion": "1.0.0",
+        "packageDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "localPackageRef": "oci://registry.local/emp-001:1.0.0-updated",
+        "agentHostId": "host-beta",
+        "registeredAt": "2026-01-02T00:00:00.000Z"
+      },
+      "expect": {
+        "outcome": "accepted"
+      }
+    },
+    {
+      "id": "deployment-invalid-digest-mismatch",
+      "description": "Reject registration when digest differs for same employee+version",
+      "precondition": {
+        "existingDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "input": {
+        "employeeId": "emp-001",
+        "employeeVersion": "1.0.0",
+        "packageDigest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "localPackageRef": "oci://registry.local/emp-001:1.0.0",
+        "agentHostId": "host-alpha",
+        "registeredAt": "2026-01-01T00:00:00.000Z"
+      },
+      "expect": {
+        "outcome": "rejected",
+        "errorCode": "DURABLE_STORE_DIGEST_MISMATCH"
+      }
+    }
+  ]
+}

--- a/fixtures/runner-durable-vectors/v1/manifest.json
+++ b/fixtures/runner-durable-vectors/v1/manifest.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "runner-durable-vectors.v1",
+  "families": [
+    "deployment",
+    "replay_claim",
+    "outbox"
+  ],
+  "files": [
+    {
+      "file": "deployment.json",
+      "sha256": "5ffe57187653ae82edb41120d16ee695c702dc7730dfa9a5cc91d4ad2fd13cc2",
+      "vectorCount": 3
+    },
+    {
+      "file": "replay-claim.json",
+      "sha256": "85d4cf0dcdeb22cfbcf9233eb6dee5fa98e136aa9af41169f4228b49885a7afc",
+      "vectorCount": 3
+    },
+    {
+      "file": "outbox.json",
+      "sha256": "508f20c1594009e8e8ce342eff847497206ac70a852957d588f03593b7d5ae93",
+      "vectorCount": 5
+    }
+  ]
+}

--- a/fixtures/runner-durable-vectors/v1/outbox.json
+++ b/fixtures/runner-durable-vectors/v1/outbox.json
@@ -1,0 +1,88 @@
+{
+  "family": "outbox",
+  "vectors": [
+    {
+      "id": "outbox-append",
+      "description": "Append an event to the outbox",
+      "input": {
+        "kind": "event",
+        "taskId": "task-100",
+        "fencingToken": 1,
+        "payload": "eyJ0eXBlIjoicHJvZ3Jlc3MifQ"
+      },
+      "expect": {
+        "outcome": "accepted",
+        "sequence": 1,
+        "status": "pending",
+        "retryCount": 0
+      }
+    },
+    {
+      "id": "outbox-retry",
+      "description": "Mark entry for retry increments retry count",
+      "precondition": {
+        "existingEntry": { "sequence": 1, "status": "inflight" }
+      },
+      "input": {
+        "action": "markRetry",
+        "sequence": 1,
+        "nextRetryAt": "2026-01-01T00:01:00.000Z"
+      },
+      "expect": {
+        "outcome": true,
+        "retryCount": 1,
+        "status": "pending"
+      }
+    },
+    {
+      "id": "outbox-ack",
+      "description": "Acknowledge successful delivery",
+      "precondition": {
+        "existingEntry": { "sequence": 1, "status": "inflight" }
+      },
+      "input": {
+        "action": "ack",
+        "sequence": 1
+      },
+      "expect": {
+        "outcome": true,
+        "status": "acknowledged"
+      }
+    },
+    {
+      "id": "outbox-compaction",
+      "description": "Compact removes acknowledged and dead entries",
+      "precondition": {
+        "entries": [
+          { "sequence": 1, "status": "acknowledged" },
+          { "sequence": 2, "status": "dead" },
+          { "sequence": 3, "status": "pending" }
+        ]
+      },
+      "input": {
+        "action": "compact"
+      },
+      "expect": {
+        "removed": 2,
+        "remainingSize": 1
+      }
+    },
+    {
+      "id": "outbox-overflow",
+      "description": "Append rejected when outbox at maximum capacity (4096 entries)",
+      "precondition": {
+        "currentSize": 4096
+      },
+      "input": {
+        "kind": "event",
+        "taskId": "overflow",
+        "fencingToken": 1,
+        "payload": "eA"
+      },
+      "expect": {
+        "outcome": "rejected",
+        "errorCode": "DURABLE_OUTBOX_OVERFLOW"
+      }
+    }
+  ]
+}

--- a/fixtures/runner-durable-vectors/v1/replay-claim.json
+++ b/fixtures/runner-durable-vectors/v1/replay-claim.json
@@ -1,0 +1,64 @@
+{
+  "family": "replay_claim",
+  "vectors": [
+    {
+      "id": "claim-valid-first",
+      "description": "First claim for a nonce succeeds",
+      "input": {
+        "taskId": "task-100",
+        "runnerId": "runner-A",
+        "nonce": "dGVzdC1ub25jZS0xMjM0NTY3OA",
+        "fencingToken": 1,
+        "expiresAt": "2026-01-01T00:05:00.000Z"
+      },
+      "clock": "2026-01-01T00:01:00.000Z",
+      "expect": {
+        "outcome": true
+      }
+    },
+    {
+      "id": "claim-duplicate-nonce",
+      "description": "Duplicate nonce for same task is rejected",
+      "precondition": {
+        "existingClaim": {
+          "taskId": "task-100",
+          "nonce": "dGVzdC1ub25jZS0xMjM0NTY3OA",
+          "fencingToken": 1
+        }
+      },
+      "input": {
+        "taskId": "task-100",
+        "runnerId": "runner-A",
+        "nonce": "dGVzdC1ub25jZS0xMjM0NTY3OA",
+        "fencingToken": 1,
+        "expiresAt": "2026-01-01T00:05:00.000Z"
+      },
+      "clock": "2026-01-01T00:02:00.000Z",
+      "expect": {
+        "outcome": false
+      }
+    },
+    {
+      "id": "claim-fencing-conflict",
+      "description": "Claim with stale fencing token is rejected when newer exists",
+      "precondition": {
+        "existingClaim": {
+          "taskId": "task-100",
+          "nonce": "bmV3LW5vbmNlLTk4NzY1NDMyMQ",
+          "fencingToken": 10
+        }
+      },
+      "input": {
+        "taskId": "task-100",
+        "runnerId": "runner-B",
+        "nonce": "c3RhbGUtbm9uY2UtMTIzNDU2Nzg",
+        "fencingToken": 5,
+        "expiresAt": "2026-01-01T00:05:00.000Z"
+      },
+      "clock": "2026-01-01T00:01:00.000Z",
+      "expect": {
+        "outcome": false
+      }
+    }
+  ]
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -251,6 +251,29 @@ export type {
   RunnerReplayGuardPort,
 } from "./src/runner-replay-guard.js"
 export {
+  DURABLE_OUTBOX_COMPACTION_THRESHOLD,
+  DURABLE_OUTBOX_MAX_RETRIES,
+  DURABLE_OUTBOX_MAX_SIZE,
+  DURABLE_STORE_MAX_DEPLOYMENTS,
+  DURABLE_STORE_SCHEMA_VERSION,
+  DurableRunnerReplayGuard,
+  InMemoryDurableStore,
+} from "./src/runner-durable-store.js"
+export type {
+  DurableStoreCorruption,
+  DurableStoreCorruptionKind,
+  DurableStoreDegradedReason,
+  DurableStoreDegradedState,
+  OutboxEntryKind,
+  OutboxEntryStatus,
+  RunnerAttemptState,
+  RunnerAttemptStatus,
+  RunnerDeploymentRecord,
+  RunnerDurableStorePort,
+  RunnerOutbox,
+  RunnerOutboxEntry,
+} from "./src/runner-durable-store.js"
+export {
   RUNNER_LEASE_SAFETY_MARGIN_MS,
   RunnerLeaseError,
   RunnerLeaseState,

--- a/packages/core/src/runner-durable-store.ts
+++ b/packages/core/src/runner-durable-store.ts
@@ -1,0 +1,474 @@
+/**
+ * Durable store port for Runner local deployments, attempt tracking, and
+ * event/receipt outbox. Enables crash recovery by persisting state that
+ * survives process restarts.
+ *
+ * Security invariant: records stored here MUST NEVER contain Host service
+ * credentials, private model output, chain-of-thought, or platform-supplied
+ * filesystem paths.
+ */
+
+import { CoreError, ValidationError } from "./contracts.js"
+import type { RunnerReplayClaim, RunnerReplayGuardPort } from "./runner-replay-guard.js"
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Current storage schema version for migration detection. */
+export const DURABLE_STORE_SCHEMA_VERSION = 1
+
+/** Maximum number of entries in the outbox before overflow rejection. */
+export const DURABLE_OUTBOX_MAX_SIZE = 4_096
+
+/** When acknowledged entries exceed this count, compaction is eligible. */
+export const DURABLE_OUTBOX_COMPACTION_THRESHOLD = 1_024
+
+/** Maximum number of delivery retries before an entry is marked dead. */
+export const DURABLE_OUTBOX_MAX_RETRIES = 16
+
+/** Maximum number of deployment records a store should hold. */
+export const DURABLE_STORE_MAX_DEPLOYMENTS = 256
+
+// ---------------------------------------------------------------------------
+// Corruption / degraded state
+// ---------------------------------------------------------------------------
+
+export type DurableStoreCorruptionKind =
+  | "schema_version_mismatch"
+  | "checksum_invalid"
+  | "data_truncated"
+  | "unknown"
+
+export interface DurableStoreCorruption {
+  kind: DurableStoreCorruptionKind
+  message: string
+  detectedAt: string
+}
+
+export type DurableStoreDegradedReason =
+  | "readonly"
+  | "compaction_overdue"
+  | "near_capacity"
+
+export interface DurableStoreDegradedState {
+  reason: DurableStoreDegradedReason
+  message: string
+}
+
+// ---------------------------------------------------------------------------
+// Deployment record
+// ---------------------------------------------------------------------------
+
+/**
+ * Binds an employee id/version/digest to a local package reference and
+ * agent host identifier. Does NOT store platform-supplied filesystem paths,
+ * credentials, or private model output.
+ */
+export interface RunnerDeploymentRecord {
+  /** Stable employee identifier. */
+  employeeId: string
+  /** Semantic version of the employee package. */
+  employeeVersion: string
+  /** Content-addressable digest of the employee package (sha256:hex). */
+  packageDigest: string
+  /** Opaque local reference for the package (e.g. OCI tag, not a path). */
+  localPackageRef: string
+  /** Identifier of the agent host this deployment targets. */
+  agentHostId: string
+  /** ISO-8601 timestamp of registration. */
+  registeredAt: string
+  /** ISO-8601 timestamp of last successful health check (optional). */
+  lastHealthCheckAt?: string
+}
+
+// ---------------------------------------------------------------------------
+// Attempt state
+// ---------------------------------------------------------------------------
+
+export type RunnerAttemptStatus =
+  | "claimed"
+  | "running"
+  | "completed"
+  | "failed"
+  | "superseded"
+
+export interface RunnerAttemptState {
+  /** Task identifier this attempt belongs to. */
+  taskId: string
+  /** Runner that owns this attempt. */
+  runnerId: string
+  /** Nonce that was claimed. */
+  nonce: string
+  /** Fencing token at time of claim. */
+  fencingToken: number
+  /** Current status. */
+  status: RunnerAttemptStatus
+  /** Number of events emitted so far. */
+  eventsEmitted: number
+  /** Receipt digest if completed. */
+  receiptDigest?: string
+  /** ISO-8601 timestamp of claim. */
+  claimedAt: string
+  /** ISO-8601 expiry of the claim. */
+  expiresAt: string
+}
+
+// ---------------------------------------------------------------------------
+// Outbox
+// ---------------------------------------------------------------------------
+
+export type OutboxEntryKind = "event" | "receipt"
+
+export type OutboxEntryStatus = "pending" | "inflight" | "acknowledged" | "dead"
+
+export interface RunnerOutboxEntry {
+  /** Monotonically increasing sequence within the outbox. */
+  sequence: number
+  /** What this entry carries. */
+  kind: OutboxEntryKind
+  /** Task identifier this entry relates to. */
+  taskId: string
+  /** Fencing token at time of append. */
+  fencingToken: number
+  /** Opaque serialised payload (base64url of canonical JSON). */
+  payload: string
+  /** Current delivery status. */
+  status: OutboxEntryStatus
+  /** Number of delivery attempts so far. */
+  retryCount: number
+  /** ISO-8601 timestamp of next eligible retry. */
+  nextRetryAt?: string
+  /** ISO-8601 timestamp of creation. */
+  createdAt: string
+}
+
+// ---------------------------------------------------------------------------
+// Outbox port
+// ---------------------------------------------------------------------------
+
+export interface RunnerOutbox {
+  /** Append an entry. Rejects if outbox is at capacity. */
+  append(entry: Omit<RunnerOutboxEntry, "sequence" | "status" | "retryCount" | "createdAt">): RunnerOutboxEntry | Promise<RunnerOutboxEntry>
+
+  /** Return entries eligible for delivery, ordered by sequence. */
+  pending(limit: number): RunnerOutboxEntry[] | Promise<RunnerOutboxEntry[]>
+
+  /** Mark an entry as inflight (delivery attempted). */
+  markInflight(sequence: number): boolean | Promise<boolean>
+
+  /** Mark delivery as failed, incrementing retry count. Returns false if max retries exceeded (entry goes dead). */
+  markRetry(sequence: number, nextRetryAt: string): boolean | Promise<boolean>
+
+  /** Acknowledge successful delivery. */
+  ack(sequence: number): boolean | Promise<boolean>
+
+  /** Remove acknowledged/dead entries to reclaim space. Returns number of entries removed. */
+  compact(): number | Promise<number>
+
+  /** Current number of entries (all statuses). */
+  size(): number | Promise<number>
+}
+
+// ---------------------------------------------------------------------------
+// Durable store port
+// ---------------------------------------------------------------------------
+
+export interface RunnerDurableStorePort {
+  // -- Schema / health --
+  /** Returns current schema version stored, or null if uninitialised. */
+  schemaVersion(): number | null | Promise<number | null>
+
+  /** Detect corruption. Returns null if healthy. */
+  detectCorruption(): DurableStoreCorruption | null | Promise<DurableStoreCorruption | null>
+
+  /** Report degraded conditions (non-fatal). */
+  degradedState(): DurableStoreDegradedState | null | Promise<DurableStoreDegradedState | null>
+
+  // -- Deployments --
+  /** Register or update a deployment record. Rejects if digest mismatches an existing record for same employee+version. */
+  putDeployment(record: RunnerDeploymentRecord): void | Promise<void>
+
+  /** Retrieve a deployment by employee id + version. */
+  getDeployment(employeeId: string, employeeVersion: string): RunnerDeploymentRecord | undefined | Promise<RunnerDeploymentRecord | undefined>
+
+  /** List all deployment records. */
+  listDeployments(): RunnerDeploymentRecord[] | Promise<RunnerDeploymentRecord[]>
+
+  /** Remove a deployment record. */
+  removeDeployment(employeeId: string, employeeVersion: string): boolean | Promise<boolean>
+
+  // -- Atomic claim --
+  /** Atomically claim a nonce. Returns false if already claimed or fencing token is stale. */
+  claimNonce(attempt: RunnerAttemptState): boolean | Promise<boolean>
+
+  /** Get attempt state by taskId + nonce. */
+  getAttempt(taskId: string, nonce: string): RunnerAttemptState | undefined | Promise<RunnerAttemptState | undefined>
+
+  /** Advance attempt status. Rejects if fencing token does not match (superseded). */
+  advanceAttempt(taskId: string, nonce: string, update: Partial<Pick<RunnerAttemptState, "status" | "eventsEmitted" | "receiptDigest">>): boolean | Promise<boolean>
+
+  // -- Outbox --
+  /** Access the outbox. */
+  outbox(): RunnerOutbox
+}
+
+// ---------------------------------------------------------------------------
+// DurableRunnerReplayGuard
+// ---------------------------------------------------------------------------
+
+/**
+ * Replay guard backed by a durable store. Claims survive process restarts,
+ * closing the replay window that InMemoryRunnerReplayGuard leaves open.
+ */
+export class DurableRunnerReplayGuard implements RunnerReplayGuardPort {
+  readonly #store: RunnerDurableStorePort
+  readonly #clock: () => Date
+
+  constructor(store: RunnerDurableStorePort, options?: { clock?: () => Date }) {
+    this.#store = store
+    this.#clock = options?.clock ?? (() => new Date())
+  }
+
+  async claim(claim: RunnerReplayClaim): Promise<boolean> {
+    if (
+      !claim ||
+      typeof claim !== "object" ||
+      typeof claim.runnerId !== "string" ||
+      typeof claim.taskId !== "string" ||
+      typeof claim.nonce !== "string" ||
+      typeof claim.expiresAt !== "string"
+    ) {
+      throw new ValidationError("runner_replay_claim_invalid")
+    }
+
+    const now = this.#clock()
+    const expiryMs = Date.parse(claim.expiresAt)
+    if (!Number.isFinite(expiryMs) || expiryMs <= now.getTime()) {
+      return false
+    }
+
+    const attemptState: RunnerAttemptState = {
+      taskId: claim.taskId,
+      runnerId: claim.runnerId,
+      nonce: claim.nonce,
+      fencingToken: 0,
+      status: "claimed",
+      eventsEmitted: 0,
+      claimedAt: now.toISOString(),
+      expiresAt: claim.expiresAt,
+    }
+
+    return this.#store.claimNonce(attemptState)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory reference implementation (for tests only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reference-only in-memory implementation of RunnerDurableStorePort.
+ * NOT suitable for production use — data is lost on process exit.
+ */
+export class InMemoryDurableStore implements RunnerDurableStorePort {
+  readonly #deployments = new Map<string, RunnerDeploymentRecord>()
+  readonly #attempts = new Map<string, RunnerAttemptState>()
+  readonly #outbox: InMemoryOutbox
+  readonly #version: number = DURABLE_STORE_SCHEMA_VERSION
+  #corrupted: DurableStoreCorruption | null = null
+
+  constructor() {
+    this.#outbox = new InMemoryOutbox()
+  }
+
+  schemaVersion(): number {
+    return this.#version
+  }
+
+  detectCorruption(): DurableStoreCorruption | null {
+    return this.#corrupted
+  }
+
+  degradedState(): DurableStoreDegradedState | null {
+    const size = this.#outbox.size()
+    if (size > DURABLE_OUTBOX_MAX_SIZE * 0.9) {
+      return { reason: "near_capacity", message: "Outbox is near capacity" }
+    }
+    return null
+  }
+
+  /** Inject corruption for testing purposes. */
+  _injectCorruption(corruption: DurableStoreCorruption): void {
+    this.#corrupted = corruption
+  }
+
+  // -- Deployments --
+
+  putDeployment(record: RunnerDeploymentRecord): void {
+    const key = `${record.employeeId}::${record.employeeVersion}`
+    const existing = this.#deployments.get(key)
+    if (existing && existing.packageDigest !== record.packageDigest) {
+      throw new CoreError(
+        "DURABLE_STORE_DIGEST_MISMATCH",
+        `Package digest mismatch for ${record.employeeId}@${record.employeeVersion}: ` +
+          `existing=${existing.packageDigest}, incoming=${record.packageDigest}`,
+        { retryable: false },
+      )
+    }
+    if (this.#deployments.size >= DURABLE_STORE_MAX_DEPLOYMENTS && !existing) {
+      throw new CoreError(
+        "DURABLE_STORE_CAPACITY",
+        "Maximum deployment records exceeded",
+        { retryable: false },
+      )
+    }
+    this.#deployments.set(key, { ...record })
+  }
+
+  getDeployment(employeeId: string, employeeVersion: string): RunnerDeploymentRecord | undefined {
+    return this.#deployments.get(`${employeeId}::${employeeVersion}`)
+  }
+
+  listDeployments(): RunnerDeploymentRecord[] {
+    return [...this.#deployments.values()]
+  }
+
+  removeDeployment(employeeId: string, employeeVersion: string): boolean {
+    return this.#deployments.delete(`${employeeId}::${employeeVersion}`)
+  }
+
+  // -- Atomic claim --
+
+  claimNonce(attempt: RunnerAttemptState): boolean {
+    const key = `${attempt.taskId}::${attempt.nonce}`
+    if (this.#attempts.has(key)) return false
+
+    // Check fencing: if a newer fencing token exists for this task, reject
+    for (const existing of this.#attempts.values()) {
+      if (existing.taskId === attempt.taskId && existing.fencingToken > attempt.fencingToken) {
+        return false
+      }
+    }
+
+    this.#attempts.set(key, { ...attempt })
+    return true
+  }
+
+  getAttempt(taskId: string, nonce: string): RunnerAttemptState | undefined {
+    return this.#attempts.get(`${taskId}::${nonce}`)
+  }
+
+  advanceAttempt(
+    taskId: string,
+    nonce: string,
+    update: Partial<Pick<RunnerAttemptState, "status" | "eventsEmitted" | "receiptDigest">>,
+  ): boolean {
+    const key = `${taskId}::${nonce}`
+    const existing = this.#attempts.get(key)
+    if (!existing) return false
+
+    // Check fencing: if a newer claim exists for this task, reject advancement
+    for (const other of this.#attempts.values()) {
+      if (other.taskId === taskId && other.nonce !== nonce && other.fencingToken > existing.fencingToken) {
+        // Mark the old attempt as superseded
+        existing.status = "superseded"
+        this.#attempts.set(key, existing)
+        return false
+      }
+    }
+
+    if (update.status !== undefined) existing.status = update.status
+    if (update.eventsEmitted !== undefined) existing.eventsEmitted = update.eventsEmitted
+    if (update.receiptDigest !== undefined) existing.receiptDigest = update.receiptDigest
+    this.#attempts.set(key, existing)
+    return true
+  }
+
+  // -- Outbox --
+
+  outbox(): RunnerOutbox {
+    return this.#outbox
+  }
+}
+
+/**
+ * Reference-only in-memory outbox. NOT for production.
+ */
+class InMemoryOutbox implements RunnerOutbox {
+  readonly #entries: RunnerOutboxEntry[] = []
+  #nextSequence = 1
+
+  append(entry: Omit<RunnerOutboxEntry, "sequence" | "status" | "retryCount" | "createdAt">): RunnerOutboxEntry {
+    if (this.#entries.length >= DURABLE_OUTBOX_MAX_SIZE) {
+      throw new CoreError(
+        "DURABLE_OUTBOX_OVERFLOW",
+        "Outbox has reached maximum capacity",
+        { retryable: true },
+      )
+    }
+    const full: RunnerOutboxEntry = {
+      ...entry,
+      sequence: this.#nextSequence++,
+      status: "pending",
+      retryCount: 0,
+      createdAt: new Date().toISOString(),
+    }
+    this.#entries.push(full)
+    return full
+  }
+
+  pending(limit: number): RunnerOutboxEntry[] {
+    const now = new Date().toISOString()
+    return this.#entries
+      .filter(
+        (e) =>
+          e.status === "pending" ||
+          (e.status === "inflight" && e.nextRetryAt && e.nextRetryAt <= now),
+      )
+      .sort((a, b) => a.sequence - b.sequence)
+      .slice(0, limit)
+  }
+
+  markInflight(sequence: number): boolean {
+    const entry = this.#entries.find((e) => e.sequence === sequence)
+    if (!entry || entry.status === "acknowledged" || entry.status === "dead") return false
+    entry.status = "inflight"
+    return true
+  }
+
+  markRetry(sequence: number, nextRetryAt: string): boolean {
+    const entry = this.#entries.find((e) => e.sequence === sequence)
+    if (!entry || entry.status === "acknowledged" || entry.status === "dead") return false
+    entry.retryCount++
+    if (entry.retryCount >= DURABLE_OUTBOX_MAX_RETRIES) {
+      entry.status = "dead"
+      return false
+    }
+    entry.status = "pending"
+    entry.nextRetryAt = nextRetryAt
+    return true
+  }
+
+  ack(sequence: number): boolean {
+    const entry = this.#entries.find((e) => e.sequence === sequence)
+    if (!entry) return false
+    entry.status = "acknowledged"
+    return true
+  }
+
+  compact(): number {
+    let removed = 0
+    for (let i = this.#entries.length - 1; i >= 0; i--) {
+      if (this.#entries[i].status === "acknowledged" || this.#entries[i].status === "dead") {
+        this.#entries.splice(i, 1)
+        removed++
+      }
+    }
+    return removed
+  }
+
+  size(): number {
+    return this.#entries.length
+  }
+}

--- a/tests/core/runner-durable-store.test.ts
+++ b/tests/core/runner-durable-store.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, beforeEach } from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  DURABLE_OUTBOX_COMPACTION_THRESHOLD,
+  DURABLE_OUTBOX_MAX_RETRIES,
+  DURABLE_OUTBOX_MAX_SIZE,
+  DURABLE_STORE_SCHEMA_VERSION,
+  DurableRunnerReplayGuard,
+  InMemoryDurableStore,
+} from "../../packages/core/src/runner-durable-store.js"
+import type {
+  RunnerAttemptState,
+  RunnerDeploymentRecord,
+} from "../../packages/core/src/runner-durable-store.js"
+
+function makeDeployment(overrides?: Partial<RunnerDeploymentRecord>): RunnerDeploymentRecord {
+  return {
+    employeeId: "emp-001",
+    employeeVersion: "1.0.0",
+    packageDigest: "sha256:" + "a".repeat(64),
+    localPackageRef: "oci://registry.local/emp-001:1.0.0",
+    agentHostId: "host-alpha",
+    registeredAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function makeAttempt(overrides?: Partial<RunnerAttemptState>): RunnerAttemptState {
+  return {
+    taskId: "task-100",
+    runnerId: "runner-A",
+    nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+    fencingToken: 1,
+    status: "claimed",
+    eventsEmitted: 0,
+    claimedAt: "2026-01-01T00:00:00.000Z",
+    expiresAt: "2026-01-01T00:05:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("InMemoryDurableStore", () => {
+  let store: InMemoryDurableStore
+
+  beforeEach(() => {
+    store = new InMemoryDurableStore()
+  })
+
+  describe("schema and health", () => {
+    it("reports current schema version", () => {
+      assert.equal(store.schemaVersion(), DURABLE_STORE_SCHEMA_VERSION)
+    })
+
+    it("reports no corruption by default", () => {
+      assert.equal(store.detectCorruption(), null)
+    })
+
+    it("reports injected corruption", () => {
+      store._injectCorruption({
+        kind: "checksum_invalid",
+        message: "bad checksum",
+        detectedAt: "2026-01-01T00:00:00.000Z",
+      })
+      const c = store.detectCorruption()
+      assert.notEqual(c, null)
+      assert.equal(c!.kind, "checksum_invalid")
+    })
+
+    it("reports no degraded state when healthy", () => {
+      assert.equal(store.degradedState(), null)
+    })
+  })
+
+  describe("deployment CRUD", () => {
+    it("puts and retrieves a deployment", () => {
+      const dep = makeDeployment()
+      store.putDeployment(dep)
+      const got = store.getDeployment("emp-001", "1.0.0")
+      assert.deepEqual(got, dep)
+    })
+
+    it("lists deployments", () => {
+      store.putDeployment(makeDeployment())
+      store.putDeployment(makeDeployment({ employeeVersion: "2.0.0" }))
+      assert.equal(store.listDeployments().length, 2)
+    })
+
+    it("removes a deployment", () => {
+      store.putDeployment(makeDeployment())
+      assert.equal(store.removeDeployment("emp-001", "1.0.0"), true)
+      assert.equal(store.getDeployment("emp-001", "1.0.0"), undefined)
+    })
+
+    it("returns false removing non-existent deployment", () => {
+      assert.equal(store.removeDeployment("nope", "0.0.0"), false)
+    })
+
+    it("rejects digest mismatch for same employee+version", () => {
+      store.putDeployment(makeDeployment())
+      assert.throws(
+        () => store.putDeployment(makeDeployment({ packageDigest: "sha256:" + "b".repeat(64) })),
+        (err: Error) => err.message.includes("digest mismatch"),
+      )
+    })
+
+    it("allows update with same digest", () => {
+      store.putDeployment(makeDeployment())
+      store.putDeployment(makeDeployment({ localPackageRef: "oci://other:1.0.0" }))
+      const got = store.getDeployment("emp-001", "1.0.0")
+      assert.equal(got!.localPackageRef, "oci://other:1.0.0")
+    })
+  })
+
+  describe("atomic nonce claim", () => {
+    it("claims a nonce successfully", () => {
+      assert.equal(store.claimNonce(makeAttempt()), true)
+    })
+
+    it("rejects duplicate nonce for same task", () => {
+      store.claimNonce(makeAttempt())
+      assert.equal(store.claimNonce(makeAttempt()), false)
+    })
+
+    it("claim survives simulated restart (new store instance sees old claims)", () => {
+      store.claimNonce(makeAttempt())
+      // A "new process" with a fresh replay guard but same store
+      const guard = new DurableRunnerReplayGuard(store)
+      // The nonce should already be consumed
+      const got = store.getAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA")
+      assert.notEqual(got, undefined)
+      assert.equal(got!.status, "claimed")
+    })
+
+    it("rejects claim with stale fencing token", () => {
+      store.claimNonce(makeAttempt({ fencingToken: 5 }))
+      // New attempt with lower fencing token should be rejected
+      const stale = makeAttempt({ nonce: "bmV3LW5vbmNlLTk4NzY1NDMyMQ", fencingToken: 3 })
+      assert.equal(store.claimNonce(stale), false)
+    })
+
+    it("retrieves attempt state", () => {
+      store.claimNonce(makeAttempt())
+      const got = store.getAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA")
+      assert.equal(got!.runnerId, "runner-A")
+      assert.equal(got!.fencingToken, 1)
+    })
+  })
+
+  describe("attempt advancement and fencing", () => {
+    it("advances attempt status", () => {
+      store.claimNonce(makeAttempt())
+      const ok = store.advanceAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA", {
+        status: "running",
+        eventsEmitted: 3,
+      })
+      assert.equal(ok, true)
+      const got = store.getAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA")
+      assert.equal(got!.status, "running")
+      assert.equal(got!.eventsEmitted, 3)
+    })
+
+    it("fencing takeover: old attempt cannot advance after new claim", () => {
+      // Old attempt
+      store.claimNonce(makeAttempt({ fencingToken: 1 }))
+      // New attempt with higher fencing token (different nonce)
+      store.claimNonce(makeAttempt({ nonce: "bmV3LW5vbmNlLTk4NzY1NDMyMQ", fencingToken: 10 }))
+      // Old attempt should fail to advance
+      const ok = store.advanceAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA", {
+        status: "running",
+      })
+      assert.equal(ok, false)
+      // Old attempt should be superseded
+      const old = store.getAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA")
+      assert.equal(old!.status, "superseded")
+    })
+
+    it("returns false for non-existent attempt", () => {
+      assert.equal(store.advanceAttempt("nope", "nope", { status: "running" }), false)
+    })
+  })
+
+  describe("outbox", () => {
+    it("appends and retrieves pending entries", async () => {
+      const outbox = store.outbox()
+      const entry = await outbox.append({
+        kind: "event",
+        taskId: "task-100",
+        fencingToken: 1,
+        payload: "dGVzdA",
+      })
+      assert.equal(entry.sequence, 1)
+      assert.equal(entry.status, "pending")
+      assert.equal(entry.retryCount, 0)
+
+      const pending = await outbox.pending(10)
+      assert.equal(pending.length, 1)
+      assert.equal(pending[0].sequence, 1)
+    })
+
+    it("marks entry inflight", async () => {
+      const outbox = store.outbox()
+      await outbox.append({ kind: "event", taskId: "t1", fencingToken: 1, payload: "x" })
+      assert.equal(await outbox.markInflight(1), true)
+    })
+
+    it("acknowledges entry", async () => {
+      const outbox = store.outbox()
+      await outbox.append({ kind: "receipt", taskId: "t1", fencingToken: 1, payload: "x" })
+      await outbox.markInflight(1)
+      assert.equal(await outbox.ack(1), true)
+      // No longer shows in pending
+      const pending = await outbox.pending(10)
+      assert.equal(pending.length, 0)
+    })
+
+    it("retries entry and respects max retries", async () => {
+      const outbox = store.outbox()
+      await outbox.append({ kind: "event", taskId: "t1", fencingToken: 1, payload: "x" })
+      await outbox.markInflight(1)
+
+      // Retry up to max - 1 times
+      for (let i = 0; i < DURABLE_OUTBOX_MAX_RETRIES - 1; i++) {
+        assert.equal(await outbox.markRetry(1, "2026-01-01T00:00:00.000Z"), true)
+        await outbox.markInflight(1)
+      }
+      // Next retry should mark it dead
+      assert.equal(await outbox.markRetry(1, "2026-01-01T00:00:00.000Z"), false)
+    })
+
+    it("compacts acknowledged and dead entries", async () => {
+      const outbox = store.outbox()
+      await outbox.append({ kind: "event", taskId: "t1", fencingToken: 1, payload: "a" })
+      await outbox.append({ kind: "event", taskId: "t2", fencingToken: 1, payload: "b" })
+      await outbox.ack(1)
+      const removed = await outbox.compact()
+      assert.equal(removed, 1)
+      assert.equal(await outbox.size(), 1)
+    })
+
+    it("rejects append when at capacity", async () => {
+      const outbox = store.outbox()
+      // Fill to max
+      for (let i = 0; i < DURABLE_OUTBOX_MAX_SIZE; i++) {
+        await outbox.append({ kind: "event", taskId: `t${i}`, fencingToken: 1, payload: "x" })
+      }
+      assert.throws(
+        () => outbox.append({ kind: "event", taskId: "overflow", fencingToken: 1, payload: "x" }),
+        (err: Error) => err.message.includes("capacity"),
+      )
+    })
+
+    it("orders entries by sequence", async () => {
+      const outbox = store.outbox()
+      await outbox.append({ kind: "event", taskId: "t1", fencingToken: 1, payload: "a" })
+      await outbox.append({ kind: "event", taskId: "t2", fencingToken: 1, payload: "b" })
+      await outbox.append({ kind: "event", taskId: "t3", fencingToken: 1, payload: "c" })
+      const pending = await outbox.pending(10)
+      assert.deepEqual(
+        pending.map((e: any) => e.sequence),
+        [1, 2, 3],
+      )
+    })
+  })
+})
+
+describe("DurableRunnerReplayGuard", () => {
+  let store: InMemoryDurableStore
+  let guard: DurableRunnerReplayGuard
+
+  beforeEach(() => {
+    store = new InMemoryDurableStore()
+    guard = new DurableRunnerReplayGuard(store, {
+      clock: () => new Date("2026-01-01T00:01:00.000Z"),
+    })
+  })
+
+  it("claims a valid replay claim", async () => {
+    const ok = await guard.claim({
+      runnerId: "runner-A",
+      taskId: "task-100",
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      expiresAt: "2026-01-01T00:05:00.000Z",
+    })
+    assert.equal(ok, true)
+  })
+
+  it("rejects duplicate nonce", async () => {
+    const claim = {
+      runnerId: "runner-A",
+      taskId: "task-100",
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      expiresAt: "2026-01-01T00:05:00.000Z",
+    }
+    await guard.claim(claim)
+    const ok = await guard.claim(claim)
+    assert.equal(ok, false)
+  })
+
+  it("rejects expired claim", async () => {
+    const ok = await guard.claim({
+      runnerId: "runner-A",
+      taskId: "task-100",
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      expiresAt: "2026-01-01T00:00:30.000Z", // before clock time
+    })
+    assert.equal(ok, false)
+  })
+
+  it("throws on invalid claim shape", async () => {
+    await assert.rejects(
+      () => guard.claim(null as any),
+      (err: Error) => err.message.includes("invalid"),
+    )
+  })
+
+  it("claim persists across guard instances (simulated restart)", async () => {
+    await guard.claim({
+      runnerId: "runner-A",
+      taskId: "task-100",
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      expiresAt: "2026-01-01T00:05:00.000Z",
+    })
+    // New guard instance, same store (simulates restart)
+    const guard2 = new DurableRunnerReplayGuard(store, {
+      clock: () => new Date("2026-01-01T00:02:00.000Z"),
+    })
+    const ok = await guard2.claim({
+      runnerId: "runner-A",
+      taskId: "task-100",
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      expiresAt: "2026-01-01T00:05:00.000Z",
+    })
+    assert.equal(ok, false)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `RunnerDurableStorePort` abstract port with deployment CRUD, atomic nonce claim (fencing-aware), and a bounded event/receipt outbox with ordered retry, ack, and compaction
- Implements `DurableRunnerReplayGuard` backed by the durable store, closing the restart replay window left open by `InMemoryRunnerReplayGuard`
- Includes `InMemoryDurableStore` reference implementation (test-only, not production)
- Golden fixture vectors in `fixtures/runner-durable-vectors/v1/` with SHA-256 manifest
- 30 passing tests covering deployment CRUD, atomic claims surviving restart, fencing takeover, outbox lifecycle, and corruption detection

Closes #27

## Test plan

- [x] `npm run typecheck` passes (all three tsconfigs)
- [x] `npx tsx --test tests/core/runner-durable-store.test.ts` — 30/30 pass
- [ ] `npm run check` full suite (stdio-agent-host timeout is known flaky)