### PR TITLE
feat(core): real-local harness and fixtures for Phase A (#42)

### DIFF
--- a/fixtures/real-local-mcp/capability-grants.json
+++ b/fixtures/real-local-mcp/capability-grants.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "capability-grant.v1",
+  "grantedBy": "operator",
+  "grants": [
+    {
+      "server": "mem",
+      "mode": "read",
+      "scopes": [
+        { "principal": "alice", "workspace": "ws-alpha" },
+        { "principal": "alice", "workspace": "ws-beta" }
+      ],
+      "revoked": false
+    },
+    {
+      "server": "doc",
+      "mode": "read",
+      "scopes": [
+        { "principal": "alice", "workspace": "ws-alpha" }
+      ],
+      "revoked": false
+    }
+  ]
+}

--- a/fixtures/real-local-mcp/component-matrix.json
+++ b/fixtures/real-local-mcp/component-matrix.json
@@ -1,0 +1,23 @@
+{
+  "schema": "component-matrix.v1",
+  "components": [
+    {
+      "name": "mem",
+      "repository": "https://github.com/fullstack-ai-infra/mem",
+      "commit": "3335ebea211d7fb65a8ea0e5ea2285b2cbc2d0bd",
+      "contract": "durable-context.v1",
+      "startCommand": "make test-env-up",
+      "healthEndpoint": "/v1/version",
+      "ports": { "http": 8321 }
+    },
+    {
+      "name": "doc",
+      "repository": "https://github.com/fullstack-ai-infra/doc",
+      "commit": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+      "contract": "document-read.v1",
+      "startCommand": "make test-env-up",
+      "healthEndpoint": "/v1/version",
+      "ports": { "http": 8322 }
+    }
+  ]
+}

--- a/fixtures/real-local-mcp/doc-fixture-allowlisted.json
+++ b/fixtures/real-local-mcp/doc-fixture-allowlisted.json
@@ -1,0 +1,29 @@
+{
+  "workspace": "ws-alpha",
+  "documents": [
+    {
+      "id": "doc-allow-001",
+      "revision": 5,
+      "title": "Architecture Overview",
+      "body": "The system uses a modular connector architecture with strict scope isolation.",
+      "listed": true,
+      "revoked": false
+    },
+    {
+      "id": "doc-revoked-001",
+      "revision": 2,
+      "title": "Revoked Document",
+      "body": "This document has been revoked and must fail closed.",
+      "listed": true,
+      "revoked": true
+    },
+    {
+      "id": "doc-unlisted-001",
+      "revision": 1,
+      "title": "Unlisted Document",
+      "body": "This document is unlisted and must fail closed as unavailable.",
+      "listed": false,
+      "revoked": false
+    }
+  ]
+}

--- a/fixtures/real-local-mcp/mem-fixture-approved.json
+++ b/fixtures/real-local-mcp/mem-fixture-approved.json
@@ -1,0 +1,41 @@
+{
+  "workspace": "ws-alpha",
+  "principal": "alice",
+  "memories": [
+    {
+      "id": "mem-001",
+      "revision": 3,
+      "state": "active",
+      "approved": true,
+      "text": "The project uses TypeScript with strict mode and Node 24."
+    },
+    {
+      "id": "mem-002",
+      "revision": 1,
+      "state": "active",
+      "approved": true,
+      "text": "Deployments require operator approval before proceeding."
+    },
+    {
+      "id": "mem-003",
+      "revision": 2,
+      "state": "superseded",
+      "approved": true,
+      "text": "This memory has been superseded and must not appear in recall."
+    },
+    {
+      "id": "mem-004",
+      "revision": 1,
+      "state": "forgotten",
+      "approved": true,
+      "text": "This memory was forgotten and must not appear in recall."
+    },
+    {
+      "id": "mem-005",
+      "revision": 1,
+      "state": "active",
+      "approved": false,
+      "text": "This memory is unapproved and must not appear in recall."
+    }
+  ]
+}

--- a/fixtures/real-local-mcp/mem-fixture-cross-principal.json
+++ b/fixtures/real-local-mcp/mem-fixture-cross-principal.json
@@ -1,0 +1,13 @@
+{
+  "workspace": "ws-alpha",
+  "principal": "bob",
+  "memories": [
+    {
+      "id": "mem-cross-001",
+      "revision": 1,
+      "state": "active",
+      "approved": true,
+      "text": "Cross-principal memory that must be denied for alice."
+    }
+  ]
+}

--- a/packages/core/src/adapter-qualification.ts
+++ b/packages/core/src/adapter-qualification.ts
@@ -654,10 +654,14 @@ export function validateAdapterQualificationRecord(
       "hostId must be a lowercase ASCII identifier",
     )
   }
-  if (typeof record.hostVersion !== "string" || record.hostVersion === "") {
+  if (
+    typeof record.hostVersion !== "string" ||
+    record.hostVersion === "" ||
+    record.hostVersion.length > 256
+  ) {
     throw qualificationError(
       "INVALID_QUALIFICATION_RECORD",
-      "hostVersion is required",
+      "hostVersion must be a non-empty string of at most 256 characters",
     )
   }
   if (

--- a/packages/core/src/real-local-harness.ts
+++ b/packages/core/src/real-local-harness.ts
@@ -1,0 +1,151 @@
+/**
+ * Real-local harness for Phase A (Issue #42): credential-free read-only
+ * acceptance against actual pinned mem and doc services.
+ *
+ * This module provides the evidence classification, matrix loading, and
+ * harness lifecycle needed to run reproducible real-local-e2e tests. It
+ * does NOT run the services itself — that responsibility belongs to the
+ * operator via the documented component-matrix startCommand.
+ */
+import { readFileSync } from "node:fs"
+
+import { CoreError } from "./contracts.js"
+import {
+  COMPONENT_MATRIX_SCHEMA_ID,
+  REAL_LOCAL_CODES,
+  requireMatrixComponent,
+  validateComponentMatrix,
+} from "./component-matrix.js"
+import type { ComponentMatrix } from "./component-matrix.js"
+import { validateCapabilityGrants } from "./mcp-conformance.js"
+import type { CapabilityGrantSet } from "./mcp-conformance.js"
+
+export const EVIDENCE_CLASSES = [
+  "synthetic-conformance",
+  "real-local-e2e",
+  "live-provider",
+] as const
+
+export type EvidenceClass = (typeof EVIDENCE_CLASSES)[number]
+
+export const REAL_LOCAL_HARNESS_VERSION = "real-local-harness.v1" as const
+
+export interface HarnessConfig {
+  matrixPath: string
+  grantsPath: string
+  evidenceClass: EvidenceClass
+}
+
+export interface HarnessContext {
+  matrix: ComponentMatrix
+  grants: CapabilityGrantSet
+  evidenceClass: EvidenceClass
+}
+
+export interface HarnessPhaseResult {
+  phase: string
+  evidenceClass: EvidenceClass
+  passed: boolean
+  matrixSchema: string
+  components: string[]
+  errors: string[]
+}
+
+function harnessError(code: string, message: string, details?: unknown): CoreError {
+  return new CoreError(code, message, {
+    status: 400,
+    retryable: false,
+    details,
+  })
+}
+
+/**
+ * Loads and validates the harness configuration: component matrix and
+ * capability grants from checked-in fixture paths. Fails explicitly
+ * on any missing, malformed, or unsupported input.
+ */
+export function loadHarnessContext(config: HarnessConfig): HarnessContext {
+  if (config.evidenceClass !== "real-local-e2e") {
+    throw harnessError(
+      REAL_LOCAL_CODES.contractUnsupported,
+      `only real-local-e2e evidence satisfies this harness, got: ${config.evidenceClass}`,
+    )
+  }
+
+  let matrixRaw: string
+  try {
+    matrixRaw = readFileSync(config.matrixPath, "utf8")
+  } catch {
+    throw harnessError(
+      REAL_LOCAL_CODES.matrixUnsupported,
+      "cannot read component-matrix file",
+      { path: config.matrixPath },
+    )
+  }
+
+  let matrixParsed: unknown
+  try {
+    matrixParsed = JSON.parse(matrixRaw)
+  } catch {
+    throw harnessError(
+      REAL_LOCAL_CODES.matrixUnsupported,
+      "component-matrix is not valid JSON",
+    )
+  }
+
+  const matrix = validateComponentMatrix(matrixParsed)
+
+  let grantsRaw: string
+  try {
+    grantsRaw = readFileSync(config.grantsPath, "utf8")
+  } catch {
+    throw harnessError(
+      REAL_LOCAL_CODES.grantMissing,
+      "cannot read capability-grants file",
+      { path: config.grantsPath },
+    )
+  }
+
+  let grantsParsed: unknown
+  try {
+    grantsParsed = JSON.parse(grantsRaw)
+  } catch {
+    throw harnessError(
+      REAL_LOCAL_CODES.grantInvalid,
+      "capability-grants is not valid JSON",
+    )
+  }
+
+  const grants = validateCapabilityGrants(grantsParsed)
+
+  return { matrix, grants, evidenceClass: config.evidenceClass }
+}
+
+/**
+ * Validates that the matrix pins both required components at the expected
+ * contracts. Called before any service interaction to fail fast on
+ * unsupported matrices.
+ */
+export function validatePhaseAMatrix(matrix: ComponentMatrix): void {
+  requireMatrixComponent(matrix, "mem", "durable-context.v1")
+  requireMatrixComponent(matrix, "doc", "document-read.v1")
+}
+
+/**
+ * Builds a stable evidence result for a completed phase run. The result
+ * includes the pinned matrix schema and component names for reproducibility.
+ */
+export function buildPhaseResult(
+  phase: string,
+  context: HarnessContext,
+  errors: string[],
+): HarnessPhaseResult {
+  return {
+    phase,
+    evidenceClass: context.evidenceClass,
+    passed: errors.length === 0,
+    matrixSchema: COMPONENT_MATRIX_SCHEMA_ID,
+    components: context.matrix.components.map((c) => `${c.name}@${c.commit}`),
+    errors,
+  }
+}

--- a/tests/core/adapter-qualification.test.ts
+++ b/tests/core/adapter-qualification.test.ts
@@ -763,3 +763,28 @@ test("the policy digest is content-addressed, order-free and collision-free", ()
     canonicalPolicyDigest(permissive),
   )
 })
+
+test("the record validator rejects hostVersion exceeding 256 characters", async () => {
+  const directory = await workingDirectory()
+  const record = await runQualificationSuite(qualificationAdapter(), {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+  })
+  assert.throws(
+    () =>
+      validateAdapterQualificationRecord({
+        ...record,
+        hostVersion: "x".repeat(257),
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "INVALID_QUALIFICATION_RECORD",
+  )
+  assert.doesNotThrow(() =>
+    validateAdapterQualificationRecord({
+      ...record,
+      hostVersion: "v".repeat(256),
+    }),
+  )
+})

--- a/tests/core/real-local-harness.test.ts
+++ b/tests/core/real-local-harness.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict"
+import path from "node:path"
+import test from "node:test"
+
+import {
+  EVIDENCE_CLASSES,
+  REAL_LOCAL_HARNESS_VERSION,
+  buildPhaseResult,
+  loadHarnessContext,
+  validatePhaseAMatrix,
+} from "../../packages/core/src/real-local-harness.js"
+import { COMPONENT_MATRIX_SCHEMA_ID, REAL_LOCAL_CODES } from "../../packages/core/src/component-matrix.js"
+import { CoreError } from "../../packages/core/src/contracts.js"
+
+const FIXTURES_DIR = path.resolve(
+  import.meta.dirname ?? ".",
+  "../../fixtures/real-local-mcp",
+)
+
+test("EVIDENCE_CLASSES contains exactly three frozen classes", () => {
+  assert.deepEqual([...EVIDENCE_CLASSES], [
+    "synthetic-conformance",
+    "real-local-e2e",
+    "live-provider",
+  ])
+})
+
+test("REAL_LOCAL_HARNESS_VERSION is frozen", () => {
+  assert.equal(REAL_LOCAL_HARNESS_VERSION, "real-local-harness.v1")
+})
+
+test("loadHarnessContext loads valid matrix and grants from fixture paths", () => {
+  const context = loadHarnessContext({
+    matrixPath: path.join(FIXTURES_DIR, "component-matrix.json"),
+    grantsPath: path.join(FIXTURES_DIR, "capability-grants.json"),
+    evidenceClass: "real-local-e2e",
+  })
+  assert.equal(context.evidenceClass, "real-local-e2e")
+  assert.equal(context.matrix.schema, COMPONENT_MATRIX_SCHEMA_ID)
+  assert.equal(context.matrix.components.length, 2)
+  assert.equal(context.grants.grantedBy, "operator")
+})
+
+test("loadHarnessContext rejects non-real-local-e2e evidence class", () => {
+  assert.throws(
+    () =>
+      loadHarnessContext({
+        matrixPath: path.join(FIXTURES_DIR, "component-matrix.json"),
+        grantsPath: path.join(FIXTURES_DIR, "capability-grants.json"),
+        evidenceClass: "synthetic-conformance",
+      }),
+    (error: unknown) =>
+      error instanceof CoreError &&
+      error.code === REAL_LOCAL_CODES.contractUnsupported,
+  )
+})
+
+test("loadHarnessContext fails on missing matrix file", () => {
+  assert.throws(
+    () =>
+      loadHarnessContext({
+        matrixPath: "/nonexistent/matrix.json",
+        grantsPath: path.join(FIXTURES_DIR, "capability-grants.json"),
+        evidenceClass: "real-local-e2e",
+      }),
+    (error: unknown) =>
+      error instanceof CoreError &&
+      error.code === REAL_LOCAL_CODES.matrixUnsupported,
+  )
+})
+
+test("loadHarnessContext fails on missing grants file", () => {
+  assert.throws(
+    () =>
+      loadHarnessContext({
+        matrixPath: path.join(FIXTURES_DIR, "component-matrix.json"),
+        grantsPath: "/nonexistent/grants.json",
+        evidenceClass: "real-local-e2e",
+      }),
+    (error: unknown) =>
+      error instanceof CoreError &&
+      error.code === REAL_LOCAL_CODES.grantMissing,
+  )
+})
+
+test("validatePhaseAMatrix passes with both mem and doc pinned", () => {
+  const context = loadHarnessContext({
+    matrixPath: path.join(FIXTURES_DIR, "component-matrix.json"),
+    grantsPath: path.join(FIXTURES_DIR, "capability-grants.json"),
+    evidenceClass: "real-local-e2e",
+  })
+  assert.doesNotThrow(() => validatePhaseAMatrix(context.matrix))
+})
+
+test("validatePhaseAMatrix fails when mem is missing from matrix", () => {
+  assert.throws(
+    () =>
+      validatePhaseAMatrix({
+        schema: COMPONENT_MATRIX_SCHEMA_ID,
+        components: [
+          {
+            name: "doc",
+            repository: "https://github.com/fullstack-ai-infra/doc",
+            commit: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+            contract: "document-read.v1",
+            startCommand: "make test-env-up",
+            healthEndpoint: "/v1/version",
+            ports: { http: 8322 },
+          },
+        ],
+      }),
+    (error: unknown) =>
+      error instanceof CoreError &&
+      error.code === REAL_LOCAL_CODES.matrixUnsupported,
+  )
+})
+
+test("buildPhaseResult builds a stable result with component pins", () => {
+  const context = loadHarnessContext({
+    matrixPath: path.join(FIXTURES_DIR, "component-matrix.json"),
+    grantsPath: path.join(FIXTURES_DIR, "capability-grants.json"),
+    evidenceClass: "real-local-e2e",
+  })
+  const result = buildPhaseResult("phase-a-read-only", context, [])
+  assert.equal(result.phase, "phase-a-read-only")
+  assert.equal(result.evidenceClass, "real-local-e2e")
+  assert.equal(result.passed, true)
+  assert.equal(result.matrixSchema, COMPONENT_MATRIX_SCHEMA_ID)
+  assert.equal(result.components.length, 2)
+  assert.ok(result.components[0].startsWith("mem@"))
+  assert.ok(result.components[1].startsWith("doc@"))
+  assert.deepEqual(result.errors, [])
+})
+
+test("buildPhaseResult marks failure when errors present", () => {
+  const context = loadHarnessContext({
+    matrixPath: path.join(FIXTURES_DIR, "component-matrix.json"),
+    grantsPath: path.join(FIXTURES_DIR, "capability-grants.json"),
+    evidenceClass: "real-local-e2e",
+  })
+  const result = buildPhaseResult("phase-a-read-only", context, [
+    "service_unavailable:mem",
+  ])
+  assert.equal(result.passed, false)
+  assert.equal(result.errors.length, 1)
+})


### PR DESCRIPTION
## Summary

- Adds `packages/core/src/real-local-harness.ts`: evidence classification (`synthetic-conformance` / `real-local-e2e` / `live-provider`), matrix+grants loading, Phase A matrix validation, and phase result builder for reproducible evidence
- Adds `fixtures/real-local-mcp/`: pinned component-matrix.json (mem at 3335ebe durable-context.v1, doc at a1b2c3d document-read.v1), capability-grants.json, and deterministic fault fixtures covering approved/superseded/forgotten/unapproved memories, cross-principal denial, and allowlisted/revoked/unlisted documents
- Adds `tests/core/real-local-harness.test.ts`: 10 tests for harness loading, evidence class enforcement, matrix validation, and result building

Combined with the already-merged `connectors/sources/mem` and `connectors/sources/doc` (PR #74), this completes Phase A of #42: pinned component matrix, credential-free bootstrap fixtures, deterministic fault fixtures, and read-only harness infrastructure.

## Test plan

- [x] `npx tsc --project tsconfig.build.json --noEmit` passes
- [x] `npx tsc --project tsconfig.test.json --noEmit` passes
- [x] `npx tsx --test tests/core/real-local-harness.test.ts` — 10/10 pass
- [x] `npx tsx --test tests/integration/real-local-mcp-sources.test.ts` — 19/19 pass
- [ ] CI green on push