### PR TITLE
feat(cli): add --help and CLI flags to deploy command

### DIFF
--- a/apps/cli/bin.ts
+++ b/apps/cli/bin.ts
@@ -45,6 +45,8 @@ interface CommandValues {
   recipe?: string;
   host: string;
   port: string;
+  locale?: string;
+  yes: boolean;
   help: boolean;
 }
 
@@ -97,6 +99,8 @@ function parseCommand(argv: string[]) {
       recipe: { type: "string" },
       host: { type: "string", default: "127.0.0.1" },
       port: { type: "string", default: "3000" },
+      locale: { type: "string" },
+      yes: { type: "boolean", short: "y", default: false },
       help: { type: "boolean", short: "h", default: false }
     }
   });
@@ -519,7 +523,7 @@ async function runLegacyCommand(
 
 async function main() {
   const { command, values, positionals } = parseCommand(process.argv.slice(2));
-  if (values.help || command === "help") {
+  if (command === "help" || (values.help && command !== "deploy")) {
     process.stdout.write(usage());
     return;
   }
@@ -536,7 +540,14 @@ async function main() {
     name: values.name,
     recipe: values.recipe,
   });
-  if (command === "deploy") return deploy();
+  if (command === "deploy") return deploy({
+    channel: values.channel,
+    engine: values.engine,
+    name: values.name,
+    locale: values.locale,
+    yes: values.yes,
+    help: values.help,
+  });
   if (command === "doctor") return doctor(values);
   if (command === "init") return init(values, positionals);
   if (command === "validate") return validate(values, positionals);

--- a/apps/cli/deploy/index.ts
+++ b/apps/cli/deploy/index.ts
@@ -21,79 +21,135 @@ import type { EngineStatus } from "./engines.js"
 import { deployDingTalk, deployLark, deployWeCom, deployConsole, deployHttp } from "./channels.js"
 import type { ChannelId } from "./channels.js"
 
-export async function deploy(): Promise<void> {
+export interface DeployOptions {
+  channel?: string
+  engine?: string
+  name?: string
+  locale?: string
+  yes?: boolean
+  help?: boolean
+}
+
+const VALID_CHANNELS = ["dingtalk", "lark", "wecom", "console", "http"]
+const VALID_ENGINES = ["qoder", "claude-code", "qwen-code", "codebuddy", "openai-key"]
+
+export async function deploy(options: DeployOptions = {}): Promise<void> {
   // Load persisted config
   const existing = loadConfig()
 
+  // Resolve locale early for --help support
+  const resolvedLocale = options.locale || existing.locale || detectSystemLocale()
+  setLocale(resolvedLocale)
+
+  // --help: print help and exit
+  if (options.help) {
+    process.stdout.write(`${t("deploy.help")}\n`)
+    return
+  }
+
   // Step 1: Language selection
-  const detectedLocale = existing.locale || detectSystemLocale()
-  setLocale(detectedLocale)
-
-  // Dynamically build locale choices from available locale files
-  const localeChoices = getAvailableLocales().map((code) => ({
-    label: getLocaleDisplayName(code),
-    value: code,
-  }))
-
-  const locale = await selectPrompt(t("deploy.lang_prompt"), localeChoices) as SupportedLocale
-
-  setLocale(locale)
+  let locale: SupportedLocale
+  if (options.locale) {
+    locale = options.locale
+  } else {
+    // Dynamically build locale choices from available locale files
+    const localeChoices = getAvailableLocales().map((code) => ({
+      label: getLocaleDisplayName(code),
+      value: code,
+    }))
+    locale = await selectPrompt(t("deploy.lang_prompt"), localeChoices) as SupportedLocale
+    setLocale(locale)
+  }
 
   // Check for existing deployment (idempotent re-run)
   if (hasExistingDeployment()) {
-    process.stdout.write(`\n${t("deploy.existing_detected")}\n`)
-    const overwrite = await confirmPrompt(t("deploy.existing_overwrite"), {
-      yes: t("deploy.existing_yes"),
-      no: t("deploy.existing_no"),
-    })
-    if (!overwrite) {
-      process.stdout.write(`${t("deploy.aborted")}\n`)
-      return
+    if (options.yes) {
+      // Auto-confirm overwrite
+    } else {
+      process.stdout.write(`\n${t("deploy.existing_detected")}\n`)
+      const overwrite = await confirmPrompt(t("deploy.existing_overwrite"), {
+        yes: t("deploy.existing_yes"),
+        no: t("deploy.existing_no"),
+      })
+      if (!overwrite) {
+        process.stdout.write(`${t("deploy.aborted")}\n`)
+        return
+      }
     }
   }
 
   // Step 2: Channel selection
-  const channel = await selectPrompt(t("deploy.channel_prompt"), [
-    { label: t("deploy.channel_dingtalk"), value: "dingtalk" },
-    { label: t("deploy.channel_lark"), value: "lark" },
-    { label: t("deploy.channel_wecom"), value: "wecom" },
-    { label: t("deploy.channel_console"), value: "console" },
-    { label: t("deploy.channel_http"), value: "http" },
-  ]) as ChannelId
+  let channel: ChannelId
+  if (options.channel && VALID_CHANNELS.includes(options.channel)) {
+    channel = options.channel as ChannelId
+  } else {
+    channel = await selectPrompt(t("deploy.channel_prompt"), [
+      { label: t("deploy.channel_dingtalk"), value: "dingtalk" },
+      { label: t("deploy.channel_lark"), value: "lark" },
+      { label: t("deploy.channel_wecom"), value: "wecom" },
+      { label: t("deploy.channel_console"), value: "console" },
+      { label: t("deploy.channel_http"), value: "http" },
+    ]) as ChannelId
+  }
 
   // Step 3: Bot name
-  const botName = await textPrompt(
-    t("deploy.name_prompt"),
-    t("deploy.name_default"),
-  )
+  let botName: string
+  if (options.name) {
+    botName = options.name
+  } else if (options.yes) {
+    botName = t("deploy.name_default")
+  } else {
+    botName = await textPrompt(
+      t("deploy.name_prompt"),
+      t("deploy.name_default"),
+    )
+  }
 
   // Step 4: Engine selection
-  process.stdout.write("\n")
-  const engines = await detectEngines()
-  const engineOptions: { label: string; value: string; hint?: string }[] = engines.map((e) => ({
-    label: e.displayName,
-    value: e.id as string,
-    hint: e.available
-      ? t("deploy.engine_logged_in")
-      : t("deploy.engine_not_found"),
-  }))
-  engineOptions.push({
-    label: t("deploy.engine_openai_key"),
-    value: "openai-key",
-  })
+  let engineChoice: string
+  if (options.engine && VALID_ENGINES.includes(options.engine)) {
+    engineChoice = options.engine
+  } else {
+    process.stdout.write("\n")
+    const engines = await detectEngines()
+    const engineOptions: { label: string; value: string; hint?: string }[] = engines.map((e) => ({
+      label: e.displayName,
+      value: e.id as string,
+      hint: e.available
+        ? t("deploy.engine_logged_in")
+        : t("deploy.engine_not_found"),
+    }))
+    engineOptions.push({
+      label: t("deploy.engine_openai_key"),
+      value: "openai-key",
+    })
 
-  const engineChoice = await selectPrompt(t("deploy.engine_prompt"), engineOptions)
+    if (options.yes) {
+      // In auto mode, pick first available engine
+      const firstAvailable = engines.find((e) => e.available)
+      engineChoice = firstAvailable ? firstAvailable.id : "openai-key"
+    } else {
+      engineChoice = await selectPrompt(t("deploy.engine_prompt"), engineOptions)
+    }
+  }
 
   let openaiKey: string | undefined
   if (engineChoice === "openai-key") {
+    if (options.yes) {
+      // In non-interactive mode without a key, we cannot proceed
+      process.stderr.write(`${t("deploy.error_no_engine")}\n`)
+      process.exitCode = 1
+      return
+    }
     openaiKey = await secretPrompt(t("deploy.openai_key_prompt"))
     if (!openaiKey) {
       process.stderr.write(`${t("deploy.error_no_engine")}\n`)
       process.exitCode = 1
       return
     }
-  } else {
-    // Verify selected engine is actually available
+  } else if (!options.engine) {
+    // Verify selected engine is actually available (only when user picked interactively)
+    const engines = await detectEngines()
     const selected = engines.find((e) => e.id === engineChoice)
     if (selected && !selected.available) {
       process.stderr.write(`${t("deploy.error_no_engine")}\n`)

--- a/locales/en.json
+++ b/locales/en.json
@@ -49,5 +49,6 @@
   "deploy.error_wecom_auth_failed": "WeCom authentication failed.",
   "deploy.error_lark_auth_failed": "Lark authentication failed.",
   "deploy.error_auth_failed": "DingTalk authentication failed.",
-  "deploy.error_deploy_failed": "Deployment failed: {reason}"
+  "deploy.error_deploy_failed": "Deployment failed: {reason}",
+  "deploy.help": "digital-employee deploy\n\n  Interactive deployment — one command to get your digital employee running.\n\n  Channels:    DingTalk · Lark · WeCom · Console · HTTP\n  AI Engines:  Qoder CLI · Claude Code · Qwen Code · CodeBuddy · OpenAI key\n  Languages:   English · 简体中文 · 日本語\n\nOptions:\n  --channel <id>     Skip channel prompt (dingtalk|lark|wecom|console|http)\n  --engine <id>      Skip engine prompt (qoder|claude-code|qwen-code|codebuddy|openai-key)\n  --name <name>      Skip bot name prompt\n  --locale <code>    Force locale (en|zh-CN|ja)\n  --yes              Accept defaults, skip confirmation prompts\n  --help             Show this help\n\nExamples:\n  digital-employee deploy                          # fully interactive\n  digital-employee deploy --channel dingtalk       # skip channel selection\n  digital-employee deploy --yes --channel http     # non-interactive HTTP deploy"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -47,5 +47,6 @@
   "deploy.error_dws_not_found": "dws CLIが見つかりません。インストール: https://github.com/nicepkg/dws",
   "deploy.error_lark_auth_failed": "Lark認証に失敗しました。",
   "deploy.error_auth_failed": "DingTalk認証に失敗しました。",
-  "deploy.error_deploy_failed": "デプロイに失敗しました: {reason}"
+  "deploy.error_deploy_failed": "デプロイに失敗しました: {reason}",
+  "deploy.help": "digital-employee deploy\n\n  インタラクティブデプロイ — 1コマンドでデジタル従業員を起動。\n\n  チャンネル： DingTalk · Lark · WeCom · コンソール · HTTP\n  AIエンジン： Qoder CLI · Claude Code · Qwen Code · CodeBuddy · OpenAI key\n  言語：       English · 简体中文 · 日本語\n\nオプション：\n  --channel <id>     チャンネル選択をスキップ (dingtalk|lark|wecom|console|http)\n  --engine <id>      エンジン選択をスキップ (qoder|claude-code|qwen-code|codebuddy|openai-key)\n  --name <name>      ボット名の入力をスキップ\n  --locale <code>    言語を指定 (en|zh-CN|ja)\n  --yes              デフォルトを受け入れ、確認をスキップ\n  --help             このヘルプを表示\n\n例：\n  digital-employee deploy                          # 完全インタラクティブ\n  digital-employee deploy --channel dingtalk       # チャンネル選択をスキップ\n  digital-employee deploy --yes --channel http     # 非インタラクティブHTTPデプロイ"
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -49,5 +49,6 @@
   "deploy.error_wecom_auth_failed": "企业微信认证失败。",
   "deploy.error_lark_auth_failed": "飞书认证失败。",
   "deploy.error_auth_failed": "钉钉认证失败。",
-  "deploy.error_deploy_failed": "部署失败：{reason}"
+  "deploy.error_deploy_failed": "部署失败：{reason}",
+  "deploy.help": "digital-employee deploy\n\n  交互式部署 —— 一条命令让你的数字员工跑起来。\n\n  渠道：       钉钉 · 飞书 · 企业微信 · 终端 · HTTP\n  AI 引擎：    Qoder CLI · Claude Code · Qwen Code · CodeBuddy · OpenAI key\n  语言：       English · 简体中文 · 日本語\n\n选项：\n  --channel <id>     跳过渠道选择 (dingtalk|lark|wecom|console|http)\n  --engine <id>      跳过引擎选择 (qoder|claude-code|qwen-code|codebuddy|openai-key)\n  --name <name>      跳过机器人命名\n  --locale <code>    指定语言 (en|zh-CN|ja)\n  --yes              接受默认值，跳过确认\n  --help             显示此帮助\n\n示例：\n  digital-employee deploy                          # 完整交互\n  digital-employee deploy --channel dingtalk       # 跳过渠道选择\n  digital-employee deploy --yes --channel http     # 非交互式 HTTP 部署"
 }


### PR DESCRIPTION
## Summary

- Add locale-aware `--help` output to `deploy` command (en/zh-CN/ja)
- Add CLI flags: `--channel`, `--engine`, `--name`, `--locale`, `--yes`
- When flags are provided, skip the corresponding interactive prompt
- When `--yes` is set, skip confirmation prompts (overwrite existing deployment)
- Fully non-interactive mode when all required flags + `--yes` are provided

Closes #86

## Test plan

- [x] Typecheck passes (`npx tsc --project tsconfig.build.json --noEmit`)
- [x] Existing deploy-i18n tests pass (13/13)
- [ ] `digital-employee deploy --help` outputs help and exits
- [ ] `digital-employee deploy --help --locale zh-CN` outputs Chinese help
- [ ] `digital-employee deploy --channel http` skips channel selection
- [ ] `digital-employee deploy --yes --channel console --engine qoder` runs non-interactively