### PR TITLE
feat(channel): add Lark (飞书) channel to deploy command

### DIFF
--- a/apps/cli/deploy/config.ts
+++ b/apps/cli/deploy/config.ts
@@ -16,6 +16,7 @@ export interface DeployConfig {
   engine?: string
   openaiKey?: string
   dingtalkAppId?: string
+  larkAppId?: string
   port?: number
   deployedAt?: string
 }


### PR DESCRIPTION
## Summary

- Adds `larkAppId` field to `DeployConfig` for persisting Lark app identifiers across deploy sessions
- Completes the Lark channel integration by ensuring the config model supports all Lark-specific state

The Lark deploy flow (OAuth QR-code auth, app creation, event subscription, version publish) was already wired in `channels.ts` and `index.ts` via #84; this PR adds the missing config persistence field.

Closes #77

## Test plan

- [x] `npx tsc --project tsconfig.build.json --noEmit` passes
- [x] `tests/apps/deploy-i18n.test.ts` passes (13/13)
- [ ] Manual: run `deploy` command, select Lark, verify flow prompts appear