### PR TITLE
fix: reject unknown capability keys in probe validation

### DIFF
--- a/connectors/sources/doc/index.ts
+++ b/connectors/sources/doc/index.ts
@@ -1,0 +1,225 @@
+/**
+ * Real-local doc MCP knowledge source connector (Phase A, Issue #42).
+ *
+ * Exercises version-addressed document reads through an actual pinned local doc
+ * service. All decisions use the REAL_LOCAL_CODES namespace.
+ */
+import { CoreError } from "../../../packages/core/src/contracts.js"
+import {
+  REAL_LOCAL_CODES,
+  requireMatrixComponent,
+} from "../../../packages/core/src/component-matrix.js"
+import type {
+  ComponentMatrix,
+  ComponentMatrixEntry,
+} from "../../../packages/core/src/component-matrix.js"
+import type {
+  CapabilityGrantSet,
+  CapabilityScope,
+  DocumentReadItem,
+} from "../../../packages/core/src/mcp-conformance.js"
+
+export const DOC_CONTRACT = "document-read.v1" as const
+export const DOC_COMPONENT_NAME = "doc" as const
+
+export interface DocSourceOptions {
+  matrix: ComponentMatrix
+  grants: CapabilityGrantSet
+  principal: string
+  workspace: string
+  /** Override fetch for testing */
+  fetchImpl?: typeof globalThis.fetch
+}
+
+export interface DocHealthResult {
+  available: boolean
+  version?: string
+  error?: string
+}
+
+function realLocalError(code: string, details?: unknown): CoreError {
+  return new CoreError(code, `real-local doc decision: ${code}`, {
+    status: 400,
+    retryable: false,
+    details,
+  })
+}
+
+function checkGrant(
+  grants: CapabilityGrantSet,
+  principal: string,
+  workspace: string,
+): void {
+  const entry = grants.grants.find((g) => g.server === DOC_COMPONENT_NAME)
+  if (!entry) {
+    throw realLocalError(REAL_LOCAL_CODES.grantMissing, {
+      server: DOC_COMPONENT_NAME,
+    })
+  }
+  if (entry.revoked) {
+    throw realLocalError(REAL_LOCAL_CODES.grantRevoked, {
+      server: DOC_COMPONENT_NAME,
+    })
+  }
+  if (entry.mode !== "read") {
+    throw realLocalError(REAL_LOCAL_CODES.modeExcessive, {
+      server: DOC_COMPONENT_NAME,
+    })
+  }
+  const scoped = entry.scopes.some(
+    (scope: CapabilityScope) =>
+      scope.principal === principal && scope.workspace === workspace,
+  )
+  if (!scoped) {
+    throw realLocalError(REAL_LOCAL_CODES.scopeDenied, {
+      server: DOC_COMPONENT_NAME,
+      principal,
+      workspace,
+    })
+  }
+}
+
+/**
+ * Read-only doc MCP source that connects to an actual pinned local doc service.
+ */
+export class DocKnowledgeSource {
+  readonly component: ComponentMatrixEntry
+  readonly grants: CapabilityGrantSet
+  readonly principal: string
+  readonly workspace: string
+  readonly baseUrl: string
+  private readonly fetchFn: typeof globalThis.fetch
+
+  constructor(options: DocSourceOptions) {
+    this.component = requireMatrixComponent(
+      options.matrix,
+      DOC_COMPONENT_NAME,
+      DOC_CONTRACT,
+    )
+    this.grants = options.grants
+    this.principal = options.principal
+    this.workspace = options.workspace
+    const port = this.component.ports["http"]
+    if (!port) {
+      throw realLocalError(REAL_LOCAL_CODES.matrixUnsupported, {
+        reason: "no http port in matrix",
+      })
+    }
+    this.baseUrl = `http://127.0.0.1:${port}`
+    this.fetchFn = options.fetchImpl ?? globalThis.fetch
+  }
+
+  /**
+   * Probes the health endpoint of the pinned doc service.
+   */
+  async health(): Promise<DocHealthResult> {
+    try {
+      const response = await this.fetchFn(
+        `${this.baseUrl}${this.component.healthEndpoint}`,
+        { method: "GET", signal: AbortSignal.timeout(5_000) },
+      )
+      if (!response.ok) {
+        return { available: false, error: `status ${response.status}` }
+      }
+      const body = (await response.json()) as Record<string, unknown>
+      return {
+        available: true,
+        version: typeof body.version === "string" ? body.version : undefined,
+      }
+    } catch (error) {
+      return {
+        available: false,
+        error: error instanceof Error ? error.message : "unknown",
+      }
+    }
+  }
+
+  /**
+   * Reads a document at an exact pinned revision. Fails closed on grant, scope,
+   * revocation, unavailability, or revision mismatch errors.
+   */
+  async read(documentId: string, revision: number): Promise<DocumentReadItem> {
+    checkGrant(this.grants, this.principal, this.workspace)
+
+    if (
+      typeof documentId !== "string" ||
+      documentId.length === 0 ||
+      documentId.length > 128
+    ) {
+      throw realLocalError(REAL_LOCAL_CODES.itemUnavailable, { documentId })
+    }
+    if (
+      !Number.isInteger(revision) ||
+      revision < 1
+    ) {
+      throw realLocalError(REAL_LOCAL_CODES.revisionMismatch, {
+        documentId,
+        revision,
+      })
+    }
+
+    let response: Response
+    try {
+      response = await this.fetchFn(
+        `${this.baseUrl}/v1/documents/${encodeURIComponent(this.workspace)}/${encodeURIComponent(documentId)}?revision=${revision}`,
+        {
+          method: "GET",
+          headers: { "Content-Type": "application/json" },
+          signal: AbortSignal.timeout(30_000),
+        },
+      )
+    } catch (error) {
+      throw realLocalError(REAL_LOCAL_CODES.serviceUnavailable, {
+        server: DOC_COMPONENT_NAME,
+        reason: error instanceof Error ? error.message : "fetch_failed",
+      })
+    }
+
+    if (response.status === 404) {
+      throw realLocalError(REAL_LOCAL_CODES.itemUnavailable, { documentId })
+    }
+    if (response.status === 410) {
+      throw realLocalError(REAL_LOCAL_CODES.grantRevoked, { documentId })
+    }
+    if (response.status === 409) {
+      throw realLocalError(REAL_LOCAL_CODES.revisionMismatch, {
+        documentId,
+        revision,
+      })
+    }
+    if (!response.ok) {
+      throw realLocalError(REAL_LOCAL_CODES.serviceUnavailable, {
+        server: DOC_COMPONENT_NAME,
+        status: response.status,
+      })
+    }
+
+    const body = (await response.json()) as Record<string, unknown>
+    if (
+      typeof body.id !== "string" ||
+      typeof body.title !== "string" ||
+      typeof body.body !== "string" ||
+      typeof body.revision !== "number"
+    ) {
+      throw realLocalError(REAL_LOCAL_CODES.serviceUnavailable, {
+        server: DOC_COMPONENT_NAME,
+        reason: "invalid_response_shape",
+      })
+    }
+
+    if (body.revision !== revision) {
+      throw realLocalError(REAL_LOCAL_CODES.revisionMismatch, {
+        documentId,
+        requested: revision,
+        actual: body.revision,
+      })
+    }
+
+    return {
+      locator: `doc://${this.workspace}/${body.id}@${body.revision}`,
+      title: body.title,
+      body: body.body,
+      revision: body.revision,
+    }
+  }
+}

--- a/connectors/sources/mem/index.ts
+++ b/connectors/sources/mem/index.ts
@@ -1,0 +1,192 @@
+/**
+ * Real-local mem MCP knowledge source connector (Phase A, Issue #42).
+ *
+ * Exercises scoped memory recall through an actual pinned local mem service
+ * using the durable-context.v1 contract. All decisions use the REAL_LOCAL_CODES
+ * namespace; synthetic codes are never reused.
+ */
+import { CoreError } from "../../../packages/core/src/contracts.js"
+import {
+  REAL_LOCAL_CODES,
+  requireMatrixComponent,
+} from "../../../packages/core/src/component-matrix.js"
+import type {
+  ComponentMatrix,
+  ComponentMatrixEntry,
+} from "../../../packages/core/src/component-matrix.js"
+import type {
+  CapabilityGrantSet,
+  CapabilityScope,
+  MemoryRecallItem,
+} from "../../../packages/core/src/mcp-conformance.js"
+
+export const MEM_CONTRACT = "durable-context.v1" as const
+export const MEM_COMPONENT_NAME = "mem" as const
+
+export interface MemSourceOptions {
+  matrix: ComponentMatrix
+  grants: CapabilityGrantSet
+  principal: string
+  workspace: string
+  /** Override fetch for testing */
+  fetchImpl?: typeof globalThis.fetch
+}
+
+export interface MemHealthResult {
+  available: boolean
+  version?: string
+  error?: string
+}
+
+function realLocalError(code: string, details?: unknown): CoreError {
+  return new CoreError(code, `real-local mem decision: ${code}`, {
+    status: 400,
+    retryable: false,
+    details,
+  })
+}
+
+function checkGrant(
+  grants: CapabilityGrantSet,
+  principal: string,
+  workspace: string,
+): void {
+  const entry = grants.grants.find((g) => g.server === MEM_COMPONENT_NAME)
+  if (!entry) {
+    throw realLocalError(REAL_LOCAL_CODES.grantMissing, {
+      server: MEM_COMPONENT_NAME,
+    })
+  }
+  if (entry.revoked) {
+    throw realLocalError(REAL_LOCAL_CODES.grantRevoked, {
+      server: MEM_COMPONENT_NAME,
+    })
+  }
+  if (entry.mode !== "read") {
+    throw realLocalError(REAL_LOCAL_CODES.modeExcessive, {
+      server: MEM_COMPONENT_NAME,
+    })
+  }
+  const scoped = entry.scopes.some(
+    (scope: CapabilityScope) =>
+      scope.principal === principal && scope.workspace === workspace,
+  )
+  if (!scoped) {
+    throw realLocalError(REAL_LOCAL_CODES.scopeDenied, {
+      server: MEM_COMPONENT_NAME,
+      principal,
+      workspace,
+    })
+  }
+}
+
+/**
+ * Read-only mem MCP source that connects to an actual pinned local mem service.
+ */
+export class MemKnowledgeSource {
+  readonly component: ComponentMatrixEntry
+  readonly grants: CapabilityGrantSet
+  readonly principal: string
+  readonly workspace: string
+  readonly baseUrl: string
+  private readonly fetchFn: typeof globalThis.fetch
+
+  constructor(options: MemSourceOptions) {
+    this.component = requireMatrixComponent(
+      options.matrix,
+      MEM_COMPONENT_NAME,
+      MEM_CONTRACT,
+    )
+    this.grants = options.grants
+    this.principal = options.principal
+    this.workspace = options.workspace
+    const port = this.component.ports["http"]
+    if (!port) {
+      throw realLocalError(REAL_LOCAL_CODES.matrixUnsupported, {
+        reason: "no http port in matrix",
+      })
+    }
+    this.baseUrl = `http://127.0.0.1:${port}`
+    this.fetchFn = options.fetchImpl ?? globalThis.fetch
+  }
+
+  /**
+   * Probes the health endpoint of the pinned mem service.
+   */
+  async health(): Promise<MemHealthResult> {
+    try {
+      const response = await this.fetchFn(
+        `${this.baseUrl}${this.component.healthEndpoint}`,
+        { method: "GET", signal: AbortSignal.timeout(5_000) },
+      )
+      if (!response.ok) {
+        return { available: false, error: `status ${response.status}` }
+      }
+      const body = (await response.json()) as Record<string, unknown>
+      return {
+        available: true,
+        version: typeof body.version === "string" ? body.version : undefined,
+      }
+    } catch (error) {
+      return {
+        available: false,
+        error: error instanceof Error ? error.message : "unknown",
+      }
+    }
+  }
+
+  /**
+   * Recalls approved, active memories for the granted principal/workspace scope.
+   * Fails closed on any grant, scope, or service error.
+   */
+  async recall(): Promise<MemoryRecallItem[]> {
+    checkGrant(this.grants, this.principal, this.workspace)
+
+    let response: Response
+    try {
+      response = await this.fetchFn(
+        `${this.baseUrl}/v1/context/${encodeURIComponent(this.workspace)}/recall`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ principal: this.principal }),
+          signal: AbortSignal.timeout(30_000),
+        },
+      )
+    } catch (error) {
+      throw realLocalError(REAL_LOCAL_CODES.serviceUnavailable, {
+        server: MEM_COMPONENT_NAME,
+        reason: error instanceof Error ? error.message : "fetch_failed",
+      })
+    }
+
+    if (!response.ok) {
+      throw realLocalError(REAL_LOCAL_CODES.serviceUnavailable, {
+        server: MEM_COMPONENT_NAME,
+        status: response.status,
+      })
+    }
+
+    const body = (await response.json()) as { memories?: unknown[] }
+    if (!Array.isArray(body.memories)) {
+      throw realLocalError(REAL_LOCAL_CODES.serviceUnavailable, {
+        server: MEM_COMPONENT_NAME,
+        reason: "invalid_response_shape",
+      })
+    }
+
+    return body.memories
+      .filter(
+        (entry): entry is Record<string, unknown> =>
+          Boolean(entry) &&
+          typeof entry === "object" &&
+          !Array.isArray(entry) &&
+          (entry as Record<string, unknown>).state === "active" &&
+          (entry as Record<string, unknown>).approved === true,
+      )
+      .map((entry) => ({
+        locator: `mem://${this.workspace}/${entry.id}@${entry.revision}`,
+        text: String(entry.text ?? ""),
+      }))
+  }
+}

--- a/packages/core/src/agent-host-registry.ts
+++ b/packages/core/src/agent-host-registry.ts
@@ -198,6 +198,9 @@ export function validateAgentHostProbeResult(
         ADAPTER_STATUSES.has(value.adapterStatus as string) &&
         (value.version === undefined || boundedString(value.version, 256)) &&
         plainRecord(capabilities) &&
+        Object.keys(capabilities).every((key) =>
+          (AGENT_HOST_CAPABILITIES as readonly string[]).includes(key),
+        ) &&
         AGENT_HOST_CAPABILITIES.every((capability) =>
           CAPABILITY_SUPPORT.has(capabilities[capability] as string),
         ) &&

--- a/packages/core/src/agent-host-wire.ts
+++ b/packages/core/src/agent-host-wire.ts
@@ -156,6 +156,7 @@ export function validateAgentHostProbeWire(
     ADAPTER_STATUSES.has(value.adapterStatus as string) &&
     (value.version === undefined || boundedString(value.version, 256)) &&
     plainRecord(capabilities) &&
+    exactKeys(capabilities, AGENT_HOST_CAPABILITIES as unknown as readonly string[]) &&
     AGENT_HOST_CAPABILITIES.every((capability) =>
       CAPABILITY_SUPPORT.has(capabilities[capability] as string),
     ) &&

--- a/tests/core/agent-host-registry.test.ts
+++ b/tests/core/agent-host-registry.test.ts
@@ -9,7 +9,10 @@ import type {
   AgentHostAdapter,
   AgentHostProbeResult,
 } from "../../packages/core/src/agent-host.js"
-import { AgentHostRegistry } from "../../packages/core/src/agent-host-registry.js"
+import {
+  AgentHostRegistry,
+  validateAgentHostProbeResult,
+} from "../../packages/core/src/agent-host-registry.js"
 import { CoreError } from "../../packages/core/src/contracts.js"
 
 function probe(
@@ -312,4 +315,40 @@ test("registration validates callbacks before changing registry state", () => {
     isCoreError({ code: "INVALID_AGENT_HOST_REGISTRATION", status: 400 }),
   )
   assert.deepEqual(registry.list(), [])
+})
+
+test("validateAgentHostProbeResult rejects unknown top-level fields", () => {
+  const valid = probe("test-host")
+  const withExtra = { ...valid, vendorExtension: "smuggled" }
+  assert.throws(
+    () => validateAgentHostProbeResult(withExtra, "test-host"),
+    isCoreError({ code: "AGENT_HOST_PROBE_INVALID", status: 500 }),
+  )
+})
+
+test("validateAgentHostProbeResult rejects unknown issue fields", () => {
+  const valid = probe("test-host")
+  const withBadIssue = {
+    ...valid,
+    issues: [{ code: "x", message: "m", blocking: false, severity: "high" }],
+  }
+  assert.throws(
+    () => validateAgentHostProbeResult(withBadIssue, "test-host"),
+    isCoreError({ code: "AGENT_HOST_PROBE_INVALID", status: 500 }),
+  )
+})
+
+test("validateAgentHostProbeResult rejects unknown capability keys", () => {
+  const valid = probe("test-host")
+  const withExtraCap = {
+    ...valid,
+    capabilities: {
+      ...valid.capabilities,
+      vendor_extension: "supported",
+    },
+  }
+  assert.throws(
+    () => validateAgentHostProbeResult(withExtraCap, "test-host"),
+    isCoreError({ code: "AGENT_HOST_PROBE_INVALID", status: 500 }),
+  )
 })

--- a/tests/core/agent-host-wire.test.ts
+++ b/tests/core/agent-host-wire.test.ts
@@ -86,6 +86,17 @@ test("probe wire rejects host id mismatch and unknown issue keys", () => {
   assert.throws(() => validateAgentHostProbeWire(probe, "fixture"))
 })
 
+test("probe wire rejects unknown capability keys", () => {
+  const probe = readyProbe()
+  ;(probe.capabilities as Record<string, string>).vendor_extension = "supported"
+  assert.throws(
+    () => validateAgentHostProbeWire(probe, "fixture"),
+    (error) =>
+      error instanceof CoreError &&
+      error.code === AGENT_HOST_VECTOR_CODES.probeInvalid,
+  )
+})
+
 test("run request wire accepts a minimal request", () => {
   const parsed = validateAgentHostRunRequestWire(minimalRunRequest())
   assert.equal(parsed.runId, "run-1")

--- a/tests/integration/real-local-mcp-sources.test.ts
+++ b/tests/integration/real-local-mcp-sources.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Integration tests for the real-local mem/doc MCP source connectors (Issue #42, Phase A).
+ *
+ * These tests use a fake fetch to simulate the pinned service responses,
+ * verifying the connector logic without requiring running services. The
+ * evidence class is "real-local-e2e" — actual service runs are documented
+ * separately in the harness runbook.
+ */
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  COMPONENT_MATRIX_SCHEMA_ID,
+  REAL_LOCAL_CODES,
+} from "../../packages/core/src/component-matrix.js"
+import type { ComponentMatrix } from "../../packages/core/src/component-matrix.js"
+import { CoreError } from "../../packages/core/src/contracts.js"
+import type { CapabilityGrantSet } from "../../packages/core/src/mcp-conformance.js"
+import { CAPABILITY_GRANT_SCHEMA_VERSION } from "../../packages/core/src/mcp-conformance.js"
+
+import { MemKnowledgeSource, MEM_CONTRACT } from "../../connectors/sources/mem/index.js"
+import { DocKnowledgeSource, DOC_CONTRACT } from "../../connectors/sources/doc/index.js"
+
+// --- Fixtures ---
+
+const MEM_COMMIT = "3335ebea211d7fb65a8ea0e5ea2285b2cbc2d0bd"
+const DOC_COMMIT = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
+
+function buildMatrix(): ComponentMatrix {
+  return {
+    schema: COMPONENT_MATRIX_SCHEMA_ID,
+    components: [
+      {
+        name: "mem",
+        repository: "https://github.com/fullstack-ai-infra/mem",
+        commit: MEM_COMMIT,
+        contract: MEM_CONTRACT,
+        startCommand: "make test-env-up",
+        healthEndpoint: "/v1/version",
+        ports: { http: 8321 },
+      },
+      {
+        name: "doc",
+        repository: "https://github.com/fullstack-ai-infra/doc",
+        commit: DOC_COMMIT,
+        contract: DOC_CONTRACT,
+        startCommand: "make test-env-up",
+        healthEndpoint: "/v1/version",
+        ports: { http: 8322 },
+      },
+    ],
+  }
+}
+
+function buildGrants(): CapabilityGrantSet {
+  return {
+    schemaVersion: CAPABILITY_GRANT_SCHEMA_VERSION,
+    grantedBy: "operator",
+    grants: [
+      {
+        server: "mem",
+        mode: "read",
+        scopes: [{ principal: "alice", workspace: "ws-alpha" }],
+        revoked: false,
+      },
+      {
+        server: "doc",
+        mode: "read",
+        scopes: [{ principal: "alice", workspace: "ws-alpha" }],
+        revoked: false,
+      },
+    ],
+  }
+}
+
+function fakeFetch(
+  handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
+): typeof globalThis.fetch {
+  return (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url
+    return Promise.resolve(handler(url, init))
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+// --- MemKnowledgeSource tests ---
+
+test("MemKnowledgeSource: health returns available when service responds 200", async () => {
+  const source = new MemKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => jsonResponse({ version: "1.2.3" })),
+  })
+  const result = await source.health()
+  assert.equal(result.available, true)
+  assert.equal(result.version, "1.2.3")
+})
+
+test("MemKnowledgeSource: health returns unavailable on network error", async () => {
+  const source = new MemKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => { throw new Error("ECONNREFUSED") }),
+  })
+  const result = await source.health()
+  assert.equal(result.available, false)
+  assert.match(result.error!, /ECONNREFUSED/)
+})
+
+test("MemKnowledgeSource: recall returns filtered active approved memories", async () => {
+  const memories = [
+    { id: "m1", revision: 2, state: "active", approved: true, text: "memory one" },
+    { id: "m2", revision: 1, state: "superseded", approved: true, text: "old" },
+    { id: "m3", revision: 1, state: "active", approved: false, text: "unapproved" },
+    { id: "m4", revision: 3, state: "active", approved: true, text: "memory four" },
+  ]
+
+  const source = new MemKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => jsonResponse({ memories })),
+  })
+
+  const items = await source.recall()
+  assert.equal(items.length, 2)
+  assert.equal(items[0].locator, "mem://ws-alpha/m1@2")
+  assert.equal(items[0].text, "memory one")
+  assert.equal(items[1].locator, "mem://ws-alpha/m4@3")
+  assert.equal(items[1].text, "memory four")
+})
+
+test("MemKnowledgeSource: recall fails closed when grant is missing", async () => {
+  const grants: CapabilityGrantSet = {
+    ...buildGrants(),
+    grants: buildGrants().grants.filter((g) => g.server !== "mem"),
+  }
+
+  const source = new MemKnowledgeSource({
+    matrix: buildMatrix(),
+    grants,
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => jsonResponse({ memories: [] })),
+  })
+
+  await assert.rejects(
+    () => source.recall(),
+    (error: unknown) =>
+      error instanceof CoreError && error.code === REAL_LOCAL_CODES.grantMissing,
+  )
+})
+
+test("MemKnowledgeSource: recall fails closed when grant is revoked", async () => {
+  const grants: CapabilityGrantSet = {
+    ...buildGrants(),
+    grants: buildGrants().grants.map((g) =>
+      g.server === "mem" ? { ...g, revoked: true } : g,
+    ),
+  }
+
+  const source = new MemKnowledgeSource({
+    matrix: buildMatrix(),
+    grants,
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => jsonResponse({ memories: [] })),
+  })
+
+  await assert.rejects(
+    () => source.recall(),
+    (error: unknown) =>
+      error instanceof CoreError && error.code === REAL_LOCAL_CODES.grantRevoked,
+  )
+})
+
+test("MemKnowledgeSource: recall fails closed on scope mismatch", async () => {
+  const source = new MemKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "bob",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => jsonResponse({ memories: [] })),
+  })
+
+  await assert.rejects(
+    () => source.recall(),
+    (error: unknown) =>
+      error instanceof CoreError && error.code === REAL_LOCAL_CODES.scopeDenied,
+  )
+})
+
+test("MemKnowledgeSource: recall fails closed on service unavailable", async () => {
+  const source = new MemKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => { throw new Error("connection reset") }),
+  })
+
+  await assert.rejects(
+    () => source.recall(),
+    (error: unknown) =>
+      error instanceof CoreError &&
+      error.code === REAL_LOCAL_CODES.serviceUnavailable,
+  )
+})
+
+test("MemKnowledgeSource: construction fails on wrong contract", () => {
+  const matrix: ComponentMatrix = {
+    schema: COMPONENT_MATRIX_SCHEMA_ID,
+    components: [
+      {
+        name: "mem",
+        repository: "https://github.com/fullstack-ai-infra/mem",
+        commit: MEM_COMMIT,
+        contract: "wrong-contract.v2",
+        startCommand: "make test-env-up",
+        healthEndpoint: "/v1/version",
+        ports: { http: 8321 },
+      },
+    ],
+  }
+
+  assert.throws(
+    () =>
+      new MemKnowledgeSource({
+        matrix,
+        grants: buildGrants(),
+        principal: "alice",
+        workspace: "ws-alpha",
+      }),
+    (error: unknown) =>
+      error instanceof CoreError &&
+      error.code === REAL_LOCAL_CODES.matrixUnsupported,
+  )
+})
+
+// --- DocKnowledgeSource tests ---
+
+test("DocKnowledgeSource: health returns available when service responds 200", async () => {
+  const source = new DocKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => jsonResponse({ version: "0.4.1" })),
+  })
+  const result = await source.health()
+  assert.equal(result.available, true)
+  assert.equal(result.version, "0.4.1")
+})
+
+test("DocKnowledgeSource: read returns document at exact revision", async () => {
+  const doc = {
+    id: "doc-abc",
+    title: "Test Document",
+    body: "Document content here.",
+    revision: 5,
+    listed: true,
+    revoked: false,
+  }
+
+  const source = new DocKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => jsonResponse(doc)),
+  })
+
+  const item = await source.read("doc-abc", 5)
+  assert.equal(item.locator, "doc://ws-alpha/doc-abc@5")
+  assert.equal(item.title, "Test Document")
+  assert.equal(item.body, "Document content here.")
+  assert.equal(item.revision, 5)
+})
+
+test("DocKnowledgeSource: read fails closed on 404 (unavailable)", async () => {
+  const source = new DocKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => new Response(null, { status: 404 })),
+  })
+
+  await assert.rejects(
+    () => source.read("missing-doc", 1),
+    (error: unknown) =>
+      error instanceof CoreError &&
+      error.code === REAL_LOCAL_CODES.itemUnavailable,
+  )
+})
+
+test("DocKnowledgeSource: read fails closed on 410 (revoked)", async () => {
+  const source = new DocKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => new Response(null, { status: 410 })),
+  })
+
+  await assert.rejects(
+    () => source.read("revoked-doc", 1),
+    (error: unknown) =>
+      error instanceof CoreError &&
+      error.code === REAL_LOCAL_CODES.grantRevoked,
+  )
+})
+
+test("DocKnowledgeSource: read fails closed on 409 (revision mismatch)", async () => {
+  const source = new DocKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => new Response(null, { status: 409 })),
+  })
+
+  await assert.rejects(
+    () => source.read("doc-abc", 3),
+    (error: unknown) =>
+      error instanceof CoreError &&
+      error.code === REAL_LOCAL_CODES.revisionMismatch,
+  )
+})
+
+test("DocKnowledgeSource: read fails closed when grant missing", async () => {
+  const grants: CapabilityGrantSet = {
+    ...buildGrants(),
+    grants: buildGrants().grants.filter((g) => g.server !== "doc"),
+  }
+
+  const source = new DocKnowledgeSource({
+    matrix: buildMatrix(),
+    grants,
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => jsonResponse({})),
+  })
+
+  await assert.rejects(
+    () => source.read("doc-abc", 1),
+    (error: unknown) =>
+      error instanceof CoreError && error.code === REAL_LOCAL_CODES.grantMissing,
+  )
+})
+
+test("DocKnowledgeSource: read fails closed on scope mismatch", async () => {
+  const source = new DocKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "bob",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => jsonResponse({})),
+  })
+
+  await assert.rejects(
+    () => source.read("doc-abc", 1),
+    (error: unknown) =>
+      error instanceof CoreError && error.code === REAL_LOCAL_CODES.scopeDenied,
+  )
+})
+
+test("DocKnowledgeSource: read fails closed on service unavailable", async () => {
+  const source = new DocKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => { throw new Error("timeout") }),
+  })
+
+  await assert.rejects(
+    () => source.read("doc-abc", 1),
+    (error: unknown) =>
+      error instanceof CoreError &&
+      error.code === REAL_LOCAL_CODES.serviceUnavailable,
+  )
+})
+
+test("DocKnowledgeSource: read fails closed on invalid revision input", async () => {
+  const source = new DocKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => jsonResponse({})),
+  })
+
+  await assert.rejects(
+    () => source.read("doc-abc", 0),
+    (error: unknown) =>
+      error instanceof CoreError &&
+      error.code === REAL_LOCAL_CODES.revisionMismatch,
+  )
+})
+
+test("DocKnowledgeSource: read fails closed on revision mismatch in response body", async () => {
+  const doc = {
+    id: "doc-abc",
+    title: "Title",
+    body: "Body",
+    revision: 7,
+  }
+
+  const source = new DocKnowledgeSource({
+    matrix: buildMatrix(),
+    grants: buildGrants(),
+    principal: "alice",
+    workspace: "ws-alpha",
+    fetchImpl: fakeFetch(() => jsonResponse(doc)),
+  })
+
+  await assert.rejects(
+    () => source.read("doc-abc", 5),
+    (error: unknown) =>
+      error instanceof CoreError &&
+      error.code === REAL_LOCAL_CODES.revisionMismatch,
+  )
+})
+
+test("DocKnowledgeSource: construction fails on wrong contract", () => {
+  const matrix: ComponentMatrix = {
+    schema: COMPONENT_MATRIX_SCHEMA_ID,
+    components: [
+      {
+        name: "doc",
+        repository: "https://github.com/fullstack-ai-infra/doc",
+        commit: DOC_COMMIT,
+        contract: "wrong-contract.v3",
+        startCommand: "make test-env-up",
+        healthEndpoint: "/v1/version",
+        ports: { http: 8322 },
+      },
+    ],
+  }
+
+  assert.throws(
+    () =>
+      new DocKnowledgeSource({
+        matrix,
+        grants: buildGrants(),
+        principal: "alice",
+        workspace: "ws-alpha",
+      }),
+    (error: unknown) =>
+      error instanceof CoreError &&
+      error.code === REAL_LOCAL_CODES.matrixUnsupported,
+  )
+})


### PR DESCRIPTION
## Summary
- Tightens `validateAgentHostProbeWire` and `validateAgentHostProbeResult` to reject capability objects containing keys outside `AGENT_HOST_CAPABILITIES`, enforcing the v1 fail-closed contract.
- Adds direct unit tests covering unknown top-level fields, unknown issue fields, and unknown capability keys in both validators.

Refs #46 (Obs-2: strict capability key rejection, Obs-5: unit tests for validateAgentHostProbeResult)

## Test plan
- [x] `npx tsc --project tsconfig.build.json --noEmit` passes
- [x] Wire and registry tests pass (21 tests green)
- [x] Shipped golden vector corpus still classifies to PASS