### PR TITLE
Add task-intake approval gate (owner confirmation before accepting tasks)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -419,6 +419,27 @@ export type {
   UsageEvidenceNormalization,
 } from "./src/runner-usage-evidence.js"
 export {
+  TASK_INTAKE_APPROVAL_VERSION,
+  TASK_INTAKE_DEFAULT_TIMEOUT_MS,
+  TASK_INTAKE_MAX_TIMEOUT_MS,
+  TASK_INTAKE_MIN_TIMEOUT_MS,
+  TaskIntakeApprovalError,
+  TaskIntakeGate,
+  computeTaskIntakeDigest,
+  evaluateIntakeGate,
+  validateTaskIntakePolicy,
+  validateTaskIntakeRequest,
+} from "./src/task-intake-approval.js"
+export type {
+  TaskIntakeApprovalErrorCode,
+  TaskIntakeDecision,
+  TaskIntakeEvent,
+  TaskIntakePolicy,
+  TaskIntakeRecord,
+  TaskIntakeRequest,
+  TaskIntakeState,
+} from "./src/task-intake-approval.js"
+export {
   WRITE_APPROVAL_VERSION,
   WriteApprovalValidationError,
   classifyApprovalGuard,

--- a/packages/core/src/task-intake-approval.ts
+++ b/packages/core/src/task-intake-approval.ts
@@ -1,0 +1,439 @@
+/**
+ * Task-intake approval: owner must confirm before the Runner accepts a task.
+ *
+ * Implements the "向上请示" (escalate upward) principle: when someone assigns
+ * a task to a digital employee, the employee first asks its owner whether to
+ * accept. This is upstream of write-approval (#12) — it gates task *intake*
+ * regardless of whether the task involves write operations.
+ *
+ * Design decisions (per #49 P9 freeze):
+ * - Gate lives in Runner policy layer (not platform).
+ * - Pending tasks are held (not declined); they expire on timeout.
+ * - Default: auto-accept when unconfigured (backward compatible).
+ * - Granularity: per-task (no per-requester batching).
+ * - Works offline/locally — no inbound port or platform-held owner state.
+ */
+
+import { createHash } from "node:crypto"
+import { CoreError } from "./contracts.js"
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const TASK_INTAKE_APPROVAL_VERSION = "task-intake-approval.v1" as const
+
+/** Default timeout (ms) for owner approval before auto-expiry. */
+export const TASK_INTAKE_DEFAULT_TIMEOUT_MS = 300_000 // 5 minutes
+
+/** Maximum allowed timeout (ms). */
+export const TASK_INTAKE_MAX_TIMEOUT_MS = 3_600_000 // 1 hour
+
+/** Minimum allowed timeout (ms). */
+export const TASK_INTAKE_MIN_TIMEOUT_MS = 10_000 // 10 seconds
+
+// ---------------------------------------------------------------------------
+// Error codes
+// ---------------------------------------------------------------------------
+
+export type TaskIntakeApprovalErrorCode =
+  | "INTAKE_ALREADY_DECIDED"
+  | "INTAKE_EXPIRED"
+  | "INTAKE_NOT_FOUND"
+  | "INTAKE_POLICY_INVALID"
+  | "INTAKE_REQUEST_INVALID"
+
+export class TaskIntakeApprovalError extends CoreError {
+  constructor(code: TaskIntakeApprovalErrorCode, message?: string) {
+    super(code, message ?? "Task intake approval operation failed", {
+      status: 400,
+      retryable: false,
+    })
+    this.name = "TaskIntakeApprovalError"
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TaskIntakeState =
+  | "pending"
+  | "approved"
+  | "declined"
+  | "expired"
+  | "auto_accepted"
+
+export interface TaskIntakePolicy {
+  /** Whether owner approval is required before accepting tasks. */
+  requireOwnerApproval: boolean
+  /** Timeout in ms before a pending approval auto-expires. */
+  timeoutMs?: number
+}
+
+export interface TaskIntakeRequest {
+  /** Unique task identifier from the signed task payload. */
+  taskId: string
+  /** Lease identifier from the transport claim. */
+  leaseId: string
+  /** ISO-8601 timestamp when the lease expires. */
+  leaseExpiresAt: string
+  /** Employee identifier the task is addressed to. */
+  employeeId: string
+  /** Runner identifier processing this task. */
+  runnerId: string
+  /** ISO-8601 timestamp when the request was created. */
+  requestedAt: string
+}
+
+export interface TaskIntakeRecord {
+  version: typeof TASK_INTAKE_APPROVAL_VERSION
+  taskId: string
+  leaseId: string
+  leaseExpiresAt: string
+  employeeId: string
+  runnerId: string
+  state: TaskIntakeState
+  requestedAt: string
+  decidedAt: string | null
+  decidedBy: string | null
+  reason: string | null
+  expiresAt: string
+  digest: string
+}
+
+export interface TaskIntakeDecision {
+  taskId: string
+  approved: boolean
+  decidedBy: string
+  reason?: string
+}
+
+/**
+ * Event emitted into the normalized event chain for observability (AC-002).
+ */
+export interface TaskIntakeEvent {
+  version: typeof TASK_INTAKE_APPROVAL_VERSION
+  type: "task_intake.state_change"
+  taskId: string
+  leaseId: string
+  previousState: TaskIntakeState | null
+  newState: TaskIntakeState
+  timestamp: string
+  digest: string
+}
+
+// ---------------------------------------------------------------------------
+// Policy validation
+// ---------------------------------------------------------------------------
+
+export function validateTaskIntakePolicy(input: unknown): TaskIntakePolicy {
+  if (input === null || typeof input !== "object") {
+    throw new TaskIntakeApprovalError(
+      "INTAKE_POLICY_INVALID",
+      "Policy must be a non-null object",
+    )
+  }
+  const obj = input as Record<string, unknown>
+  if (typeof obj.requireOwnerApproval !== "boolean") {
+    throw new TaskIntakeApprovalError(
+      "INTAKE_POLICY_INVALID",
+      "requireOwnerApproval must be a boolean",
+    )
+  }
+  let timeoutMs: number | undefined
+  if (obj.timeoutMs !== undefined) {
+    if (
+      typeof obj.timeoutMs !== "number" ||
+      !Number.isSafeInteger(obj.timeoutMs) ||
+      obj.timeoutMs < TASK_INTAKE_MIN_TIMEOUT_MS ||
+      obj.timeoutMs > TASK_INTAKE_MAX_TIMEOUT_MS
+    ) {
+      throw new TaskIntakeApprovalError(
+        "INTAKE_POLICY_INVALID",
+        `timeoutMs must be an integer between ${TASK_INTAKE_MIN_TIMEOUT_MS} and ${TASK_INTAKE_MAX_TIMEOUT_MS}`,
+      )
+    }
+    timeoutMs = obj.timeoutMs
+  }
+  return {
+    requireOwnerApproval: obj.requireOwnerApproval,
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Request validation
+// ---------------------------------------------------------------------------
+
+export function validateTaskIntakeRequest(input: unknown): TaskIntakeRequest {
+  if (input === null || typeof input !== "object") {
+    throw new TaskIntakeApprovalError(
+      "INTAKE_REQUEST_INVALID",
+      "Request must be a non-null object",
+    )
+  }
+  const obj = input as Record<string, unknown>
+  for (const field of ["taskId", "leaseId", "leaseExpiresAt", "employeeId", "runnerId", "requestedAt"] as const) {
+    if (typeof obj[field] !== "string" || (obj[field] as string).length === 0) {
+      throw new TaskIntakeApprovalError(
+        "INTAKE_REQUEST_INVALID",
+        `${field} must be a non-empty string`,
+      )
+    }
+  }
+  return {
+    taskId: obj.taskId as string,
+    leaseId: obj.leaseId as string,
+    leaseExpiresAt: obj.leaseExpiresAt as string,
+    employeeId: obj.employeeId as string,
+    runnerId: obj.runnerId as string,
+    requestedAt: obj.requestedAt as string,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Digest computation
+// ---------------------------------------------------------------------------
+
+export function computeTaskIntakeDigest(
+  taskId: string,
+  leaseId: string,
+  state: TaskIntakeState,
+  requestedAt: string,
+): string {
+  const payload = [taskId, leaseId, state, requestedAt].join("|")
+  return createHash("sha256").update(payload).digest("hex")
+}
+
+// ---------------------------------------------------------------------------
+// Evaluate policy gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Determines the initial intake state based on the configured policy.
+ * When policy does not require approval, the task is auto-accepted immediately.
+ */
+export function evaluateIntakeGate(
+  policy: TaskIntakePolicy,
+): { requiresApproval: boolean } {
+  return { requiresApproval: policy.requireOwnerApproval }
+}
+
+// ---------------------------------------------------------------------------
+// TaskIntakeGate — stateful per-runner gate
+// ---------------------------------------------------------------------------
+
+export class TaskIntakeGate {
+  private readonly records = new Map<string, TaskIntakeRecord>()
+  private readonly events: TaskIntakeEvent[] = []
+  private readonly policy: TaskIntakePolicy
+  private readonly clock: () => Date
+
+  constructor(options: { policy: TaskIntakePolicy; clock?: () => Date }) {
+    this.policy = options.policy
+    this.clock = options.clock ?? (() => new Date())
+  }
+
+  /**
+   * Submit a task for intake approval. Returns the initial record.
+   * If policy does not require approval, immediately auto-accepts.
+   */
+  submit(request: TaskIntakeRequest): TaskIntakeRecord {
+    const validated = validateTaskIntakeRequest(request)
+    if (this.records.has(validated.taskId)) {
+      throw new TaskIntakeApprovalError(
+        "INTAKE_ALREADY_DECIDED",
+        `Task ${validated.taskId} already submitted for intake`,
+      )
+    }
+
+    const now = this.clock()
+    const timeoutMs = this.policy.timeoutMs ?? TASK_INTAKE_DEFAULT_TIMEOUT_MS
+    // Expiry is the earlier of policy timeout or lease expiry
+    const policyExpiry = new Date(now.getTime() + timeoutMs)
+    const leaseExpiry = new Date(validated.leaseExpiresAt)
+    const expiresAt = policyExpiry < leaseExpiry ? policyExpiry : leaseExpiry
+
+    const initialState: TaskIntakeState = this.policy.requireOwnerApproval
+      ? "pending"
+      : "auto_accepted"
+
+    const record: TaskIntakeRecord = {
+      version: TASK_INTAKE_APPROVAL_VERSION,
+      taskId: validated.taskId,
+      leaseId: validated.leaseId,
+      leaseExpiresAt: validated.leaseExpiresAt,
+      employeeId: validated.employeeId,
+      runnerId: validated.runnerId,
+      state: initialState,
+      requestedAt: validated.requestedAt,
+      decidedAt: initialState === "auto_accepted" ? now.toISOString() : null,
+      decidedBy: initialState === "auto_accepted" ? "policy:auto_accept" : null,
+      reason: null,
+      expiresAt: expiresAt.toISOString(),
+      digest: computeTaskIntakeDigest(
+        validated.taskId,
+        validated.leaseId,
+        initialState,
+        validated.requestedAt,
+      ),
+    }
+
+    this.records.set(validated.taskId, record)
+    this.emitEvent(validated.taskId, null, initialState)
+    return record
+  }
+
+  /**
+   * Record an owner decision (approve or decline) for a pending task.
+   */
+  decide(decision: TaskIntakeDecision): TaskIntakeRecord {
+    if (typeof decision.taskId !== "string" || decision.taskId.length === 0) {
+      throw new TaskIntakeApprovalError(
+        "INTAKE_REQUEST_INVALID",
+        "decision.taskId must be a non-empty string",
+      )
+    }
+    const record = this.records.get(decision.taskId)
+    if (!record) {
+      throw new TaskIntakeApprovalError(
+        "INTAKE_NOT_FOUND",
+        `No intake record for task ${decision.taskId}`,
+      )
+    }
+    if (record.state !== "pending") {
+      throw new TaskIntakeApprovalError(
+        "INTAKE_ALREADY_DECIDED",
+        `Task ${decision.taskId} is already in state '${record.state}'`,
+      )
+    }
+
+    // Check if expired before applying decision
+    const now = this.clock()
+    if (now >= new Date(record.expiresAt)) {
+      const previousState = record.state
+      record.state = "expired"
+      record.decidedAt = now.toISOString()
+      record.decidedBy = "system:timeout"
+      record.digest = computeTaskIntakeDigest(
+        record.taskId,
+        record.leaseId,
+        record.state,
+        record.requestedAt,
+      )
+      this.emitEvent(record.taskId, previousState, "expired")
+      throw new TaskIntakeApprovalError(
+        "INTAKE_EXPIRED",
+        `Task ${decision.taskId} intake approval has expired`,
+      )
+    }
+
+    const previousState = record.state
+    const newState: TaskIntakeState = decision.approved ? "approved" : "declined"
+    record.state = newState
+    record.decidedAt = now.toISOString()
+    record.decidedBy = decision.decidedBy
+    record.reason = decision.reason ?? null
+    record.digest = computeTaskIntakeDigest(
+      record.taskId,
+      record.leaseId,
+      record.state,
+      record.requestedAt,
+    )
+    this.emitEvent(record.taskId, previousState, newState)
+    return record
+  }
+
+  /**
+   * Expire any pending records that have passed their timeout.
+   * Returns the list of task IDs that were expired.
+   */
+  expirePending(): string[] {
+    const now = this.clock()
+    const expired: string[] = []
+    for (const record of this.records.values()) {
+      if (record.state === "pending" && now >= new Date(record.expiresAt)) {
+        const previousState = record.state
+        record.state = "expired"
+        record.decidedAt = now.toISOString()
+        record.decidedBy = "system:timeout"
+        record.digest = computeTaskIntakeDigest(
+          record.taskId,
+          record.leaseId,
+          record.state,
+          record.requestedAt,
+        )
+        this.emitEvent(record.taskId, previousState, "expired")
+        expired.push(record.taskId)
+      }
+    }
+    return expired
+  }
+
+  /**
+   * Query the current intake record for a task.
+   */
+  get(taskId: string): TaskIntakeRecord | null {
+    return this.records.get(taskId) ?? null
+  }
+
+  /**
+   * Whether the task is allowed to proceed to Host execution (AC-002).
+   */
+  canLaunch(taskId: string): boolean {
+    const record = this.records.get(taskId)
+    if (!record) return false
+    return record.state === "approved" || record.state === "auto_accepted"
+  }
+
+  /**
+   * Return all emitted intake events (for observability / event chain).
+   */
+  drainEvents(): TaskIntakeEvent[] {
+    return this.events.splice(0, this.events.length)
+  }
+
+  /**
+   * Return the number of pending approvals.
+   */
+  pendingCount(): number {
+    let count = 0
+    for (const record of this.records.values()) {
+      if (record.state === "pending") count++
+    }
+    return count
+  }
+
+  private emitEvent(
+    taskId: string,
+    previousState: TaskIntakeState | null,
+    newState: TaskIntakeState,
+  ): void {
+    const record = this.records.get(taskId)!
+    const timestamp = this.clock().toISOString()
+    const digest = createHash("sha256")
+      .update(
+        [
+          TASK_INTAKE_APPROVAL_VERSION,
+          taskId,
+          record.leaseId,
+          previousState ?? "null",
+          newState,
+          timestamp,
+        ].join("|"),
+      )
+      .digest("hex")
+
+    this.events.push({
+      version: TASK_INTAKE_APPROVAL_VERSION,
+      type: "task_intake.state_change",
+      taskId,
+      leaseId: record.leaseId,
+      previousState,
+      newState,
+      timestamp,
+      digest,
+    })
+  }
+}

--- a/tests/core/task-intake-approval.test.ts
+++ b/tests/core/task-intake-approval.test.ts
@@ -1,0 +1,371 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  TASK_INTAKE_APPROVAL_VERSION,
+  TASK_INTAKE_DEFAULT_TIMEOUT_MS,
+  TASK_INTAKE_MIN_TIMEOUT_MS,
+  TASK_INTAKE_MAX_TIMEOUT_MS,
+  TaskIntakeApprovalError,
+  TaskIntakeGate,
+  computeTaskIntakeDigest,
+  evaluateIntakeGate,
+  validateTaskIntakePolicy,
+  validateTaskIntakeRequest,
+} from "../../packages/core/src/task-intake-approval.js"
+import type {
+  TaskIntakePolicy,
+  TaskIntakeRequest,
+  TaskIntakeDecision,
+} from "../../packages/core/src/task-intake-approval.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeClock(iso?: string): () => Date {
+  let t = iso ? new Date(iso).getTime() : Date.now()
+  return () => new Date(t++)
+}
+
+function makeRequest(overrides?: Partial<TaskIntakeRequest>): TaskIntakeRequest {
+  return {
+    taskId: "task-001",
+    leaseId: "lease-001",
+    leaseExpiresAt: "2025-06-01T01:00:00.000Z",
+    employeeId: "emp-001",
+    runnerId: "runner-001",
+    requestedAt: "2025-06-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// validateTaskIntakePolicy
+// ---------------------------------------------------------------------------
+
+test("validateTaskIntakePolicy: valid policy with requireOwnerApproval true", () => {
+  const policy = validateTaskIntakePolicy({ requireOwnerApproval: true })
+  assert.equal(policy.requireOwnerApproval, true)
+  assert.equal(policy.timeoutMs, undefined)
+})
+
+test("validateTaskIntakePolicy: valid policy with custom timeout", () => {
+  const policy = validateTaskIntakePolicy({
+    requireOwnerApproval: true,
+    timeoutMs: 60_000,
+  })
+  assert.equal(policy.requireOwnerApproval, true)
+  assert.equal(policy.timeoutMs, 60_000)
+})
+
+test("validateTaskIntakePolicy: rejects null", () => {
+  assert.throws(
+    () => validateTaskIntakePolicy(null),
+    (err: unknown) => err instanceof TaskIntakeApprovalError && err.code === "INTAKE_POLICY_INVALID",
+  )
+})
+
+test("validateTaskIntakePolicy: rejects missing requireOwnerApproval", () => {
+  assert.throws(
+    () => validateTaskIntakePolicy({}),
+    (err: unknown) => err instanceof TaskIntakeApprovalError && err.code === "INTAKE_POLICY_INVALID",
+  )
+})
+
+test("validateTaskIntakePolicy: rejects timeoutMs below minimum", () => {
+  assert.throws(
+    () => validateTaskIntakePolicy({ requireOwnerApproval: true, timeoutMs: 1_000 }),
+    (err: unknown) => err instanceof TaskIntakeApprovalError && err.code === "INTAKE_POLICY_INVALID",
+  )
+})
+
+test("validateTaskIntakePolicy: rejects timeoutMs above maximum", () => {
+  assert.throws(
+    () => validateTaskIntakePolicy({ requireOwnerApproval: true, timeoutMs: 9_999_999 }),
+    (err: unknown) => err instanceof TaskIntakeApprovalError && err.code === "INTAKE_POLICY_INVALID",
+  )
+})
+
+// ---------------------------------------------------------------------------
+// validateTaskIntakeRequest
+// ---------------------------------------------------------------------------
+
+test("validateTaskIntakeRequest: valid request", () => {
+  const request = validateTaskIntakeRequest(makeRequest())
+  assert.equal(request.taskId, "task-001")
+  assert.equal(request.leaseId, "lease-001")
+})
+
+test("validateTaskIntakeRequest: rejects null", () => {
+  assert.throws(
+    () => validateTaskIntakeRequest(null),
+    (err: unknown) => err instanceof TaskIntakeApprovalError && err.code === "INTAKE_REQUEST_INVALID",
+  )
+})
+
+test("validateTaskIntakeRequest: rejects empty taskId", () => {
+  assert.throws(
+    () => validateTaskIntakeRequest({ ...makeRequest(), taskId: "" }),
+    (err: unknown) => err instanceof TaskIntakeApprovalError && err.code === "INTAKE_REQUEST_INVALID",
+  )
+})
+
+// ---------------------------------------------------------------------------
+// evaluateIntakeGate
+// ---------------------------------------------------------------------------
+
+test("evaluateIntakeGate: returns requiresApproval false when policy auto-accepts", () => {
+  const result = evaluateIntakeGate({ requireOwnerApproval: false })
+  assert.equal(result.requiresApproval, false)
+})
+
+test("evaluateIntakeGate: returns requiresApproval true when policy requires approval", () => {
+  const result = evaluateIntakeGate({ requireOwnerApproval: true })
+  assert.equal(result.requiresApproval, true)
+})
+
+// ---------------------------------------------------------------------------
+// computeTaskIntakeDigest
+// ---------------------------------------------------------------------------
+
+test("computeTaskIntakeDigest: deterministic", () => {
+  const d1 = computeTaskIntakeDigest("t1", "l1", "pending", "2025-01-01T00:00:00.000Z")
+  const d2 = computeTaskIntakeDigest("t1", "l1", "pending", "2025-01-01T00:00:00.000Z")
+  assert.equal(d1, d2)
+  assert.equal(d1.length, 64)
+})
+
+test("computeTaskIntakeDigest: changes with state", () => {
+  const d1 = computeTaskIntakeDigest("t1", "l1", "pending", "2025-01-01T00:00:00.000Z")
+  const d2 = computeTaskIntakeDigest("t1", "l1", "approved", "2025-01-01T00:00:00.000Z")
+  assert.notEqual(d1, d2)
+})
+
+// ---------------------------------------------------------------------------
+// TaskIntakeGate: auto-accept (default behavior)
+// ---------------------------------------------------------------------------
+
+test("TaskIntakeGate: auto-accepts when policy does not require approval", () => {
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: false },
+    clock: fakeClock("2025-06-01T00:00:00.000Z"),
+  })
+  const record = gate.submit(makeRequest())
+  assert.equal(record.state, "auto_accepted")
+  assert.equal(record.decidedBy, "policy:auto_accept")
+  assert.equal(record.version, TASK_INTAKE_APPROVAL_VERSION)
+  assert.equal(gate.canLaunch("task-001"), true)
+})
+
+// ---------------------------------------------------------------------------
+// TaskIntakeGate: pending / approve / decline
+// ---------------------------------------------------------------------------
+
+test("TaskIntakeGate: holds task as pending when approval required", () => {
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: true },
+    clock: fakeClock("2025-06-01T00:00:00.000Z"),
+  })
+  const record = gate.submit(makeRequest())
+  assert.equal(record.state, "pending")
+  assert.equal(record.decidedAt, null)
+  assert.equal(record.decidedBy, null)
+  assert.equal(gate.canLaunch("task-001"), false)
+})
+
+test("TaskIntakeGate: approve transitions pending to approved", () => {
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: true },
+    clock: fakeClock("2025-06-01T00:00:00.000Z"),
+  })
+  gate.submit(makeRequest())
+  const record = gate.decide({
+    taskId: "task-001",
+    approved: true,
+    decidedBy: "owner:alice",
+    reason: "looks good",
+  })
+  assert.equal(record.state, "approved")
+  assert.equal(record.decidedBy, "owner:alice")
+  assert.equal(record.reason, "looks good")
+  assert.equal(gate.canLaunch("task-001"), true)
+})
+
+test("TaskIntakeGate: decline transitions pending to declined", () => {
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: true },
+    clock: fakeClock("2025-06-01T00:00:00.000Z"),
+  })
+  gate.submit(makeRequest())
+  const record = gate.decide({
+    taskId: "task-001",
+    approved: false,
+    decidedBy: "owner:alice",
+  })
+  assert.equal(record.state, "declined")
+  assert.equal(gate.canLaunch("task-001"), false)
+})
+
+// ---------------------------------------------------------------------------
+// TaskIntakeGate: expiry
+// ---------------------------------------------------------------------------
+
+test("TaskIntakeGate: pending task expires on timeout", () => {
+  let t = new Date("2025-06-01T00:00:00.000Z").getTime()
+  const clock = () => new Date(t)
+
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: true, timeoutMs: 60_000 },
+    clock,
+  })
+  gate.submit(makeRequest())
+
+  // Advance past timeout
+  t += 61_000
+  const expired = gate.expirePending()
+  assert.deepEqual(expired, ["task-001"])
+
+  const record = gate.get("task-001")!
+  assert.equal(record.state, "expired")
+  assert.equal(record.decidedBy, "system:timeout")
+  assert.equal(gate.canLaunch("task-001"), false)
+})
+
+test("TaskIntakeGate: decide after expiry throws INTAKE_EXPIRED", () => {
+  let t = new Date("2025-06-01T00:00:00.000Z").getTime()
+  const clock = () => new Date(t)
+
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: true, timeoutMs: 60_000 },
+    clock,
+  })
+  gate.submit(makeRequest())
+
+  // Advance past timeout
+  t += 61_000
+  assert.throws(
+    () => gate.decide({ taskId: "task-001", approved: true, decidedBy: "owner:bob" }),
+    (err: unknown) => err instanceof TaskIntakeApprovalError && err.code === "INTAKE_EXPIRED",
+  )
+})
+
+test("TaskIntakeGate: expiry uses min of policy timeout and lease expiry", () => {
+  let t = new Date("2025-06-01T00:00:00.000Z").getTime()
+  const clock = () => new Date(t)
+
+  // Lease expires in 30s, but policy timeout is 5 minutes
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: true, timeoutMs: 300_000 },
+    clock,
+  })
+  gate.submit(makeRequest({ leaseExpiresAt: "2025-06-01T00:00:30.000Z" }))
+
+  // After 31s the lease-based expiry should trigger
+  t += 31_000
+  const expired = gate.expirePending()
+  assert.deepEqual(expired, ["task-001"])
+})
+
+// ---------------------------------------------------------------------------
+// TaskIntakeGate: error paths
+// ---------------------------------------------------------------------------
+
+test("TaskIntakeGate: duplicate submit throws INTAKE_ALREADY_DECIDED", () => {
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: true },
+    clock: fakeClock("2025-06-01T00:00:00.000Z"),
+  })
+  gate.submit(makeRequest())
+  assert.throws(
+    () => gate.submit(makeRequest()),
+    (err: unknown) => err instanceof TaskIntakeApprovalError && err.code === "INTAKE_ALREADY_DECIDED",
+  )
+})
+
+test("TaskIntakeGate: decide on unknown task throws INTAKE_NOT_FOUND", () => {
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: true },
+    clock: fakeClock("2025-06-01T00:00:00.000Z"),
+  })
+  assert.throws(
+    () => gate.decide({ taskId: "unknown", approved: true, decidedBy: "owner:x" }),
+    (err: unknown) => err instanceof TaskIntakeApprovalError && err.code === "INTAKE_NOT_FOUND",
+  )
+})
+
+test("TaskIntakeGate: decide twice on same task throws INTAKE_ALREADY_DECIDED", () => {
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: true },
+    clock: fakeClock("2025-06-01T00:00:00.000Z"),
+  })
+  gate.submit(makeRequest())
+  gate.decide({ taskId: "task-001", approved: true, decidedBy: "owner:x" })
+  assert.throws(
+    () => gate.decide({ taskId: "task-001", approved: false, decidedBy: "owner:x" }),
+    (err: unknown) => err instanceof TaskIntakeApprovalError && err.code === "INTAKE_ALREADY_DECIDED",
+  )
+})
+
+// ---------------------------------------------------------------------------
+// TaskIntakeGate: events (AC-002 observability)
+// ---------------------------------------------------------------------------
+
+test("TaskIntakeGate: emits state change events", () => {
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: true },
+    clock: fakeClock("2025-06-01T00:00:00.000Z"),
+  })
+  gate.submit(makeRequest())
+  gate.decide({ taskId: "task-001", approved: true, decidedBy: "owner:x" })
+
+  const events = gate.drainEvents()
+  assert.equal(events.length, 2)
+  assert.equal(events[0].type, "task_intake.state_change")
+  assert.equal(events[0].previousState, null)
+  assert.equal(events[0].newState, "pending")
+  assert.equal(events[1].previousState, "pending")
+  assert.equal(events[1].newState, "approved")
+  assert.equal(events[0].version, TASK_INTAKE_APPROVAL_VERSION)
+  // Digest should be a 64-char hex string
+  assert.match(events[0].digest, /^[a-f0-9]{64}$/)
+})
+
+test("TaskIntakeGate: drainEvents empties the queue", () => {
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: false },
+    clock: fakeClock("2025-06-01T00:00:00.000Z"),
+  })
+  gate.submit(makeRequest())
+  assert.equal(gate.drainEvents().length, 1)
+  assert.equal(gate.drainEvents().length, 0)
+})
+
+// ---------------------------------------------------------------------------
+// TaskIntakeGate: pendingCount
+// ---------------------------------------------------------------------------
+
+test("TaskIntakeGate: pendingCount reflects pending tasks", () => {
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: true },
+    clock: fakeClock("2025-06-01T00:00:00.000Z"),
+  })
+  assert.equal(gate.pendingCount(), 0)
+  gate.submit(makeRequest({ taskId: "t1" }))
+  gate.submit(makeRequest({ taskId: "t2" }))
+  assert.equal(gate.pendingCount(), 2)
+  gate.decide({ taskId: "t1", approved: true, decidedBy: "owner:x" })
+  assert.equal(gate.pendingCount(), 1)
+})
+
+// ---------------------------------------------------------------------------
+// TaskIntakeGate: get returns null for unknown
+// ---------------------------------------------------------------------------
+
+test("TaskIntakeGate: get returns null for unknown task", () => {
+  const gate = new TaskIntakeGate({
+    policy: { requireOwnerApproval: true },
+    clock: fakeClock("2025-06-01T00:00:00.000Z"),
+  })
+  assert.equal(gate.get("nonexistent"), null)
+})


### PR DESCRIPTION
## Summary

- Implements the task-intake approval gate from #49 — the "向上请示" principle requiring owner confirmation before a digital employee accepts a task.
- Adds `TaskIntakeGate` class in Runner policy layer with full lifecycle: submit, decide (approve/decline), expire, and observable state-change events.
- Defaults to auto-accept when `requireOwnerApproval` is false (backward compatible, AC-001).
- Unapproved tasks cannot launch Host runs; approval, decline, and timeout paths are all observable via `TaskIntakeEvent` (AC-002).
- Works entirely offline/locally with no inbound port or platform-held state (AC-003).

## Test plan

- [x] 27 new unit tests covering: policy validation, request validation, auto-accept path, pending/approve/decline lifecycle, expiry (policy timeout and lease-based), error paths, event emission, and pending count.
- [x] All 426 existing tests continue to pass.
- [x] TypeScript typecheck passes (only pre-existing unrelated error in apps/cli/setup.ts).

Closes #49