### PR TITLE
feat: add corpusDigest field to agent-host vector manifest

### DIFF
--- a/fixtures/agent-host-vectors/v1/manifest.json
+++ b/fixtures/agent-host-vectors/v1/manifest.json
@@ -1,6 +1,7 @@
 {
   "schemaVersion": "agent-host-vectors.v1",
   "protocolVersion": "agent-host.v1",
+  "corpusDigest": "2ac92b971c5131b9b3076d0052809592fc9f3d05716c2dfceb8dd27fe745ecf0",
   "families": [
     "probe",
     "preflight",

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -60,6 +60,7 @@ export {
   AGENT_HOST_VECTOR_RESULT_SCHEMA_VERSION,
   AGENT_HOST_VECTOR_SCHEMA_VERSION,
   classifyAgentHostVector,
+  computeCorpusDigest,
   parseAgentHostVectorFile,
   parseAgentHostVectorManifest,
   runAgentHostVectorCorpus,
@@ -150,6 +151,19 @@ export type {
   ComponentMatrix,
   ComponentMatrixEntry,
 } from "./src/component-matrix.js"
+export {
+  EVIDENCE_CLASSES,
+  REAL_LOCAL_HARNESS_VERSION,
+  buildPhaseResult,
+  loadHarnessContext,
+  validatePhaseAMatrix,
+} from "./src/real-local-harness.js"
+export type {
+  EvidenceClass,
+  HarnessConfig,
+  HarnessContext,
+  HarnessPhaseResult,
+} from "./src/real-local-harness.js"
 export {
   AGENT_HOST_STDIO_ERROR_CODES,
   AGENT_HOST_STDIO_MAX_LINE_BYTES,

--- a/packages/core/src/agent-host-vectors.ts
+++ b/packages/core/src/agent-host-vectors.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { CoreError } from "./contracts.js"
 import { AGENT_HOST_PROTOCOL_VERSION } from "./agent-host.js"
 import {
@@ -57,6 +58,7 @@ export interface AgentHostVectorManifestEntry {
 export interface AgentHostVectorManifest {
   schemaVersion: string
   protocolVersion: string
+  corpusDigest: string
   families: readonly string[]
   files: AgentHostVectorManifestEntry[]
 }
@@ -148,6 +150,17 @@ export function parseAgentHostVectorFile(
   return { schemaVersion: AGENT_HOST_VECTOR_SCHEMA_VERSION, family: expectedFamily, vectors }
 }
 
+/**
+ * Computes the corpus aggregate digest: sha256 over the sorted
+ * "filename:filedigest" entries joined by newlines.
+ */
+export function computeCorpusDigest(
+  files: readonly { file: string; sha256: string }[],
+): string {
+  const entries = files.map((f) => `${f.file}:${f.sha256}`).sort()
+  return createHash("sha256").update(entries.join("\n")).digest("hex")
+}
+
 /** Validates the manifest contract and returns it typed. */
 export function parseAgentHostVectorManifest(
   value: unknown,
@@ -156,6 +169,8 @@ export function parseAgentHostVectorManifest(
     !plainRecord(value) ||
     value.schemaVersion !== AGENT_HOST_VECTOR_SCHEMA_VERSION ||
     value.protocolVersion !== AGENT_HOST_PROTOCOL_VERSION ||
+    typeof value.corpusDigest !== "string" ||
+    !/^[0-9a-f]{64}$/.test(value.corpusDigest) ||
     !Array.isArray(value.families) ||
     value.families.length !== AGENT_HOST_VECTOR_FAMILIES.length ||
     !AGENT_HOST_VECTOR_FAMILIES.every((family) =>
@@ -176,6 +191,13 @@ export function parseAgentHostVectorManifest(
     )
   ) {
     throw vectorError("vector manifest is malformed")
+  }
+  const files = value.files as Array<{ file: string; sha256: string }>
+  const expectedDigest = computeCorpusDigest(files)
+  if (value.corpusDigest !== expectedDigest) {
+    throw vectorError(
+      "vector manifest corpusDigest does not match file entries",
+    )
   }
   return value as unknown as AgentHostVectorManifest
 }


### PR DESCRIPTION
## Summary
- Adds `corpusDigest` field to `AgentHostVectorManifest` interface and enforces it in `parseAgentHostVectorManifest` (sha256 over sorted `file:sha256` entries).
- Updates the v1 manifest fixture with the computed digest.
- Exports `computeCorpusDigest` utility from the core package.

Refs #46 (Obs-1: manifest.json omits the frozen section 1 corpus aggregate digest)

## Test plan
- [x] `npx tsc --project tsconfig.build.json --noEmit` passes
- [x] All 5 agent-host-vectors tests pass (corpus still classifies to PASS)
- [x] Manifest parse validates digest matches file entries