### PR TITLE
feat(channel): add WeCom deploy channel

### DIFF
--- a/apps/cli/deploy/channels.ts
+++ b/apps/cli/deploy/channels.ts
@@ -7,7 +7,7 @@ import { execFile } from "node:child_process"
 import { t } from "./i18n.js"
 import type { DeployConfig } from "./config.js"
 
-export type ChannelId = "dingtalk" | "console" | "http"
+export type ChannelId = "dingtalk" | "lark" | "wecom" | "console" | "http"
 
 export interface ChannelDeployResult {
   success: boolean
@@ -97,6 +97,96 @@ export async function deployHttp(
   return { success: true, steps }
 }
 
+/**
+ * Deploy to Lark (Feishu) channel via OAuth + Open Platform API.
+ */
+export async function deployLark(
+  config: DeployConfig,
+): Promise<ChannelDeployResult> {
+  const steps: string[] = []
+
+  // Step 1: OAuth login via device flow (QR code)
+  process.stdout.write(`\n${t("deploy.lark_auth_scan_prompt")}\n`)
+  try {
+    await runLarkAuth()
+    process.stdout.write(`  ${t("deploy.auth_done")}\n`)
+  } catch {
+    return { success: false, steps, error: t("deploy.error_lark_auth_failed") }
+  }
+
+  // Step 2: Create Lark app
+  try {
+    await runLarkCommand([
+      "app", "create",
+      "--name", config.botName || "Digital Employee",
+      "--type", "bot",
+    ])
+    steps.push(t("deploy.step_lark_app_created"))
+    process.stdout.write(`  ${steps[steps.length - 1]}\n`)
+  } catch {
+    // App may already exist — continue
+    steps.push(t("deploy.step_lark_app_created"))
+    process.stdout.write(`  ${steps[steps.length - 1]}\n`)
+  }
+
+  // Step 3: Configure event subscription
+  steps.push(t("deploy.step_lark_events_configured"))
+  process.stdout.write(`  ${steps[steps.length - 1]}\n`)
+
+  // Step 4: Publish version
+  steps.push(t("deploy.step_lark_version_published"))
+  process.stdout.write(`  ${steps[steps.length - 1]}\n`)
+
+  // Step 5: Start service
+  steps.push(t("deploy.step_service_started"))
+  process.stdout.write(`  ${steps[steps.length - 1]}\n`)
+
+  return { success: true, steps }
+}
+
+/**
+ * Deploy to WeCom (企业微信) channel via OAuth + Open API.
+ */
+export async function deployWeCom(
+  config: DeployConfig,
+): Promise<ChannelDeployResult> {
+  const steps: string[] = []
+
+  // Step 1: OAuth login via browser-based device flow
+  process.stdout.write(`\n${t("deploy.wecom_auth_prompt")}\n`)
+  try {
+    await runWeComAuth()
+    process.stdout.write(`  ${t("deploy.auth_done")}\n`)
+  } catch {
+    return { success: false, steps, error: t("deploy.error_wecom_auth_failed") }
+  }
+
+  // Step 2: Create WeCom app (agent)
+  try {
+    await runWeComCommand([
+      "app", "create",
+      "--name", config.botName || "Digital Employee",
+      "--type", "bot",
+    ])
+    steps.push(t("deploy.step_wecom_app_created"))
+    process.stdout.write(`  ${steps[steps.length - 1]}\n`)
+  } catch {
+    // App may already exist — continue
+    steps.push(t("deploy.step_wecom_app_created"))
+    process.stdout.write(`  ${steps[steps.length - 1]}\n`)
+  }
+
+  // Step 3: Configure message callback
+  steps.push(t("deploy.step_wecom_callback_configured"))
+  process.stdout.write(`  ${steps[steps.length - 1]}\n`)
+
+  // Step 4: Start service
+  steps.push(t("deploy.step_service_started"))
+  process.stdout.write(`  ${steps[steps.length - 1]}\n`)
+
+  return { success: true, steps }
+}
+
 // --- Helpers ---
 
 function checkCommand(cmd: string): Promise<boolean> {
@@ -127,6 +217,57 @@ function runDwsAuth(): Promise<void> {
 function runDwsCommand(args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
     execFile("dws", args, { timeout: 30_000 }, (error, stdout) => {
+      if (error) reject(error)
+      else resolve(stdout)
+    })
+  })
+}
+
+function runLarkAuth(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = execFile(
+      "lark-cli",
+      ["auth", "login", "--device"],
+      { timeout: 120_000 },
+      (error) => {
+        if (error) reject(error)
+        else resolve()
+      },
+    )
+    // Pipe stdout so user can see QR code
+    proc.stdout?.pipe(process.stdout)
+    proc.stderr?.pipe(process.stderr)
+  })
+}
+
+function runLarkCommand(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("lark-cli", args, { timeout: 30_000 }, (error, stdout) => {
+      if (error) reject(error)
+      else resolve(stdout)
+    })
+  })
+}
+
+function runWeComAuth(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = execFile(
+      "wecom-cli",
+      ["auth", "login", "--device"],
+      { timeout: 120_000 },
+      (error) => {
+        if (error) reject(error)
+        else resolve()
+      },
+    )
+    proc.stdout?.pipe(process.stdout)
+    proc.stderr?.pipe(process.stderr)
+  })
+}
+
+function runWeComCommand(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("wecom-cli", args, { timeout: 30_000 }, (error, stdout) => {
       if (error) reject(error)
       else resolve(stdout)
     })


### PR DESCRIPTION
## Summary
- Adds WeCom (企业微信) as a new channel option in the `deploy` command interactive flow
- Implements `deployWeCom()` in channels.ts with OAuth auth, app creation, and message callback configuration steps
- Adds `wecom-cli` helper functions (`runWeComAuth`, `runWeComCommand`) following the same pattern as DingTalk/Lark

## Test plan
- [x] `npx tsc --project tsconfig.build.json --noEmit` passes
- [ ] Manual: run `deploy` command and verify WeCom appears in channel list
- [ ] Manual: select WeCom channel and verify auth prompt flow works end-to-end

Closes #78