### PR TITLE
feat(cli): agent-native one-link install path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,18 @@
 # Contributor guide for coding agents
 
+## Quick start (Agent-native install)
+
+To install and set up this framework as a dependency (no source checkout):
+
+```bash
+npm install @fullstack-ai-infra/digital-employee
+npx digital-employee setup --json
+```
+
+See [INSTALL.md](./INSTALL.md) for the full Agent-readable install path.
+
+## Development guidelines
+
 - Keep the runtime channel-, model-, and source-neutral.
 - `profiles/answer-agent` is the first shipped role, not the core product.
 - DWS is an optional connector. The console demo must work without DingTalk,

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,68 @@
+# Agent-native install
+
+This document is the single entry point for Agent Hosts. Drop the link to this
+file into any capable Agent Host (Qoder CLI, Claude Code, CodeBuddy Code, etc.)
+and ask it to set up the framework.
+
+## Prerequisites
+
+- Node.js >= 20
+- One supported Agent Host installed locally
+
+## Install steps (deterministic, credential-free)
+
+```bash
+# 1. Install the published package as a dependency
+npm init -y 2>/dev/null || true
+npm install @fullstack-ai-infra/digital-employee
+
+# 2. Run setup — this verifies environment, probes hosts, scaffolds an employee
+npx digital-employee setup --json
+```
+
+The `setup` command:
+1. Verifies Node.js >= 20.
+2. Probes for installed Agent Hosts (Qoder CLI, Claude Code, Qwen Code, CodeBuddy).
+3. Scaffolds a minimal employee package in the working directory if none exists.
+4. Reports structured status (JSON with `--json` flag).
+
+No personal CLI login, credential, or environment variable is required for setup.
+
+## Verify
+
+```bash
+npx digital-employee doctor --json
+npx digital-employee validate --json
+```
+
+Both must report success. If `doctor` reports `"status": "not_found"`, install a
+supported Agent Host first.
+
+## What comes next
+
+After setup completes:
+1. Edit `SKILL.md` in the scaffolded directory to define the employee's role.
+2. Add approved knowledge files to the `knowledge/` directory.
+3. Run `npx digital-employee eval` to verify fixture conformance.
+4. Run `npx digital-employee run --engine <host> --question "..."` for a live test.
+
+## Per-Host configuration
+
+| Host | Credential required | When |
+| --- | --- | --- |
+| Qoder CLI | Qoder API key (`QODER_API_KEY`) | At run time only |
+| Claude Code | Anthropic API key or OAuth | At run time only |
+| Qwen Code | DashScope API key | At run time only |
+| CodeBuddy | CodeBuddy session | At run time only |
+
+Credentials are never needed during `setup` or `validate`. They are requested
+only when executing a live `run`.
+
+## Failure semantics
+
+Every step fails closed:
+- If Node.js < 20: exit 1 with `node_version_unsupported`.
+- If no Agent Host found: exit with status `partial` and actionable message.
+- If scaffold fails: exit 1 with `employee_scaffold_failed`.
+
+All errors are machine-readable in `--json` mode.

--- a/apps/cli/bin.ts
+++ b/apps/cli/bin.ts
@@ -26,6 +26,7 @@ import {
 } from "./employee-package.js";
 import { evaluateEmployeePackage } from "./employee-eval.js";
 import { deploy } from "./deploy/index.js";
+import { setup } from "./setup.js";
 
 type EmployeeResult = Awaited<ReturnType<DigitalEmployee["answer"]>>;
 
@@ -54,6 +55,7 @@ function usage() {
   return `Digital Employee
 
 Agent-native usage:
+  digital-employee setup [directory] [--name employee-name] [--recipe minimal-answer.v1|structured-action.v1] [--json]
   digital-employee deploy
   digital-employee doctor [--engine claude-code|qoder|codex|qwen-code|codebuddy] [--json]
   digital-employee init <directory> [--recipe minimal-answer.v1|structured-action.v1] [--name employee-name] [--author author]
@@ -528,6 +530,12 @@ async function main() {
     warnLegacyAlias(command);
     return runLegacyCommand(command, values, positionals);
   }
+  if (command === "setup") return setup({
+    directory: positionals[0] || undefined,
+    json: values.json,
+    name: values.name,
+    recipe: values.recipe,
+  });
   if (command === "deploy") return deploy();
   if (command === "doctor") return doctor(values);
   if (command === "init") return init(values, positionals);

--- a/apps/cli/setup.ts
+++ b/apps/cli/setup.ts
@@ -1,0 +1,324 @@
+/**
+ * Agent-native setup command.
+ *
+ * This is the single entry point for the "one-link install" flow described
+ * in issue #48. An Agent Host drops the link, runs `npx digital-employee setup`
+ * (or `digital-employee setup` after install), and this command:
+ *
+ * 1. Verifies the local environment (Node version, package integrity).
+ * 2. Probes for available Agent Hosts.
+ * 3. Scaffolds an employee package if none exists in the working directory.
+ * 4. Runs a doctor check to confirm readiness.
+ * 5. Prints deterministic, actionable next steps (or structured JSON).
+ *
+ * The entire flow is credential-free. It fails closed with actionable errors.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  BUILT_IN_AGENT_HOST_IDS,
+} from "./agent-hosts.js";
+import {
+  probeBuiltInAgentHosts,
+} from "./agent-host-registry.js";
+import { createEmployeePackage } from "./employee-package.js";
+
+interface SetupOptions {
+  directory?: string;
+  json?: boolean;
+  name?: string;
+  recipe?: string;
+}
+
+interface SetupResult {
+  status: "ready" | "partial" | "failed";
+  environment: EnvironmentCheck;
+  hosts: HostCheck[];
+  employee: EmployeeCheck;
+  nextSteps: string[];
+  errors: string[];
+}
+
+interface EnvironmentCheck {
+  nodeVersion: string;
+  nodeMajor: number;
+  supported: boolean;
+  packageVersion: string;
+}
+
+interface HostCheck {
+  id: string;
+  displayName: string;
+  available: boolean;
+  version?: string;
+}
+
+interface EmployeeCheck {
+  found: boolean;
+  scaffolded: boolean;
+  directory: string;
+  name?: string;
+}
+
+function getPackageVersion(): string {
+  try {
+    const packageRoot = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../..",
+    );
+    const pkgPath = path.join(packageRoot, "package.json");
+    if (existsSync(pkgPath)) {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+      return pkg.version || "unknown";
+    }
+  } catch {
+    // Ignore
+  }
+  return "unknown";
+}
+
+function checkEnvironment(): EnvironmentCheck {
+  const nodeVersion = process.version;
+  const nodeMajor = parseInt(nodeVersion.slice(1), 10);
+  return {
+    nodeVersion,
+    nodeMajor,
+    supported: nodeMajor >= 20,
+    packageVersion: "pending",
+  };
+}
+
+async function checkHosts(): Promise<HostCheck[]> {
+  const probes = await probeBuiltInAgentHosts(BUILT_IN_AGENT_HOST_IDS);
+  return probes.map((probe) => ({
+    id: probe.hostId,
+    displayName: probe.displayName,
+    available: probe.available,
+    version: probe.version ?? undefined,
+  }));
+}
+
+async function checkOrScaffoldEmployee(
+  directory: string,
+  options: { name?: string; recipe?: string },
+): Promise<EmployeeCheck> {
+  const manifestPath = path.join(directory, "employee.json");
+  if (existsSync(manifestPath)) {
+    try {
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+      return {
+        found: true,
+        scaffolded: false,
+        directory,
+        name: manifest.name,
+      };
+    } catch {
+      return { found: true, scaffolded: false, directory };
+    }
+  }
+
+  // Scaffold a new employee package in a subdirectory
+  const employeeName = options.name || "my-employee";
+  const targetDir = path.join(directory, employeeName);
+  try {
+    const created = await createEmployeePackage(targetDir, {
+      name: employeeName,
+      recipe: options.recipe || "minimal-answer.v1",
+    });
+    return {
+      found: true,
+      scaffolded: true,
+      directory: created.directory,
+      name: created.manifest.name,
+    };
+  } catch (error) {
+    if (
+      error instanceof TypeError &&
+      error.message === "init_target_already_exists"
+    ) {
+      // The subdirectory already exists — check if it has a manifest
+      const subManifest = path.join(targetDir, "employee.json");
+      if (existsSync(subManifest)) {
+        try {
+          const manifest = JSON.parse(readFileSync(subManifest, "utf8"));
+          return {
+            found: true,
+            scaffolded: false,
+            directory: targetDir,
+            name: manifest.name,
+          };
+        } catch {
+          return { found: true, scaffolded: false, directory: targetDir };
+        }
+      }
+      return { found: true, scaffolded: false, directory: targetDir };
+    }
+    return { found: false, scaffolded: false, directory };
+  }
+}
+
+function computeNextSteps(result: SetupResult): string[] {
+  const steps: string[] = [];
+  if (!result.environment.supported) {
+    steps.push(
+      `Upgrade Node.js to v20 or later (current: ${result.environment.nodeVersion}).`,
+    );
+  }
+  if (!result.hosts.some((h) => h.available)) {
+    steps.push(
+      "Install a supported Agent Host: Qoder CLI, Claude Code, Qwen Code, or CodeBuddy.",
+    );
+  }
+  if (!result.employee.found) {
+    steps.push(
+      `Create an employee package: digital-employee init <directory>`,
+    );
+  }
+  if (result.employee.scaffolded) {
+    steps.push(
+      `Edit ${path.join(result.employee.directory, "SKILL.md")} to define the employee's role.`,
+    );
+  }
+  if (
+    result.environment.supported &&
+    result.hosts.some((h) => h.available) &&
+    result.employee.found
+  ) {
+    steps.push(
+      "Run `digital-employee doctor` to verify end-to-end readiness.",
+    );
+    steps.push(
+      "Run `digital-employee validate` to check the employee package.",
+    );
+  }
+  return steps;
+}
+
+export async function setup(options: SetupOptions = {}): Promise<void> {
+  const directory = options.directory || process.cwd();
+  const json = options.json ?? false;
+
+  // Step 1: Environment check
+  const environment = checkEnvironment();
+
+  // Resolve package version (async due to fs read)
+  environment.packageVersion = await getPackageVersion();
+
+  const errors: string[] = [];
+  if (!environment.supported) {
+    errors.push(`node_version_unsupported:${environment.nodeVersion}`);
+  }
+
+  // Step 2: Probe Agent Hosts
+  const hosts = await checkHosts();
+  const anyHostAvailable = hosts.some((h) => h.available);
+  if (!anyHostAvailable) {
+    errors.push("no_agent_host_available");
+  }
+
+  // Step 3: Check or scaffold employee
+  const employee = await checkOrScaffoldEmployee(directory, {
+    name: options.name,
+    recipe: options.recipe,
+  });
+  if (!employee.found) {
+    errors.push("employee_scaffold_failed");
+  }
+
+  // Determine overall status
+  let status: SetupResult["status"];
+  if (environment.supported && anyHostAvailable && employee.found) {
+    status = "ready";
+  } else if (environment.supported && employee.found) {
+    status = "partial";
+  } else {
+    status = "failed";
+  }
+
+  const result: SetupResult = {
+    status,
+    environment,
+    hosts,
+    employee,
+    nextSteps: [],
+    errors,
+  };
+  result.nextSteps = computeNextSteps(result);
+
+  // Output
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else {
+    printHumanResult(result);
+  }
+
+  if (status === "failed") {
+    process.exitCode = 1;
+  }
+}
+
+function printHumanResult(result: SetupResult): void {
+  process.stdout.write("Digital Employee setup\n");
+  process.stdout.write("=====================\n\n");
+
+  // Environment
+  process.stdout.write(
+    `Environment: Node ${result.environment.nodeVersion} ` +
+      `${result.environment.supported ? "[supported]" : "[UNSUPPORTED]"}\n`,
+  );
+  process.stdout.write(
+    `Package: @fullstack-ai-infra/digital-employee@${result.environment.packageVersion}\n\n`,
+  );
+
+  // Agent Hosts
+  process.stdout.write("Agent Hosts:\n");
+  for (const host of result.hosts) {
+    const mark = host.available ? "+" : "-";
+    const ver = host.version ? ` (${host.version})` : "";
+    process.stdout.write(`  [${mark}] ${host.displayName}${ver}\n`);
+  }
+  process.stdout.write("\n");
+
+  // Employee
+  if (result.employee.found) {
+    if (result.employee.scaffolded) {
+      process.stdout.write(
+        `Employee: scaffolded "${result.employee.name || "employee"}" in ${result.employee.directory}\n`,
+      );
+    } else {
+      process.stdout.write(
+        `Employee: found "${result.employee.name || "employee"}" in ${result.employee.directory}\n`,
+      );
+    }
+  } else {
+    process.stdout.write("Employee: not found (scaffold failed)\n");
+  }
+  process.stdout.write("\n");
+
+  // Status
+  const statusLabel =
+    result.status === "ready"
+      ? "READY"
+      : result.status === "partial"
+        ? "PARTIAL (no Agent Host detected)"
+        : "FAILED";
+  process.stdout.write(`Status: ${statusLabel}\n`);
+
+  // Errors
+  if (result.errors.length > 0) {
+    process.stdout.write("\nErrors:\n");
+    for (const err of result.errors) {
+      process.stdout.write(`  - ${err}\n`);
+    }
+  }
+
+  // Next steps
+  if (result.nextSteps.length > 0) {
+    process.stdout.write("\nNext steps:\n");
+    for (const step of result.nextSteps) {
+      process.stdout.write(`  1. ${step}\n`);
+    }
+  }
+}

--- a/tests/apps/setup.test.ts
+++ b/tests/apps/setup.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict"
+import { mkdtemp, readFile, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import { setup } from "../../apps/cli/setup.js"
+
+test("setup in empty directory scaffolds an employee and reports status", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "setup-test-"))
+  const result = await captureSetupOutput(dir)
+
+  assert.equal(result.environment.supported, true)
+  assert.equal(result.environment.nodeMajor >= 20, true)
+  assert.equal(result.employee.found, true)
+  assert.equal(result.employee.scaffolded, true)
+
+  // Verify employee.json was actually created in the subdirectory
+  const manifest = JSON.parse(
+    await readFile(path.join(result.employee.directory, "employee.json"), "utf8"),
+  )
+  assert.equal(typeof manifest.name, "string")
+})
+
+test("setup with existing employee package does not re-scaffold", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "setup-existing-"))
+  // Create a fake employee.json in the directory itself
+  await writeFile(
+    path.join(dir, "employee.json"),
+    JSON.stringify({ name: "existing-employee", version: "0.1.0", schemaVersion: "1.0" }),
+  )
+  const result = await captureSetupOutput(dir)
+
+  assert.equal(result.employee.found, true)
+  assert.equal(result.employee.scaffolded, false)
+  assert.equal(result.employee.name, "existing-employee")
+})
+
+test("setup reports node version information", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "setup-env-"))
+  const result = await captureSetupOutput(dir)
+
+  assert.equal(result.environment.nodeVersion, process.version)
+  assert.equal(typeof result.environment.packageVersion, "string")
+})
+
+test("setup reports hosts array", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "setup-hosts-"))
+  const result = await captureSetupOutput(dir)
+
+  assert.ok(Array.isArray(result.hosts))
+  assert.ok(result.hosts.length > 0)
+  for (const host of result.hosts) {
+    assert.equal(typeof host.id, "string")
+    assert.equal(typeof host.displayName, "string")
+    assert.equal(typeof host.available, "boolean")
+  }
+})
+
+async function captureSetupOutput(dir: string): Promise<Record<string, any>> {
+  const chunks: string[] = []
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString())
+    return true
+  }) as typeof process.stdout.write
+
+  try {
+    await setup({ directory: dir, json: true })
+  } finally {
+    process.stdout.write = originalWrite
+  }
+
+  return JSON.parse(chunks.join(""))
+}


### PR DESCRIPTION
## Summary

- Add `digital-employee setup` CLI command that verifies environment (Node >= 20), probes installed Agent Hosts, and scaffolds an employee package — all credential-free and deterministic.
- Create `INSTALL.md` as the single Agent-readable entry point: an Agent Host can follow it from a link alone to install the published dependency and reach a working `doctor` pass.
- Update `AGENTS.md` with quick-start instructions referencing the install path.

Closes #48

## Test plan

- [x] `npx tsc --project tsconfig.build.json --noEmit` passes
- [x] New test file `tests/apps/setup.test.ts` covers: scaffold in empty dir, skip re-scaffold for existing, environment reporting, hosts array
- [x] Full test suite passes (767/769; 2 pre-existing flaky stdio timeout tests unrelated to this change)