### PR TITLE
fix: bound hostVersion length to 256 in qualification record validator

### DIFF
--- a/packages/core/src/adapter-qualification.ts
+++ b/packages/core/src/adapter-qualification.ts
@@ -654,10 +654,14 @@ export function validateAdapterQualificationRecord(
       "hostId must be a lowercase ASCII identifier",
     )
   }
-  if (typeof record.hostVersion !== "string" || record.hostVersion === "") {
+  if (
+    typeof record.hostVersion !== "string" ||
+    record.hostVersion === "" ||
+    record.hostVersion.length > 256
+  ) {
     throw qualificationError(
       "INVALID_QUALIFICATION_RECORD",
-      "hostVersion is required",
+      "hostVersion must be a non-empty string of at most 256 characters",
     )
   }
   if (

--- a/tests/core/adapter-qualification.test.ts
+++ b/tests/core/adapter-qualification.test.ts
@@ -763,3 +763,28 @@ test("the policy digest is content-addressed, order-free and collision-free", ()
     canonicalPolicyDigest(permissive),
   )
 })
+
+test("the record validator rejects hostVersion exceeding 256 characters", async () => {
+  const directory = await workingDirectory()
+  const record = await runQualificationSuite(qualificationAdapter(), {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+  })
+  assert.throws(
+    () =>
+      validateAdapterQualificationRecord({
+        ...record,
+        hostVersion: "x".repeat(257),
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "INVALID_QUALIFICATION_RECORD",
+  )
+  assert.doesNotThrow(() =>
+    validateAdapterQualificationRecord({
+      ...record,
+      hostVersion: "v".repeat(256),
+    }),
+  )
+})


### PR DESCRIPTION
## Summary
- Adds a 256-character length bound to `hostVersion` in `validateAdapterQualificationRecord`, consistent with other bounded string fields in the protocol.
- Adds a test pinning both the rejection of oversized versions and acceptance at the boundary.

Refs #52 (m4: validator leniency on unbounded hostVersion length)

## Test plan
- [x] `npx tsc --project tsconfig.build.json --noEmit` passes
- [x] All 18 adapter-qualification tests pass