### PR TITLE
fix: correct IPv6 loopback matching in real-local host

### DIFF
--- a/apps/cli/real-local-stdio-host.ts
+++ b/apps/cli/real-local-stdio-host.ts
@@ -161,7 +161,7 @@ function requireLoopbackBaseUrl(name: string): string {
   }
   const loopback =
     url.hostname === "127.0.0.1" ||
-    url.hostname === "::1" ||
+    url.hostname === "[::1]" ||
     url.hostname === "localhost"
   if (url.protocol !== "http:" || !loopback) {
     // Phase A is local-only by design; anything non-loopback is refused so a


### PR DESCRIPTION
## Summary
- Fixes dead-code IPv6 loopback check in `requireLoopbackBaseUrl`: matches `[::1]` (the form URL.hostname actually returns) instead of bare `::1`.
- The direction was already fail-closed (IPv6 was refused, not allowed incorrectly), so this is a usability fix rather than a security fix.

Refs #55 (m1), #56 (m1)

## Test plan
- [x] `npx tsc --project tsconfig.build.json --noEmit` passes
- [x] Verified via `new URL("http://[::1]:8321/").hostname === "[::1]"` that the fix is correct
- [x] Other host implementations (qwen, codebuddy) already use `[::1]` correctly