### PR TITLE
fix: make exactKeys in component-matrix reject missing keys

### DIFF
--- a/packages/core/src/component-matrix.ts
+++ b/packages/core/src/component-matrix.ts
@@ -52,11 +52,21 @@ function plainRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value)
 }
 
+/**
+ * Rejects both unknown AND missing keys. Every declared key must be present
+ * and no undeclared key is tolerated. This makes schema violations explicit
+ * at the structural check layer instead of relying on downstream per-field
+ * validation to catch omissions.
+ */
 function exactKeys(
   value: Record<string, unknown>,
   allowed: readonly string[],
 ): boolean {
-  return Object.keys(value).every((key) => allowed.includes(key))
+  const keys = Object.keys(value)
+  return (
+    keys.length === allowed.length &&
+    keys.every((key) => allowed.includes(key))
+  )
 }
 
 /**

--- a/tests/core/component-matrix.test.ts
+++ b/tests/core/component-matrix.test.ts
@@ -87,6 +87,29 @@ test("a missing component or contract mismatch is an unsupported matrix", () => 
   )
 })
 
+test("missing required entry fields fail closed", () => {
+  for (const fieldToRemove of [
+    "name",
+    "repository",
+    "commit",
+    "contract",
+    "startCommand",
+    "healthEndpoint",
+    "ports",
+  ]) {
+    const matrix = validMatrix()
+    const entry = (matrix.components as Array<Record<string, unknown>>)[0]
+    delete entry[fieldToRemove]
+    expectUnsupported(matrix)
+  }
+})
+
+test("missing top-level schema field fails closed", () => {
+  const matrix = validMatrix()
+  delete (matrix as Record<string, unknown>).schema
+  expectUnsupported(matrix)
+})
+
 test("duplicate components fail closed", () => {
   const matrix = validMatrix()
   ;(matrix.components as Array<unknown>).push(


### PR DESCRIPTION
## Summary
- Strengthens `exactKeys` in `component-matrix.ts` to reject missing required keys (not just unknown keys), making schema violations explicit at the structural check layer.
- Adds tests pinning the new behavior for both missing entry fields and missing top-level fields.

Refs #56 (nit-2: exactKeys tolerates missing keys)

## Test plan
- [x] `npx tsc --project tsconfig.build.json --noEmit` passes
- [x] All 8 component-matrix tests pass (including 2 new ones)