### PR TITLE
fix(distribution): make installed artifacts reproducible

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,5 @@
-.git
-.github
-.cache
-node_modules
-coverage
-data
-docs/assets
-*.log
-.env
-.env.*
-!.env.example
+**
+!Dockerfile
+!.cache/
+!.cache/distribution/
+!.cache/distribution/digital-employee-package.tgz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,9 @@ jobs:
         run: docker run --rm digital-employee:ci | grep --fixed-strings "Agent-native usage:"
       - name: Verify explicit standalone-v1 health endpoint
         run: |
-          container_id="$(docker run --detach --rm --publish 127.0.0.1:3000:3000 digital-employee:ci legacy serve --config ./dist/configs/demo.json --host 0.0.0.0 --port 3000)"
-          trap 'docker stop "$container_id" >/dev/null 2>&1 || true' EXIT
+          container_name="digital-employee-ci-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          container_id="$(docker run --detach --name "$container_name" --publish 127.0.0.1:3000:3000 digital-employee:ci legacy serve --config ./node_modules/@fullstack-ai-infra/digital-employee/dist/configs/demo.json --host 0.0.0.0 --port 3000)"
+          trap 'docker rm --force "$container_name" >/dev/null 2>&1 || true' EXIT
           for attempt in 1 2 3 4 5 6 7 8 9 10; do
             if curl --fail --silent http://127.0.0.1:3000/health; then
               exit 0
@@ -182,17 +183,19 @@ jobs:
         with:
           node-version: 24
           package-manager-cache: false
-      - name: Compare two clean checkout candidates
+      - name: Compare two clean checkout payload manifests
         shell: bash
         run: |
           for candidate in candidate-a candidate-b; do
-            npm --prefix "$candidate" ci
             mkdir -p "$RUNNER_TEMP/$candidate"
-            npm --prefix "$candidate" pack --json --pack-destination "$RUNNER_TEMP/$candidate" > "$RUNNER_TEMP/$candidate-pack.json"
+            (
+              cd "$candidate"
+              npm ci
+              npm pack --json --pack-destination "$RUNNER_TEMP/$candidate" > "$RUNNER_TEMP/$candidate-pack.json"
+            )
           done
           file_a="$(node --input-type=module -e "import fs from 'node:fs'; const [entry] = JSON.parse(fs.readFileSync('$RUNNER_TEMP/candidate-a-pack.json', 'utf8')); process.stdout.write(entry.filename)")"
           file_b="$(node --input-type=module -e "import fs from 'node:fs'; const [entry] = JSON.parse(fs.readFileSync('$RUNNER_TEMP/candidate-b-pack.json', 'utf8')); process.stdout.write(entry.filename)")"
-          cmp "$RUNNER_TEMP/candidate-a/$file_a" "$RUNNER_TEMP/candidate-b/$file_b"
           tar -xOzf "$RUNNER_TEMP/candidate-a/$file_a" package/dist/distribution-manifest.json > "$RUNNER_TEMP/manifest-a.json"
           tar -xOzf "$RUNNER_TEMP/candidate-b/$file_b" package/dist/distribution-manifest.json > "$RUNNER_TEMP/manifest-b.json"
           cmp "$RUNNER_TEMP/manifest-a.json" "$RUNNER_TEMP/manifest-b.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Smoke installed CLI without a source checkout
         shell: bash
         run: |
-          package_file="$(find distribution-candidate -maxdepth 1 -name '*digital-employee-0.3.0.tgz' ! -name '*core*' -print -quit)"
+          package_file="$(find distribution-candidate -maxdepth 1 -name 'fullstack-ai-infra-digital-employee-*.tgz' ! -name '*-core-*' -print -quit)"
           test -n "$package_file"
           node distribution-candidate/distribution-smoke.js "$package_file"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - run: npm ci
+      - name: Build and verify the container candidate
+        shell: bash
+        run: |
+          pack_destination="$RUNNER_TEMP/distribution-pack"
+          mkdir -p "$pack_destination" .cache/distribution
+          npm pack --json --pack-destination "$pack_destination" > "$RUNNER_TEMP/root-pack.json"
+          npm pack ./packages/core --json --pack-destination "$pack_destination" > "$RUNNER_TEMP/core-pack.json"
+          node ./scripts/release-pack-check.js \
+            "$pack_destination" \
+            "$RUNNER_TEMP/root-pack.json" \
+            "$RUNNER_TEMP/core-pack.json"
+          package_file="$(node --input-type=module -e "import fs from 'node:fs'; const [entry] = JSON.parse(fs.readFileSync('$RUNNER_TEMP/root-pack.json', 'utf8')); process.stdout.write(entry.filename)")"
+          cp "$pack_destination/$package_file" .cache/distribution/digital-employee-package.tgz
       - run: docker build --tag digital-employee:ci .
       - name: Verify default Agent-native entry point
         run: docker run --rm digital-employee:ci | grep --fixed-strings "Agent-native usage:"
@@ -95,3 +113,86 @@ jobs:
           done
           docker logs "$container_id"
           exit 1
+
+  distribution-candidate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - run: npm ci
+      - name: Build, verify and smoke the candidate tarball
+        shell: bash
+        run: |
+          artifact_directory="$RUNNER_TEMP/distribution-artifact"
+          mkdir -p "$artifact_directory"
+          npm pack --json --pack-destination "$artifact_directory" > "$RUNNER_TEMP/root-pack.json"
+          npm pack ./packages/core --json --pack-destination "$artifact_directory" > "$RUNNER_TEMP/core-pack.json"
+          node ./scripts/release-pack-check.js \
+            "$artifact_directory" \
+            "$RUNNER_TEMP/root-pack.json" \
+            "$RUNNER_TEMP/core-pack.json"
+          package_file="$(node --input-type=module -e "import fs from 'node:fs'; const [entry] = JSON.parse(fs.readFileSync('$RUNNER_TEMP/root-pack.json', 'utf8')); process.stdout.write(entry.filename)")"
+          node ./scripts/distribution-smoke.js "$artifact_directory/$package_file"
+          cp ./scripts/distribution-smoke.js "$artifact_directory/distribution-smoke.js"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digital-employee-distribution-candidate
+          path: ${{ runner.temp }}/distribution-artifact
+          if-no-files-found: error
+
+  distribution-consumer:
+    needs: distribution-candidate
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 20
+          - 22
+          - 24
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: digital-employee-distribution-candidate
+          path: distribution-candidate
+      - name: Smoke installed CLI without a source checkout
+        shell: bash
+        run: |
+          package_file="$(find distribution-candidate -maxdepth 1 -name '*digital-employee-0.3.0.tgz' ! -name '*core*' -print -quit)"
+          test -n "$package_file"
+          node distribution-candidate/distribution-smoke.js "$package_file"
+
+  distribution-reproducibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: candidate-a
+      - uses: actions/checkout@v6
+        with:
+          path: candidate-b
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - name: Compare two clean checkout candidates
+        shell: bash
+        run: |
+          for candidate in candidate-a candidate-b; do
+            npm --prefix "$candidate" ci
+            mkdir -p "$RUNNER_TEMP/$candidate"
+            npm --prefix "$candidate" pack --json --pack-destination "$RUNNER_TEMP/$candidate" > "$RUNNER_TEMP/$candidate-pack.json"
+          done
+          file_a="$(node --input-type=module -e "import fs from 'node:fs'; const [entry] = JSON.parse(fs.readFileSync('$RUNNER_TEMP/candidate-a-pack.json', 'utf8')); process.stdout.write(entry.filename)")"
+          file_b="$(node --input-type=module -e "import fs from 'node:fs'; const [entry] = JSON.parse(fs.readFileSync('$RUNNER_TEMP/candidate-b-pack.json', 'utf8')); process.stdout.write(entry.filename)")"
+          cmp "$RUNNER_TEMP/candidate-a/$file_a" "$RUNNER_TEMP/candidate-b/$file_b"
+          tar -xOzf "$RUNNER_TEMP/candidate-a/$file_a" package/dist/distribution-manifest.json > "$RUNNER_TEMP/manifest-a.json"
+          tar -xOzf "$RUNNER_TEMP/candidate-b/$file_b" package/dist/distribution-manifest.json > "$RUNNER_TEMP/manifest-b.json"
+          cmp "$RUNNER_TEMP/manifest-a.json" "$RUNNER_TEMP/manifest-b.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -483,6 +483,19 @@ jobs:
             echo "::error::$RELEASE_TAG moved after release preparation"
             exit 1
           fi
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - run: npm ci
+      - name: Stage the declared npm candidate for the container
+        shell: bash
+        run: |
+          pack_destination="$RUNNER_TEMP/ghcr-pack"
+          mkdir -p "$pack_destination" .cache/distribution
+          npm pack --json --pack-destination "$pack_destination" > "$RUNNER_TEMP/ghcr-root-pack.json"
+          package_file="$(node --input-type=module -e "import fs from 'node:fs'; const [entry] = JSON.parse(fs.readFileSync('$RUNNER_TEMP/ghcr-root-pack.json', 'utf8')); process.stdout.write(entry.filename)")"
+          cp "$pack_destination/$package_file" .cache/distribution/digital-employee-package.tgz
       - name: Log in to GHCR
         env:
           GHCR_TOKEN: ${{ github.token }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,15 @@
-FROM node:24-alpine AS build
-
-WORKDIR /app
-
-COPY --chown=node:node package.json package-lock.json .npmrc ./
-COPY --chown=node:node packages/core/package.json ./packages/core/package.json
-RUN npm ci --ignore-scripts
-
-COPY --chown=node:node . .
-RUN npm run build
-
 FROM node:24-alpine
 
 WORKDIR /app
 
-COPY --chown=node:node package.json package-lock.json .npmrc ./
-COPY --chown=node:node packages/core/package.json ./packages/core/package.json
-RUN npm ci --omit=dev --ignore-scripts
-COPY --from=build --chown=node:node /app/dist ./dist
-COPY --chown=node:node README.md README.zh-CN.md LICENSE NOTICE ./
+# The build context contains only the already verified npm candidate. The
+# container never recompiles or copies repository-local runtime assets.
+COPY --chown=node:node .cache/distribution/digital-employee-package.tgz ./digital-employee-package.tgz
+RUN npm init --yes >/dev/null \
+  && npm install --omit=dev --ignore-scripts --no-audit --no-fund ./digital-employee-package.tgz \
+  && rm ./digital-employee-package.tgz
 
 USER node
 
-ENTRYPOINT ["node", "./dist/apps/cli/bin.js"]
+ENTRYPOINT ["node", "./node_modules/@fullstack-ai-infra/digital-employee/dist/apps/cli/bin.js"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ explicitly only when testing the compatibility runtime:
 docker build -t digital-employee:candidate .
 docker run --rm digital-employee:candidate
 docker run --rm -p 3000:3000 digital-employee:candidate \
-  legacy serve --config ./dist/configs/demo.json --host 0.0.0.0 --port 3000
+  legacy serve \
+  --config ./node_modules/@fullstack-ai-infra/digital-employee/dist/configs/demo.json \
+  --host 0.0.0.0 --port 3000
 ```
 
 ## Not one bot and not another Agent loop

--- a/README.md
+++ b/README.md
@@ -187,13 +187,15 @@ docker run --rm -p 3000:3000 \
   ghcr.io/fullstack-ai-infra/digital-employee:0.1.0
 ```
 
-The current source `Dockerfile` is instead a generic CLI base image and defaults
-to help. Enter `legacy` explicitly only when testing the compatibility runtime:
+The current source `Dockerfile` installs an already verified npm candidate and
+defaults to help. It does not rebuild from the source checkout. Follow the
+[candidate build and staging steps](docs/distribution.md), then enter `legacy`
+explicitly only when testing the compatibility runtime:
 
 ```bash
-docker build -t digital-employee:source .
-docker run --rm digital-employee:source
-docker run --rm -p 3000:3000 digital-employee:source \
+docker build -t digital-employee:candidate .
+docker run --rm digital-employee:candidate
+docker run --rm -p 3000:3000 digital-employee:candidate \
   legacy serve --config ./dist/configs/demo.json --host 0.0.0.0 --port 3000
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,12 +99,12 @@ docker run --rm -p 3000:3000 \
   ghcr.io/fullstack-ai-infra/digital-employee:0.1.0
 ```
 
-当前源码的 `Dockerfile` 已改为通用 CLI 基础镜像，默认只显示帮助；只有明确测试兼容运行时时才进入 `legacy`：
+当前源码的 `Dockerfile` 只安装已经验证的 npm 候选制品，不会重新从源码树构建，默认只显示帮助。先按[候选制品构建与暂存步骤](docs/distribution.md)准备同一个 tarball；只有明确测试兼容运行时时才进入 `legacy`：
 
 ```bash
-docker build -t digital-employee:source .
-docker run --rm digital-employee:source
-docker run --rm -p 3000:3000 digital-employee:source \
+docker build -t digital-employee:candidate .
+docker run --rm digital-employee:candidate
+docker run --rm -p 3000:3000 digital-employee:candidate \
   legacy serve --config ./dist/configs/demo.json --host 0.0.0.0 --port 3000
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -105,7 +105,9 @@ docker run --rm -p 3000:3000 \
 docker build -t digital-employee:candidate .
 docker run --rm digital-employee:candidate
 docker run --rm -p 3000:3000 digital-employee:candidate \
-  legacy serve --config ./dist/configs/demo.json --host 0.0.0.0 --port 3000
+  legacy serve \
+  --config ./node_modules/@fullstack-ai-infra/digital-employee/dist/configs/demo.json \
+  --host 0.0.0.0 --port 3000
 ```
 
 ## 不是只开源一个机器人，也不是再造一个 Agent

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -63,5 +63,7 @@ docker run --rm digital-employee:candidate --help
 ```
 
 `.dockerignore` rejects every other source path from the context. CI repeats
-the installed smoke on Node 20, 22 and 24 and compares two independently built
-clean-checkout tarballs and manifests byte for byte.
+the installed smoke on Node 20, 22 and 24 and compares the payload manifest and
+every declared file digest from two independently built clean checkouts. The
+npm tar container encoding is not a cross-toolchain byte-reproducibility
+contract.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -25,6 +25,8 @@ node ./scripts/release-pack-check.js \
   "$pack_directory" \
   "$pack_directory/root-pack.json" \
   "$pack_directory/core-pack.json"
+package_file="$(node --input-type=module -e \
+  "import fs from 'node:fs'; const [entry] = JSON.parse(fs.readFileSync('$pack_directory/root-pack.json', 'utf8')); process.stdout.write(entry.filename)")"
 ```
 
 The root tarball contains `dist/distribution-manifest.json`. It records the
@@ -42,7 +44,7 @@ consumer and npm cache, installs only the tarball, runs CLI help and completes
 
 ```bash
 node ./scripts/distribution-smoke.js \
-  "$pack_directory/fullstack-ai-infra-digital-employee-0.3.0.tgz"
+  "$pack_directory/$package_file"
 ```
 
 This is offline package/Schema fixture conformance. It does not evaluate a
@@ -54,7 +56,7 @@ Stage the already verified root tarball at the single Docker input path:
 
 ```bash
 mkdir -p .cache/distribution
-cp "$pack_directory/fullstack-ai-infra-digital-employee-0.3.0.tgz" \
+cp "$pack_directory/$package_file" \
   .cache/distribution/digital-employee-package.tgz
 docker build --tag digital-employee:candidate .
 docker run --rm digital-employee:candidate --help

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,65 @@
+# Reproducible distribution candidate
+
+This repository treats the generated npm tarball as the release candidate. A
+container installs that same tarball; it does not rebuild or copy runtime files
+from the source checkout. Issue #92 owns publication. The commands below only
+build and verify a candidate.
+
+The root package has a fail-closed allowlist. Compiled files must correspond to
+tracked runtime TypeScript sources, and runtime data is copied from an exact
+asset map. That map includes the two bounded recipes and the `en`, `zh-CN` and
+`ja` locale catalogs. Missing files, undeclared files and credential-shaped
+paths stop verification.
+
+## Build and verify
+
+Start with a clean checkout. Provenance preparation rejects staged, modified or
+untracked source input.
+
+```bash
+npm ci
+pack_directory="$(mktemp -d)"
+npm pack --json --pack-destination "$pack_directory" > "$pack_directory/root-pack.json"
+npm pack ./packages/core --json --pack-destination "$pack_directory" > "$pack_directory/core-pack.json"
+node ./scripts/release-pack-check.js \
+  "$pack_directory" \
+  "$pack_directory/root-pack.json" \
+  "$pack_directory/core-pack.json"
+```
+
+The root tarball contains `dist/distribution-manifest.json`. It records the
+exact source commit, package identity, Node/npm/TypeScript toolchain and a
+SHA-256 digest for every other packed file. The manifest explicitly excludes
+its own digest to avoid a recursive checksum; the verifier extracts it from the
+tarball, verifies every listed byte, and binds the complete archive through
+the integrity emitted by `npm pack`.
+
+## Installed consumer smoke
+
+Run the smoke harness against the generated root tarball. It creates an empty
+consumer and npm cache, installs only the tarball, runs CLI help and completes
+`init -> validate -> eval` for both recipes.
+
+```bash
+node ./scripts/distribution-smoke.js \
+  "$pack_directory/fullstack-ai-infra-digital-employee-0.3.0.tgz"
+```
+
+This is offline package/Schema fixture conformance. It does not evaluate a
+model, Agent Host, MCP service, live provider behavior or employee quality.
+
+## Container from the same candidate
+
+Stage the already verified root tarball at the single Docker input path:
+
+```bash
+mkdir -p .cache/distribution
+cp "$pack_directory/fullstack-ai-infra-digital-employee-0.3.0.tgz" \
+  .cache/distribution/digital-employee-package.tgz
+docker build --tag digital-employee:candidate .
+docker run --rm digital-employee:candidate --help
+```
+
+`.dockerignore` rejects every other source path from the context. CI repeats
+the installed smoke on Node 20, 22 and 24 and compares two independently built
+clean-checkout tarballs and manifests byte for byte.

--- a/package.json
+++ b/package.json
@@ -38,14 +38,13 @@
   ],
   "files": [
     "dist",
-    "locales",
     "README.md",
     "README.zh-CN.md",
     "LICENSE",
     "NOTICE"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json && node ./scripts/copy-build-assets.js",
+    "build": "node ./scripts/clean-build-output.js && tsc --project tsconfig.build.json && node ./scripts/copy-build-assets.js",
     "typecheck": "tsc --project tsconfig.json && tsc --project tsconfig.test.json",
     "ask": "npm run build --silent && node ./dist/apps/cli/bin.js ask",
     "demo": "npm run build --silent && node ./dist/apps/cli/bin.js ask --config ./dist/configs/demo.json",
@@ -67,7 +66,9 @@
     "governance:check": "node ./scripts/requirement-governance-check.js",
     "security:check": "node ./scripts/security-check.js",
     "release:check": "node ./scripts/release-check.js",
-    "prepack": "npm run build",
+    "distribution:prepare": "npm run build && node ./scripts/prepare-distribution.js",
+    "distribution:smoke": "node ./scripts/distribution-smoke.js",
+    "prepack": "npm run distribution:prepare",
     "prepublishOnly": "npm run check && npm run release:check",
     "check": "npm run typecheck && npm run build && npm test && npm run governance:check && npm run security:check"
   },

--- a/scripts/clean-build-output.js
+++ b/scripts/clean-build-output.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+import { rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+await rm(path.join(repositoryRoot, "dist"), { recursive: true, force: true });
+await rm(path.join(repositoryRoot, "packages", "core", "dist"), {
+  recursive: true,
+  force: true
+});

--- a/scripts/copy-build-assets.js
+++ b/scripts/copy-build-assets.js
@@ -3,33 +3,21 @@
 import { chmod, cp, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { DISTRIBUTION_ASSET_MAPPINGS } from "./distribution-policy.js";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const outputRoot = path.join(repositoryRoot, "dist");
 const corePackageOutput = path.join(repositoryRoot, "packages", "core", "dist");
 
-async function copyDirectory(name) {
-  await cp(path.join(repositoryRoot, name), path.join(outputRoot, name), {
-    recursive: true,
-    force: true
-  });
-}
-
 await mkdir(outputRoot, { recursive: true });
-for (const directory of ["configs", "locales", "tests/fixtures/knowledge"]) {
-  await rm(path.join(outputRoot, directory), { recursive: true, force: true });
-  await copyDirectory(directory);
+for (const [source, destination] of DISTRIBUTION_ASSET_MAPPINGS) {
+  const destinationPath = path.join(repositoryRoot, destination);
+  await mkdir(path.dirname(destinationPath), { recursive: true });
+  await cp(path.join(repositoryRoot, source), destinationPath, { force: true });
 }
 await rm(corePackageOutput, { recursive: true, force: true });
 await cp(path.join(outputRoot, "packages", "core"), corePackageOutput, {
   recursive: true,
   force: true
 });
-const answerAgentOutput = path.join(outputRoot, "profiles", "answer-agent");
-await mkdir(answerAgentOutput, { recursive: true });
-await cp(
-  path.join(repositoryRoot, "profiles", "answer-agent", "profile.json"),
-  path.join(answerAgentOutput, "profile.json"),
-  { force: true }
-);
 await chmod(path.join(outputRoot, "apps", "cli", "bin.js"), 0o755);

--- a/scripts/distribution-policy.js
+++ b/scripts/distribution-policy.js
@@ -1,0 +1,160 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+export const DISTRIBUTION_MANIFEST_PATH = "dist/distribution-manifest.json";
+export const DISTRIBUTION_SCHEMA_VERSION = "digital-employee-distribution.v1";
+
+export const DISTRIBUTION_ROOT_FILES = Object.freeze([
+  "LICENSE",
+  "NOTICE",
+  "README.md",
+  "README.zh-CN.md",
+  "package.json"
+]);
+
+export const DISTRIBUTION_ASSET_MAPPINGS = Object.freeze([
+  ["configs/demo.json", "dist/configs/demo.json"],
+  ["configs/dingtalk-dws.example.json", "dist/configs/dingtalk-dws.example.json"],
+  ["configs/employee-mcp.schema.json", "dist/configs/employee-mcp.schema.json"],
+  ["configs/employee-package.schema.json", "dist/configs/employee-package.schema.json"],
+  ["configs/profile.schema.json", "dist/configs/profile.schema.json"],
+  ["configs/schema.json", "dist/configs/schema.json"],
+  ["locales/README.md", "dist/locales/README.md"],
+  ["locales/en.json", "dist/locales/en.json"],
+  ["locales/ja.json", "dist/locales/ja.json"],
+  ["locales/zh-CN.json", "dist/locales/zh-CN.json"],
+  ["profiles/answer-agent/profile.json", "dist/profiles/answer-agent/profile.json"],
+  ["tests/fixtures/knowledge/handbook.md", "dist/tests/fixtures/knowledge/handbook.md"],
+  ["tests/fixtures/knowledge/release-notes.md", "dist/tests/fixtures/knowledge/release-notes.md"],
+  [
+    "examples/recipes/minimal-answer.v1/minimal-answer/SKILL.md",
+    "dist/examples/recipes/minimal-answer.v1/minimal-answer/SKILL.md"
+  ],
+  [
+    "examples/recipes/minimal-answer.v1/minimal-answer/employee.json",
+    "dist/examples/recipes/minimal-answer.v1/minimal-answer/employee.json"
+  ],
+  [
+    "examples/recipes/minimal-answer.v1/minimal-answer/evals/cases.json",
+    "dist/examples/recipes/minimal-answer.v1/minimal-answer/evals/cases.json"
+  ],
+  [
+    "examples/recipes/minimal-answer.v1/minimal-answer/knowledge/README.md",
+    "dist/examples/recipes/minimal-answer.v1/minimal-answer/knowledge/README.md"
+  ],
+  [
+    "examples/recipes/minimal-answer.v1/minimal-answer/schemas/input.schema.json",
+    "dist/examples/recipes/minimal-answer.v1/minimal-answer/schemas/input.schema.json"
+  ],
+  [
+    "examples/recipes/minimal-answer.v1/minimal-answer/schemas/output.schema.json",
+    "dist/examples/recipes/minimal-answer.v1/minimal-answer/schemas/output.schema.json"
+  ],
+  [
+    "examples/recipes/structured-action.v1/structured-action/SKILL.md",
+    "dist/examples/recipes/structured-action.v1/structured-action/SKILL.md"
+  ],
+  [
+    "examples/recipes/structured-action.v1/structured-action/employee.json",
+    "dist/examples/recipes/structured-action.v1/structured-action/employee.json"
+  ],
+  [
+    "examples/recipes/structured-action.v1/structured-action/evals/cases.json",
+    "dist/examples/recipes/structured-action.v1/structured-action/evals/cases.json"
+  ],
+  [
+    "examples/recipes/structured-action.v1/structured-action/knowledge/README.md",
+    "dist/examples/recipes/structured-action.v1/structured-action/knowledge/README.md"
+  ],
+  [
+    "examples/recipes/structured-action.v1/structured-action/schemas/input.schema.json",
+    "dist/examples/recipes/structured-action.v1/structured-action/schemas/input.schema.json"
+  ],
+  [
+    "examples/recipes/structured-action.v1/structured-action/schemas/output.schema.json",
+    "dist/examples/recipes/structured-action.v1/structured-action/schemas/output.schema.json"
+  ]
+]);
+
+const COMPILED_SOURCE_ROOTS = Object.freeze([
+  "apps/",
+  "connectors/",
+  "packages/",
+  "profiles/"
+]);
+
+const CREDENTIAL_PATH = /(?:^|\/)(?:\.env(?:\.|$)|credentials?(?:\.|$)|secrets?(?:\.|$)|id_(?:rsa|dsa|ecdsa|ed25519)(?:\.|$)|[^/]*(?:private[-_]?key|api[-_]?key|access[-_]?token|auth[-_]?token)[^/]*)/i;
+
+export function portablePath(value) {
+  return value.split(path.sep).join("/");
+}
+
+export function compiledDistributionFiles(sourceFiles) {
+  const output = [];
+  for (const source of sourceFiles) {
+    const portable = portablePath(source);
+    if (
+      !COMPILED_SOURCE_ROOTS.some((root) => portable.startsWith(root)) ||
+      !portable.endsWith(".ts") ||
+      portable.endsWith(".d.ts")
+    ) {
+      continue;
+    }
+    const stem = `dist/${portable.slice(0, -3)}`;
+    output.push(`${stem}.d.ts`, `${stem}.d.ts.map`, `${stem}.js`, `${stem}.js.map`);
+  }
+  return output.sort((left, right) => left.localeCompare(right, "en"));
+}
+
+export function expectedDistributionFiles(sourceFiles) {
+  return [
+    ...DISTRIBUTION_ROOT_FILES,
+    ...compiledDistributionFiles(sourceFiles),
+    ...DISTRIBUTION_ASSET_MAPPINGS.map(([, destination]) => destination)
+  ].sort((left, right) => left.localeCompare(right, "en"));
+}
+
+export function credentialShapedPath(filePath) {
+  return CREDENTIAL_PATH.test(portablePath(filePath));
+}
+
+export function computeDistributionFileSetDigest(files) {
+  const hash = createHash("sha256");
+  for (const file of files) {
+    hash.update(file.path, "utf8");
+    hash.update("\0", "ascii");
+    hash.update(String(file.size), "ascii");
+    hash.update("\0", "ascii");
+    hash.update(file.sha256, "ascii");
+    hash.update("\n", "ascii");
+  }
+  return `sha256:${hash.digest("hex")}`;
+}
+
+export function validateCandidateFileSet(expectedFiles, actualFiles) {
+  const expected = new Set(expectedFiles);
+  const actual = new Set(actualFiles);
+  const violations = [];
+  for (const file of [...expected].sort()) {
+    if (!actual.has(file)) {
+      violations.push({
+        code: "DISTRIBUTION_REQUIRED_FILE_MISSING",
+        path: file
+      });
+    }
+  }
+  for (const file of [...actual].sort()) {
+    if (credentialShapedPath(file)) {
+      violations.push({
+        code: "DISTRIBUTION_CREDENTIAL_PATH_FORBIDDEN",
+        path: file
+      });
+    } else if (!expected.has(file)) {
+      violations.push({
+        code: "DISTRIBUTION_UNDECLARED_FILE",
+        path: file
+      });
+    }
+  }
+  return violations;
+}

--- a/scripts/distribution-smoke.js
+++ b/scripts/distribution-smoke.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    env: options.env ?? process.env,
+    input: options.input,
+    timeout: 120_000
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `distribution_smoke_command_failed:${path.basename(command)}:${result.status}\n` +
+      `${result.stdout || ""}${result.stderr || ""}`
+    );
+  }
+  return result.stdout;
+}
+
+function parseJsonOutput(command, text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new TypeError(`distribution_smoke_invalid_json:${command}`);
+  }
+}
+
+async function main() {
+  const archiveArgument = process.argv[2];
+  if (!archiveArgument) {
+    throw new TypeError("usage: distribution-smoke.js <package.tgz>");
+  }
+  const archive = path.resolve(archiveArgument);
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "digital-employee-consumer-"));
+  try {
+    const consumer = path.join(temporaryRoot, "consumer");
+    const npmCache = path.join(temporaryRoot, "npm-cache");
+    await mkdir(consumer);
+    await writeFile(
+      path.join(consumer, "package.json"),
+      `${JSON.stringify({ private: true, type: "module" }, null, 2)}\n`,
+      { mode: 0o600 }
+    );
+    const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+    run(npmCommand, [
+      "install",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      "--cache",
+      npmCache,
+      archive
+    ], { cwd: consumer });
+
+    const installedManifest = JSON.parse(await readFile(
+      path.join(
+        consumer,
+        "node_modules",
+        "@fullstack-ai-infra",
+        "digital-employee",
+        "package.json"
+      ),
+      "utf8"
+    ));
+    const cli = path.join(
+      consumer,
+      "node_modules",
+      "@fullstack-ai-infra",
+      "digital-employee",
+      "dist",
+      "apps",
+      "cli",
+      "bin.js"
+    );
+    run(process.execPath, [cli, "--help"], { cwd: consumer });
+
+    const recipes = [];
+    for (const recipe of ["minimal-answer.v1", "structured-action.v1"]) {
+      const target = path.join(consumer, recipe.replace(".v1", ""));
+      run(process.execPath, [
+        cli,
+        "init",
+        target,
+        "--recipe",
+        recipe,
+        "--json"
+      ], { cwd: consumer });
+      run(process.execPath, [cli, "validate", target, "--json"], { cwd: consumer });
+      const evaluation = parseJsonOutput(
+        "eval",
+        run(process.execPath, [cli, "eval", target, "--json"], { cwd: consumer })
+      );
+      if (evaluation.status !== "passed" || !Array.isArray(evaluation.cases)) {
+        throw new TypeError(`distribution_smoke_eval_failed:${recipe}`);
+      }
+      recipes.push({ recipe, caseCount: evaluation.cases.length });
+    }
+
+    process.stdout.write(`${JSON.stringify({
+      schemaVersion: "distribution-consumer-smoke-result.v1",
+      package: `${installedManifest.name}@${installedManifest.version}`,
+      node: process.version,
+      status: "passed",
+      recipes
+    }, null, 2)}\n`);
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${JSON.stringify({
+    schemaVersion: "distribution-consumer-smoke-result.v1",
+    status: "failed",
+    code: String(error?.message || "distribution_smoke_failed").split("\n", 1)[0]
+  })}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/distribution-smoke.js
+++ b/scripts/distribution-smoke.js
@@ -57,7 +57,50 @@ function assertExactKeys(value, keys, code) {
   }
 }
 
-function assertEvalResult(result, expectedStatus) {
+const RECIPE_CONTRACTS = Object.freeze([
+  Object.freeze({
+    recipe: "minimal-answer.v1",
+    directory: "minimal-answer",
+    employee: Object.freeze({
+      name: "minimal-answer",
+      version: "0.1.0",
+      schemaVersion: "employee-package.v1alpha1"
+    })
+  }),
+  Object.freeze({
+    recipe: "structured-action.v1",
+    directory: "structured-action",
+    employee: Object.freeze({
+      name: "structured-action",
+      version: "0.1.0",
+      schemaVersion: "employee-package.v1alpha1"
+    })
+  })
+]);
+
+const INITIALIZED_FILES = Object.freeze([
+  "./employee.json",
+  "./SKILL.md",
+  "./schemas/input.schema.json",
+  "./schemas/output.schema.json",
+  "./knowledge/README.md",
+  "./evals/cases.json"
+]);
+
+function assertEmployeeIdentity(employee, expected, code) {
+  if (
+    !employee ||
+    typeof employee !== "object" ||
+    Array.isArray(employee) ||
+    employee.name !== expected.name ||
+    employee.version !== expected.version ||
+    employee.schemaVersion !== expected.schemaVersion
+  ) {
+    throw new TypeError(code);
+  }
+}
+
+function assertEvalResult(result, expectedStatus, expectedEmployee) {
   assertExactKeys(result, [
     "schemaVersion",
     "status",
@@ -71,6 +114,11 @@ function assertEvalResult(result, expectedStatus) {
     "version",
     "schemaVersion"
   ], "distribution_smoke_eval_employee_invalid");
+  assertEmployeeIdentity(
+    result.employee,
+    expectedEmployee,
+    "distribution_smoke_eval_employee_invalid"
+  );
   assertExactKeys(result.summary, [
     "total",
     "passed",
@@ -152,8 +200,9 @@ async function main() {
 
     const recipes = [];
     let negativeEvalCode;
-    for (const recipe of ["minimal-answer.v1", "structured-action.v1"]) {
-      const target = path.join(consumer, recipe.replace(".v1", ""));
+    for (const contract of RECIPE_CONTRACTS) {
+      const { employee, recipe } = contract;
+      const target = path.join(consumer, contract.directory);
       const initialized = parseJsonOutput("init", run(process.execPath, [
         cli,
         "init",
@@ -172,13 +221,15 @@ async function main() {
         initialized.recipe !== recipe ||
         initialized.directory !== target ||
         !Array.isArray(initialized.files) ||
-        initialized.files.length === 0 ||
-        typeof initialized.manifest?.name !== "string" ||
-        typeof initialized.manifest?.version !== "string" ||
-        initialized.manifest?.schemaVersion !== "employee-package.v1alpha1"
+        JSON.stringify(initialized.files) !== JSON.stringify(INITIALIZED_FILES)
       ) {
         throw new TypeError(`distribution_smoke_init_contract_invalid:${recipe}`);
       }
+      assertEmployeeIdentity(
+        initialized.manifest,
+        employee,
+        `distribution_smoke_init_identity_invalid:${recipe}`
+      );
 
       const validation = parseJsonOutput(
         "validate",
@@ -190,14 +241,15 @@ async function main() {
         "version",
         "schemaVersion"
       ], "distribution_smoke_validate_employee_invalid");
+      assertEmployeeIdentity(
+        validation.employee,
+        employee,
+        `distribution_smoke_validate_identity_invalid:${recipe}`
+      );
       if (
         validation.status !== "valid" ||
-        validation.employee.name !== initialized.manifest.name ||
-        validation.employee.version !== initialized.manifest.version ||
-        validation.employee.schemaVersion !== "employee-package.v1alpha1" ||
         !Array.isArray(validation.files) ||
-        initialized.files[0] !== "./employee.json" ||
-        JSON.stringify(validation.files) !== JSON.stringify(initialized.files.slice(1))
+        JSON.stringify(validation.files) !== JSON.stringify(INITIALIZED_FILES.slice(1))
       ) {
         throw new TypeError(`distribution_smoke_validate_contract_invalid:${recipe}`);
       }
@@ -206,7 +258,7 @@ async function main() {
         "eval",
         run(process.execPath, [cli, "eval", target, "--json"], { cwd: consumer })
       );
-      assertEvalResult(evaluation, "passed");
+      assertEvalResult(evaluation, "passed", employee);
       if (
         evaluation.code !== "EVAL_PASSED" ||
         evaluation.summary.passed !== 1 ||
@@ -216,7 +268,12 @@ async function main() {
       ) {
         throw new TypeError(`distribution_smoke_eval_failed:${recipe}`);
       }
-      recipes.push({ recipe, caseCount: evaluation.cases.length });
+      recipes.push({
+        recipe,
+        employee,
+        fileCount: initialized.files.length,
+        caseCount: evaluation.cases.length
+      });
 
       if (recipe === "minimal-answer.v1") {
         const casesPath = path.join(target, "evals", "cases.json");
@@ -232,7 +289,7 @@ async function main() {
           throw new TypeError("distribution_smoke_negative_exit_invalid");
         }
         const failedEvaluation = parseJsonOutput("eval-negative", failedProcess.stdout);
-        assertEvalResult(failedEvaluation, "failed");
+        assertEvalResult(failedEvaluation, "failed", employee);
         if (
           failedEvaluation.code !== "EVAL_CASE_INPUT_SCHEMA_INVALID" ||
           failedEvaluation.summary.passed !== 0 ||

--- a/scripts/distribution-smoke.js
+++ b/scripts/distribution-smoke.js
@@ -23,11 +23,71 @@ function run(command, args, options = {}) {
   return result.stdout;
 }
 
+function runResult(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    env: options.env ?? process.env,
+    input: options.input,
+    timeout: 120_000
+  });
+  if (result.error) throw result.error;
+  return result;
+}
+
 function parseJsonOutput(command, text) {
   try {
     return JSON.parse(text);
   } catch {
     throw new TypeError(`distribution_smoke_invalid_json:${command}`);
+  }
+}
+
+function assertExactKeys(value, keys, code) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(code);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (
+    actual.length !== expected.length ||
+    actual.some((key, index) => key !== expected[index])
+  ) {
+    throw new TypeError(code);
+  }
+}
+
+function assertEvalResult(result, expectedStatus) {
+  assertExactKeys(result, [
+    "schemaVersion",
+    "status",
+    "code",
+    "employee",
+    "summary",
+    "cases"
+  ], "distribution_smoke_eval_shape_invalid");
+  assertExactKeys(result.employee, [
+    "name",
+    "version",
+    "schemaVersion"
+  ], "distribution_smoke_eval_employee_invalid");
+  assertExactKeys(result.summary, [
+    "total",
+    "passed",
+    "failed"
+  ], "distribution_smoke_eval_summary_invalid");
+  if (
+    result.schemaVersion !== "employee-eval-result.v1alpha1" ||
+    result.status !== expectedStatus ||
+    !Array.isArray(result.cases) ||
+    result.cases.length !== 1 ||
+    result.summary.total !== 1 ||
+    result.summary.passed + result.summary.failed !== 1
+  ) {
+    throw new TypeError("distribution_smoke_eval_contract_invalid");
+  }
+  for (const evalCase of result.cases) {
+    assertExactKeys(evalCase, ["id", "status", "code"], "distribution_smoke_eval_case_invalid");
   }
 }
 
@@ -78,28 +138,112 @@ async function main() {
       "cli",
       "bin.js"
     );
-    run(process.execPath, [cli, "--help"], { cwd: consumer });
+    const help = run(process.execPath, [cli, "--help"], { cwd: consumer });
+    for (const requiredHelp of [
+      "Agent-native usage:",
+      "digital-employee init",
+      "digital-employee validate",
+      "digital-employee eval"
+    ]) {
+      if (!help.includes(requiredHelp)) {
+        throw new TypeError("distribution_smoke_help_contract_invalid");
+      }
+    }
 
     const recipes = [];
+    let negativeEvalCode;
     for (const recipe of ["minimal-answer.v1", "structured-action.v1"]) {
       const target = path.join(consumer, recipe.replace(".v1", ""));
-      run(process.execPath, [
+      const initialized = parseJsonOutput("init", run(process.execPath, [
         cli,
         "init",
         target,
         "--recipe",
         recipe,
         "--json"
-      ], { cwd: consumer });
-      run(process.execPath, [cli, "validate", target, "--json"], { cwd: consumer });
+      ], { cwd: consumer }));
+      assertExactKeys(initialized, [
+        "directory",
+        "manifest",
+        "files",
+        "recipe"
+      ], "distribution_smoke_init_shape_invalid");
+      if (
+        initialized.recipe !== recipe ||
+        initialized.directory !== target ||
+        !Array.isArray(initialized.files) ||
+        initialized.files.length === 0 ||
+        typeof initialized.manifest?.name !== "string" ||
+        typeof initialized.manifest?.version !== "string" ||
+        initialized.manifest?.schemaVersion !== "employee-package.v1alpha1"
+      ) {
+        throw new TypeError(`distribution_smoke_init_contract_invalid:${recipe}`);
+      }
+
+      const validation = parseJsonOutput(
+        "validate",
+        run(process.execPath, [cli, "validate", target, "--json"], { cwd: consumer })
+      );
+      assertExactKeys(validation, ["status", "employee", "files"], "distribution_smoke_validate_shape_invalid");
+      assertExactKeys(validation.employee, [
+        "name",
+        "version",
+        "schemaVersion"
+      ], "distribution_smoke_validate_employee_invalid");
+      if (
+        validation.status !== "valid" ||
+        validation.employee.name !== initialized.manifest.name ||
+        validation.employee.version !== initialized.manifest.version ||
+        validation.employee.schemaVersion !== "employee-package.v1alpha1" ||
+        !Array.isArray(validation.files) ||
+        initialized.files[0] !== "./employee.json" ||
+        JSON.stringify(validation.files) !== JSON.stringify(initialized.files.slice(1))
+      ) {
+        throw new TypeError(`distribution_smoke_validate_contract_invalid:${recipe}`);
+      }
+
       const evaluation = parseJsonOutput(
         "eval",
         run(process.execPath, [cli, "eval", target, "--json"], { cwd: consumer })
       );
-      if (evaluation.status !== "passed" || !Array.isArray(evaluation.cases)) {
+      assertEvalResult(evaluation, "passed");
+      if (
+        evaluation.code !== "EVAL_PASSED" ||
+        evaluation.summary.passed !== 1 ||
+        evaluation.summary.failed !== 0 ||
+        evaluation.cases[0].status !== "passed" ||
+        evaluation.cases[0].code !== "EVAL_CASE_PASSED"
+      ) {
         throw new TypeError(`distribution_smoke_eval_failed:${recipe}`);
       }
       recipes.push({ recipe, caseCount: evaluation.cases.length });
+
+      if (recipe === "minimal-answer.v1") {
+        const casesPath = path.join(target, "evals", "cases.json");
+        const contract = JSON.parse(await readFile(casesPath, "utf8"));
+        contract.cases[0].input = {};
+        await writeFile(casesPath, `${JSON.stringify(contract, null, 2)}\n`);
+        const failedProcess = runResult(
+          process.execPath,
+          [cli, "eval", target, "--json"],
+          { cwd: consumer }
+        );
+        if (failedProcess.status !== 1 || failedProcess.stderr !== "") {
+          throw new TypeError("distribution_smoke_negative_exit_invalid");
+        }
+        const failedEvaluation = parseJsonOutput("eval-negative", failedProcess.stdout);
+        assertEvalResult(failedEvaluation, "failed");
+        if (
+          failedEvaluation.code !== "EVAL_CASE_INPUT_SCHEMA_INVALID" ||
+          failedEvaluation.summary.passed !== 0 ||
+          failedEvaluation.summary.failed !== 1 ||
+          failedEvaluation.cases[0].status !== "failed" ||
+          failedEvaluation.cases[0].code !== "EVAL_CASE_INPUT_SCHEMA_INVALID"
+        ) {
+          throw new TypeError("distribution_smoke_negative_contract_invalid");
+        }
+        negativeEvalCode = failedEvaluation.code;
+      }
     }
 
     process.stdout.write(`${JSON.stringify({
@@ -107,7 +251,13 @@ async function main() {
       package: `${installedManifest.name}@${installedManifest.version}`,
       node: process.version,
       status: "passed",
-      recipes
+      recipes,
+      machineContracts: {
+        init: "exact",
+        validate: "exact",
+        evalSchemaVersion: "employee-eval-result.v1alpha1",
+        negativeEvalCode
+      }
     }, null, 2)}\n`);
   } finally {
     await rm(temporaryRoot, { recursive: true, force: true });

--- a/scripts/prepare-distribution.js
+++ b/scripts/prepare-distribution.js
@@ -141,7 +141,9 @@ async function main() {
     flag: "wx"
   });
   await rename(temporary, destination);
-  process.stdout.write(`${JSON.stringify({
+  // npm pack --json owns stdout. Lifecycle diagnostics must not corrupt its
+  // machine-readable payload.
+  process.stderr.write(`${JSON.stringify({
     schemaVersion: "distribution-prepare-result.v1",
     status: "passed",
     sourceSha,

--- a/scripts/prepare-distribution.js
+++ b/scripts/prepare-distribution.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import {
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile
+} from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DISTRIBUTION_MANIFEST_PATH,
+  DISTRIBUTION_SCHEMA_VERSION,
+  computeDistributionFileSetDigest,
+  expectedDistributionFiles,
+  validateCandidateFileSet
+} from "./distribution-policy.js";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function git(args) {
+  return execFileSync("git", args, {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+async function walkFiles(directory, prefix) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name, "en"))) {
+    const absolute = path.join(directory, entry.name);
+    const portable = `${prefix}/${entry.name}`;
+    if (entry.isSymbolicLink()) {
+      files.push(portable);
+    } else if (entry.isDirectory()) {
+      files.push(...await walkFiles(absolute, portable));
+    } else {
+      files.push(portable);
+    }
+  }
+  return files;
+}
+
+function npmVersion() {
+  const userAgent = process.env.npm_config_user_agent ?? "";
+  const match = /(?:^|\s)npm\/([^\s]+)/.exec(userAgent);
+  if (match?.[1]) return match[1];
+  return execFileSync(process.platform === "win32" ? "npm.cmd" : "npm", ["--version"], {
+    encoding: "utf8"
+  }).trim();
+}
+
+function fail(violations) {
+  process.stderr.write(`${JSON.stringify({
+    schemaVersion: "distribution-verification-result.v1",
+    status: "failed",
+    violations
+  })}\n`);
+  process.exitCode = 1;
+}
+
+async function main() {
+  const dirty = git(["status", "--porcelain=v1", "--untracked-files=all"]);
+  if (dirty) {
+    fail([{ code: "DISTRIBUTION_SOURCE_DIRTY" }]);
+    return;
+  }
+
+  const sourceSha = git(["rev-parse", "HEAD"]);
+  const sourceFiles = git(["ls-files", "-z"]).split("\0").filter(Boolean);
+  const expectedFiles = expectedDistributionFiles(sourceFiles);
+  const actualFiles = [
+    ...expectedFiles.filter((file) => !file.startsWith("dist/")),
+    ...await walkFiles(path.join(repositoryRoot, "dist"), "dist")
+  ];
+  const violations = validateCandidateFileSet(expectedFiles, actualFiles);
+  if (violations.length) {
+    fail(violations);
+    return;
+  }
+
+  const files = [];
+  for (const file of expectedFiles) {
+    const absolute = path.join(repositoryRoot, file);
+    const metadata = await lstat(absolute);
+    if (!metadata.isFile() || metadata.isSymbolicLink()) {
+      violations.push({ code: "DISTRIBUTION_FILE_NOT_REGULAR", path: file });
+      continue;
+    }
+    const bytes = await readFile(absolute);
+    files.push({
+      path: file,
+      size: bytes.length,
+      sha256: createHash("sha256").update(bytes).digest("hex")
+    });
+  }
+  if (violations.length) {
+    fail(violations);
+    return;
+  }
+
+  const packageManifest = JSON.parse(await readFile(path.join(repositoryRoot, "package.json"), "utf8"));
+  const typescriptManifest = JSON.parse(await readFile(
+    path.join(repositoryRoot, "node_modules", "typescript", "package.json"),
+    "utf8"
+  ));
+  const manifest = {
+    schemaVersion: DISTRIBUTION_SCHEMA_VERSION,
+    package: {
+      name: packageManifest.name,
+      version: packageManifest.version
+    },
+    source: {
+      gitCommit: sourceSha,
+      dirty: false
+    },
+    toolchain: {
+      node: process.version,
+      npm: npmVersion(),
+      typescript: typescriptManifest.version
+    },
+    digestAlgorithm: "sha256",
+    manifestPath: DISTRIBUTION_MANIFEST_PATH,
+    manifestDigestExcluded: true,
+    fileSetDigest: computeDistributionFileSetDigest(files),
+    files
+  };
+  const destination = path.join(repositoryRoot, DISTRIBUTION_MANIFEST_PATH);
+  const temporary = `${destination}.tmp`;
+  await mkdir(path.dirname(destination), { recursive: true });
+  await rm(temporary, { force: true });
+  await writeFile(temporary, `${JSON.stringify(manifest, null, 2)}\n`, {
+    mode: 0o644,
+    flag: "wx"
+  });
+  await rename(temporary, destination);
+  process.stdout.write(`${JSON.stringify({
+    schemaVersion: "distribution-prepare-result.v1",
+    status: "passed",
+    sourceSha,
+    fileCount: files.length,
+    fileSetDigest: manifest.fileSetDigest
+  })}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${JSON.stringify({
+    schemaVersion: "distribution-verification-result.v1",
+    status: "failed",
+    violations: [{ code: "DISTRIBUTION_PREPARE_FAILED" }]
+  })}\n`);
+  if (process.env.DEBUG_DISTRIBUTION === "1") {
+    process.stderr.write(`${String(error?.stack || error)}\n`);
+  }
+  process.exitCode = 2;
+});

--- a/scripts/release-pack-check.js
+++ b/scripts/release-pack-check.js
@@ -106,7 +106,7 @@ function manifestViolations(manifest, packageManifest) {
       file.size < 0 ||
       !/^[0-9a-f]{64}$/.test(file.sha256 ?? "") ||
       file.path === DISTRIBUTION_MANIFEST_PATH ||
-      file.path <= previous ||
+      (previous && previous.localeCompare(file.path, "en") >= 0) ||
       seen.has(file.path)
     ) {
       violations.push({ code: "DISTRIBUTION_MANIFEST_FILE_INVALID", path: file?.path });

--- a/scripts/release-pack-check.js
+++ b/scripts/release-pack-check.js
@@ -63,7 +63,7 @@ function expectedFilename(manifest) {
   return `${packageSlug}-${manifest.version}.tgz`;
 }
 
-function manifestViolations(manifest, packageManifest) {
+export function validateDistributionManifest(manifest, packageManifest) {
   const violations = [];
   if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
     return [{ code: "DISTRIBUTION_MANIFEST_INVALID" }];
@@ -146,10 +146,12 @@ async function validateRootArchive({ archivePath, pack, packageManifest }) {
   try {
     artifactManifest = await archiveManifest(archivePath);
   } catch {
-    return [{ code: "DISTRIBUTION_MANIFEST_MISSING", path: DISTRIBUTION_MANIFEST_PATH }];
+    return {
+      violations: [{ code: "DISTRIBUTION_MANIFEST_MISSING", path: DISTRIBUTION_MANIFEST_PATH }]
+    };
   }
-  const violations = manifestViolations(artifactManifest, packageManifest);
-  if (violations.length) return violations;
+  const violations = validateDistributionManifest(artifactManifest, packageManifest);
+  if (violations.length) return { violations };
 
   const expectedFiles = [
     ...artifactManifest.files.map((file) => file.path),
@@ -159,7 +161,7 @@ async function validateRootArchive({ archivePath, pack, packageManifest }) {
     expectedFiles,
     pack.files.map((file) => file.path)
   ));
-  if (violations.length) return violations;
+  if (violations.length) return { violations };
 
   const temporary = await mkdtemp(path.join(os.tmpdir(), "digital-employee-pack-"));
   try {
@@ -178,7 +180,15 @@ async function validateRootArchive({ archivePath, pack, packageManifest }) {
   } finally {
     await rm(temporary, { recursive: true, force: true });
   }
-  return violations;
+  return {
+    violations,
+    summary: {
+      sourceSha: artifactManifest.source.gitCommit,
+      fileCount: artifactManifest.files.length,
+      fileSetDigest: artifactManifest.fileSetDigest,
+      toolchain: artifactManifest.toolchain
+    }
+  };
 }
 
 export function validatePackOutput({
@@ -286,7 +296,7 @@ async function main() {
       });
     }
   }
-  if (rootVerification) errors.push(...rootVerification);
+  if (rootVerification) errors.push(...rootVerification.violations);
 
   if (errors.length) {
     process.stderr.write(`${JSON.stringify({
@@ -302,7 +312,8 @@ async function main() {
   process.stdout.write(`${JSON.stringify({
     schemaVersion: "distribution-verification-result.v1",
     status: "passed",
-    packages: ["root", "core"]
+    packages: ["root", "core"],
+    artifact: rootVerification?.summary
   })}\n`);
 }
 

--- a/scripts/release-pack-check.js
+++ b/scripts/release-pack-check.js
@@ -154,7 +154,7 @@ async function walkExtractedFiles(directory, prefix = "") {
   return files;
 }
 
-async function validateRootArchive({ archivePath, pack, packageManifest }) {
+export async function validateRootArchive({ archivePath, pack, packageManifest }) {
   const archiveBytes = await readFile(archivePath);
   const integrityViolations = validateArchiveIntegrity(archiveBytes, pack);
   if (integrityViolations.length) return { violations: integrityViolations };
@@ -202,6 +202,7 @@ async function validateRootArchive({ archivePath, pack, packageManifest }) {
     const packageRoot = path.join(temporary, "package");
     const extractedFiles = await walkExtractedFiles(packageRoot);
     violations.push(...validateCandidateFileSet(expectedFiles, extractedFiles));
+    if (violations.length) return { violations };
     const expectedByPath = new Map(artifactManifest.files.map((file) => [file.path, file]));
     for (const [filePath, expected] of expectedByPath) {
       const bytes = await readFile(path.join(packageRoot, filePath));

--- a/scripts/release-pack-check.js
+++ b/scripts/release-pack-check.js
@@ -129,6 +129,19 @@ async function archiveManifest(archivePath) {
   return JSON.parse(stdout);
 }
 
+export function validateArchiveIntegrity(bytes, pack) {
+  const violations = [];
+  const sha1 = createHash("sha1").update(bytes).digest("hex");
+  const integrity = `sha512-${createHash("sha512").update(bytes).digest("base64")}`;
+  if (pack?.shasum !== sha1) {
+    violations.push({ code: "DISTRIBUTION_ARCHIVE_SHASUM_MISMATCH" });
+  }
+  if (pack?.integrity !== integrity) {
+    violations.push({ code: "DISTRIBUTION_ARCHIVE_INTEGRITY_MISMATCH" });
+  }
+  return violations;
+}
+
 async function walkExtractedFiles(directory, prefix = "") {
   const entries = await readdir(directory, { withFileTypes: true });
   const files = [];
@@ -142,6 +155,10 @@ async function walkExtractedFiles(directory, prefix = "") {
 }
 
 async function validateRootArchive({ archivePath, pack, packageManifest }) {
+  const archiveBytes = await readFile(archivePath);
+  const integrityViolations = validateArchiveIntegrity(archiveBytes, pack);
+  if (integrityViolations.length) return { violations: integrityViolations };
+
   let artifactManifest;
   try {
     artifactManifest = await archiveManifest(archivePath);
@@ -165,6 +182,22 @@ async function validateRootArchive({ archivePath, pack, packageManifest }) {
 
   const temporary = await mkdtemp(path.join(os.tmpdir(), "digital-employee-pack-"));
   try {
+    const { stdout: archiveListing } = await execFileAsync("tar", ["-tzf", archivePath], {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024
+    });
+    const unsafeArchivePath = archiveListing.split("\n").filter(Boolean).find((entry) => {
+      const segments = entry.split("/");
+      return !entry.startsWith("package/") ||
+        entry.includes("\\") ||
+        segments.includes("..") ||
+        path.posix.isAbsolute(entry);
+    });
+    if (unsafeArchivePath) {
+      return {
+        violations: [{ code: "DISTRIBUTION_ARCHIVE_PATH_INVALID", path: unsafeArchivePath }]
+      };
+    }
     await execFileAsync("tar", ["-xzf", archivePath, "-C", temporary]);
     const packageRoot = path.join(temporary, "package");
     const extractedFiles = await walkExtractedFiles(packageRoot);

--- a/scripts/release-pack-check.js
+++ b/scripts/release-pack-check.js
@@ -1,11 +1,22 @@
 #!/usr/bin/env node
 
 import { createHash } from "node:crypto";
-import { lstat, readFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, readdir, rm, stat } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import {
+  DISTRIBUTION_MANIFEST_PATH,
+  DISTRIBUTION_SCHEMA_VERSION,
+  computeDistributionFileSetDigest,
+  validateCandidateFileSet
+} from "./distribution-policy.js";
 
-export const PACKAGE_SPECS = [
+const execFileAsync = promisify(execFile);
+
+const PACKAGE_SPECS = [
   {
     label: "root",
     manifestPath: "package.json",
@@ -14,20 +25,24 @@ export const PACKAGE_SPECS = [
       "dist/apps/cli/bin.js",
       "dist/packages/core/index.js",
       "dist/packages/core/index.d.ts",
-      "locales/README.md",
-      "locales/en.json",
-      "locales/ja.json",
-      "locales/zh-CN.json"
+      DISTRIBUTION_MANIFEST_PATH,
+      "dist/examples/recipes/minimal-answer.v1/minimal-answer/employee.json",
+      "dist/examples/recipes/minimal-answer.v1/minimal-answer/SKILL.md",
+      "dist/examples/recipes/minimal-answer.v1/minimal-answer/evals/cases.json",
+      "dist/examples/recipes/minimal-answer.v1/minimal-answer/knowledge/README.md",
+      "dist/examples/recipes/minimal-answer.v1/minimal-answer/schemas/input.schema.json",
+      "dist/examples/recipes/minimal-answer.v1/minimal-answer/schemas/output.schema.json",
+      "dist/examples/recipes/structured-action.v1/structured-action/employee.json",
+      "dist/examples/recipes/structured-action.v1/structured-action/SKILL.md",
+      "dist/examples/recipes/structured-action.v1/structured-action/evals/cases.json",
+      "dist/examples/recipes/structured-action.v1/structured-action/knowledge/README.md",
+      "dist/examples/recipes/structured-action.v1/structured-action/schemas/input.schema.json",
+      "dist/examples/recipes/structured-action.v1/structured-action/schemas/output.schema.json",
+      "dist/locales/en.json",
+      "dist/locales/ja.json",
+      "dist/locales/zh-CN.json"
     ],
-    allowedFiles: [
-      "package.json",
-      "LICENSE",
-      "NOTICE",
-      "locales/README.md",
-      "locales/en.json",
-      "locales/ja.json",
-      "locales/zh-CN.json"
-    ],
+    allowedFiles: ["package.json", "LICENSE", "NOTICE"],
     allowedPrefixes: ["dist/"],
     allowedPatterns: [/^README[^/]*\.md$/]
   },
@@ -46,6 +61,124 @@ function expectedFilename(manifest) {
     .replace(/^@/, "")
     .replaceAll("/", "-");
   return `${packageSlug}-${manifest.version}.tgz`;
+}
+
+function manifestViolations(manifest, packageManifest) {
+  const violations = [];
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+    return [{ code: "DISTRIBUTION_MANIFEST_INVALID" }];
+  }
+  if (manifest.schemaVersion !== DISTRIBUTION_SCHEMA_VERSION) {
+    violations.push({ code: "DISTRIBUTION_MANIFEST_INVALID", field: "schemaVersion" });
+  }
+  if (
+    manifest.package?.name !== packageManifest.name ||
+    manifest.package?.version !== packageManifest.version
+  ) {
+    violations.push({ code: "DISTRIBUTION_MANIFEST_IDENTITY_MISMATCH" });
+  }
+  if (!/^[0-9a-f]{40}$/.test(manifest.source?.gitCommit ?? "") || manifest.source?.dirty !== false) {
+    violations.push({ code: "DISTRIBUTION_MANIFEST_SOURCE_INVALID" });
+  }
+  if (
+    typeof manifest.toolchain?.node !== "string" ||
+    typeof manifest.toolchain?.npm !== "string" ||
+    typeof manifest.toolchain?.typescript !== "string"
+  ) {
+    violations.push({ code: "DISTRIBUTION_MANIFEST_TOOLCHAIN_INVALID" });
+  }
+  if (
+    manifest.digestAlgorithm !== "sha256" ||
+    manifest.manifestPath !== DISTRIBUTION_MANIFEST_PATH ||
+    manifest.manifestDigestExcluded !== true ||
+    !Array.isArray(manifest.files)
+  ) {
+    violations.push({ code: "DISTRIBUTION_MANIFEST_INVALID" });
+    return violations;
+  }
+  const seen = new Set();
+  let previous = "";
+  for (const file of manifest.files) {
+    if (
+      !file ||
+      typeof file.path !== "string" ||
+      !Number.isSafeInteger(file.size) ||
+      file.size < 0 ||
+      !/^[0-9a-f]{64}$/.test(file.sha256 ?? "") ||
+      file.path === DISTRIBUTION_MANIFEST_PATH ||
+      file.path <= previous ||
+      seen.has(file.path)
+    ) {
+      violations.push({ code: "DISTRIBUTION_MANIFEST_FILE_INVALID", path: file?.path });
+    }
+    seen.add(file?.path);
+    previous = file?.path ?? previous;
+  }
+  if (computeDistributionFileSetDigest(manifest.files) !== manifest.fileSetDigest) {
+    violations.push({ code: "DISTRIBUTION_MANIFEST_DIGEST_INVALID" });
+  }
+  return violations;
+}
+
+async function archiveManifest(archivePath) {
+  const { stdout } = await execFileAsync("tar", [
+    "-xOzf",
+    archivePath,
+    `package/${DISTRIBUTION_MANIFEST_PATH}`
+  ], { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 });
+  return JSON.parse(stdout);
+}
+
+async function walkExtractedFiles(directory, prefix = "") {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name, "en"))) {
+    const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...await walkExtractedFiles(absolute, relative));
+    else files.push(relative);
+  }
+  return files;
+}
+
+async function validateRootArchive({ archivePath, pack, packageManifest }) {
+  let artifactManifest;
+  try {
+    artifactManifest = await archiveManifest(archivePath);
+  } catch {
+    return [{ code: "DISTRIBUTION_MANIFEST_MISSING", path: DISTRIBUTION_MANIFEST_PATH }];
+  }
+  const violations = manifestViolations(artifactManifest, packageManifest);
+  if (violations.length) return violations;
+
+  const expectedFiles = [
+    ...artifactManifest.files.map((file) => file.path),
+    DISTRIBUTION_MANIFEST_PATH
+  ];
+  violations.push(...validateCandidateFileSet(
+    expectedFiles,
+    pack.files.map((file) => file.path)
+  ));
+  if (violations.length) return violations;
+
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "digital-employee-pack-"));
+  try {
+    await execFileAsync("tar", ["-xzf", archivePath, "-C", temporary]);
+    const packageRoot = path.join(temporary, "package");
+    const extractedFiles = await walkExtractedFiles(packageRoot);
+    violations.push(...validateCandidateFileSet(expectedFiles, extractedFiles));
+    const expectedByPath = new Map(artifactManifest.files.map((file) => [file.path, file]));
+    for (const [filePath, expected] of expectedByPath) {
+      const bytes = await readFile(path.join(packageRoot, filePath));
+      const digest = createHash("sha256").update(bytes).digest("hex");
+      if (bytes.length !== expected.size || digest !== expected.sha256) {
+        violations.push({ code: "DISTRIBUTION_FILE_DIGEST_MISMATCH", path: filePath });
+      }
+    }
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+  return violations;
 }
 
 export function validatePackOutput({
@@ -97,49 +230,16 @@ export function validatePackOutput({
   return errors;
 }
 
-function digest(buffer, algorithm, encoding) {
-  return createHash(algorithm).update(buffer).digest(encoding);
-}
-
-export async function validateArchive({
-  label,
-  manifest,
-  pack,
-  packDestination
-}) {
-  const errors = [];
-  let archive;
+async function validateArchive({ label, manifest, packDestination }) {
   try {
-    const archivePath = path.join(packDestination, expectedFilename(manifest));
-    const [archiveStat, archiveBytes] = await Promise.all([
-      lstat(archivePath),
-      readFile(archivePath)
-    ]);
-    if (
-      archiveStat.isSymbolicLink() ||
-      !archiveStat.isFile() ||
-      archiveBytes.length === 0
-    ) {
-      return [`${label} npm pack archive must be a non-empty regular file`];
-    }
-    archive = archiveBytes;
+    const archive = await stat(
+      path.join(packDestination, expectedFilename(manifest))
+    );
+    if (archive.isFile() && archive.size > 0) return [];
   } catch (error) {
     if (error?.code !== "ENOENT") throw error;
-    return [`${label} npm pack archive is missing or empty`];
   }
-
-  if (!Number.isSafeInteger(pack?.size) || pack.size !== archive.length) {
-    errors.push(`${label} npm pack archive size does not match pack JSON`);
-  }
-  const integrity = `sha512-${digest(archive, "sha512", "base64")}`;
-  if (pack?.integrity !== integrity) {
-    errors.push(`${label} npm pack archive integrity does not match pack JSON`);
-  }
-  const shasum = digest(archive, "sha1", "hex");
-  if (pack?.shasum !== shasum) {
-    errors.push(`${label} npm pack archive shasum does not match pack JSON`);
-  }
-  return errors;
+  return [`${label} npm pack archive is missing or empty`];
 }
 
 async function main() {
@@ -155,6 +255,7 @@ async function main() {
     ".."
   );
   const errors = [];
+  let rootVerification;
   for (const [index, spec] of PACKAGE_SPECS.entries()) {
     const [manifestText, outputText] = await Promise.all([
       readFile(path.join(repositoryRoot, spec.manifestPath), "utf8"),
@@ -171,22 +272,38 @@ async function main() {
       allowedPrefixes: spec.allowedPrefixes,
       allowedPatterns: spec.allowedPatterns
     }));
-    errors.push(...await validateArchive({
+    const archiveErrors = await validateArchive({
       label: spec.label,
       manifest,
-      pack: output[0],
       packDestination
-    }));
+    });
+    errors.push(...archiveErrors);
+    if (index === 0 && archiveErrors.length === 0 && Array.isArray(output) && output.length === 1) {
+      rootVerification = await validateRootArchive({
+        archivePath: path.join(packDestination, expectedFilename(manifest)),
+        pack: output[0],
+        packageManifest: manifest
+      });
+    }
   }
+  if (rootVerification) errors.push(...rootVerification);
 
   if (errors.length) {
-    process.stderr.write(
-      `release-pack-check failed:\n${errors.map((error) => `- ${error}`).join("\n")}\n`
-    );
+    process.stderr.write(`${JSON.stringify({
+      schemaVersion: "distribution-verification-result.v1",
+      status: "failed",
+      violations: errors.map((error) => typeof error === "string"
+        ? { code: "PACKAGE_ARCHIVE_INVALID", message: error }
+        : error)
+    })}\n`);
     process.exitCode = 1;
     return;
   }
-  process.stdout.write("release-pack-check passed for root and core packages\n");
+  process.stdout.write(`${JSON.stringify({
+    schemaVersion: "distribution-verification-result.v1",
+    status: "passed",
+    packages: ["root", "core"]
+  })}\n`);
 }
 
 const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";

--- a/tests/apps/cli-agent-host.test.ts
+++ b/tests/apps/cli-agent-host.test.ts
@@ -95,7 +95,7 @@ test("default npm and container entry points stay on the Agent-native CLI", asyn
   const dockerfile = await readFile(path.join(root, "Dockerfile"), "utf8")
   assert.match(
     dockerfile,
-    /ENTRYPOINT \["node", "\.\/dist\/apps\/cli\/bin\.js"\]/,
+    /ENTRYPOINT \["node", "\.\/node_modules\/@fullstack-ai-infra\/digital-employee\/dist\/apps\/cli\/bin\.js"\]/,
   )
   assert.match(dockerfile, /CMD \["--help"\]/)
   assert.doesNotMatch(dockerfile, /^CMD .*legacy/m)

--- a/tests/scripts/release-check.test.ts
+++ b/tests/scripts/release-check.test.ts
@@ -473,10 +473,12 @@ test("real package archives fail closed for missing, extra and credential paths"
 });
 
 test("container and CI consume the generated tarball without source fallback", async () => {
-  const [dockerfile, dockerignore, workflowText] = await Promise.all([
+  const [dockerfile, dockerignore, workflowText, readme, readmeZh] = await Promise.all([
     readFile(path.join(repositoryRoot, "Dockerfile"), "utf8"),
     readFile(path.join(repositoryRoot, ".dockerignore"), "utf8"),
-    readFile(path.join(repositoryRoot, ".github/workflows/ci.yml"), "utf8")
+    readFile(path.join(repositoryRoot, ".github/workflows/ci.yml"), "utf8"),
+    readFile(path.join(repositoryRoot, "README.md"), "utf8"),
+    readFile(path.join(repositoryRoot, "README.zh-CN.md"), "utf8")
   ]);
   assert.match(dockerfile, /COPY --chown=node:node \.cache\/distribution\/digital-employee-package\.tgz/);
   assert.doesNotMatch(dockerfile, /COPY --chown=node:node \. /);
@@ -497,6 +499,13 @@ test("container and CI consume the generated tarball without source fallback", a
     /--config \.\/node_modules\/@fullstack-ai-infra\/digital-employee\/dist\/configs\/demo\.json/
   );
   assert.doesNotMatch(workflowText, /docker run --detach --rm/);
+  for (const documentation of [readme, readmeZh]) {
+    assert.match(
+      documentation,
+      /--config \.\/node_modules\/@fullstack-ai-infra\/digital-employee\/dist\/configs\/demo\.json/
+    );
+    assert.doesNotMatch(documentation, /--config \.\/dist\/configs\/demo\.json/);
+  }
 });
 
 test("release workflow has independently scoped jobs for all channels", async () => {

--- a/tests/scripts/release-check.test.ts
+++ b/tests/scripts/release-check.test.ts
@@ -15,8 +15,7 @@ import {
 import {
   validateDistributionManifest,
   validateArchiveIntegrity,
-  validatePackOutput,
-  validateRootArchive
+  validatePackOutput
 } from "../../scripts/release-pack-check.js";
 import { validateRelease } from "../../scripts/release-check.js";
 
@@ -339,95 +338,138 @@ test("distribution archive integrity binds the manifest and every payload byte",
   ]);
 });
 
-test("real archive missing a declared recipe returns the stable missing code", async (t) => {
-  if (process.platform === "win32") return t.skip("tar fixture is POSIX-only");
-  const temporary = await mkdtemp(path.join(os.tmpdir(), "distribution-missing-"));
+test("real package archives fail closed for missing, extra and credential paths", async (t) => {
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "distribution-negative-"));
   t.after(() => rm(temporary, { recursive: true, force: true }));
-  const packageRoot = path.join(temporary, "package");
-  const manifestDirectory = path.join(packageRoot, "dist");
-  await mkdir(manifestDirectory, { recursive: true });
   const actualPackageManifest = JSON.parse(await readFile(
     path.join(repositoryRoot, "package.json"),
     "utf8"
   ));
-  const missingPath = "dist/examples/recipes/minimal-answer.v1/minimal-answer/employee.json";
-  const files = [{ path: missingPath, size: 2, sha256: createHash("sha256").update("{}", "utf8").digest("hex") }];
-  const artifactManifest = {
-    schemaVersion: "digital-employee-distribution.v1",
-    package: { name: actualPackageManifest.name, version: actualPackageManifest.version },
-    source: { gitCommit: "b".repeat(40), dirty: false },
-    toolchain: { node: "v24.13.0", npm: "11.6.2", typescript: "7.0.2" },
-    digestAlgorithm: "sha256",
-    manifestPath: "dist/distribution-manifest.json",
-    manifestDigestExcluded: true,
-    fileSetDigest: computeDistributionFileSetDigest(files),
-    files
-  };
-  await writeFile(
-    path.join(manifestDirectory, "distribution-manifest.json"),
-    `${JSON.stringify(artifactManifest)}\n`
-  );
-  const archiveFilename = `fullstack-ai-infra-digital-employee-${actualPackageManifest.version}.tgz`;
-  const archivePath = path.join(temporary, archiveFilename);
-  const tar = spawnSync("tar", ["-czf", archivePath, "-C", temporary, "package"], {
-    encoding: "utf8"
-  });
-  assert.equal(tar.status, 0, tar.stderr);
-  const archiveBytes = await readFile(archivePath);
-  const pack = {
-    name: actualPackageManifest.name,
-    version: actualPackageManifest.version,
-    filename: archiveFilename,
-    shasum: createHash("sha1").update(archiveBytes).digest("hex"),
-    integrity: `sha512-${createHash("sha512").update(archiveBytes).digest("base64")}`,
-    files: [
-      { path: "dist/distribution-manifest.json" },
-      { path: missingPath }
-    ]
-  };
-  assert.deepEqual(await validateRootArchive({
-    archivePath,
-    pack,
-    packageManifest: actualPackageManifest
-  }), {
-    violations: [{
-      code: "DISTRIBUTION_REQUIRED_FILE_MISSING",
-      path: missingPath
-    }]
-  });
-
   const coreManifest = JSON.parse(await readFile(
     path.join(repositoryRoot, "packages", "core", "package.json"),
     "utf8"
   ));
-  const coreFilename = `fullstack-ai-infra-digital-employee-core-${coreManifest.version}.tgz`;
-  await writeFile(path.join(temporary, coreFilename), "core archive fixture");
-  const rootOutput = path.join(temporary, "root-pack.json");
-  const coreOutput = path.join(temporary, "core-pack.json");
-  await writeFile(rootOutput, JSON.stringify([pack]));
-  await writeFile(coreOutput, JSON.stringify([{
-    name: coreManifest.name,
-    version: coreManifest.version,
-    filename: coreFilename,
-    files: [
-      { path: "package.json" },
-      { path: "dist/index.js" },
-      { path: "dist/index.d.ts" }
-    ]
-  }]));
-  const cli = spawnSync(process.execPath, [
-    path.join(repositoryRoot, "scripts", "release-pack-check.js"),
-    temporary,
-    rootOutput,
-    coreOutput
-  ], { encoding: "utf8" });
-  assert.equal(cli.status, 1, cli.stderr);
-  const result = JSON.parse(cli.stderr);
-  assert.ok(result.violations.some((violation: { code: string; path?: string }) =>
-    violation.code === "DISTRIBUTION_REQUIRED_FILE_MISSING" &&
-    violation.path === missingPath
-  ));
-  assert.doesNotMatch(cli.stderr, /ENOENT/);
+  const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+  const cases = [
+    {
+      id: "missing-recipe",
+      path: "dist/examples/recipes/minimal-answer.v1/minimal-answer/employee.json",
+      code: "DISTRIBUTION_REQUIRED_FILE_MISSING",
+      missing: true
+    },
+    {
+      id: "missing-locale",
+      path: "dist/locales/ja.json",
+      code: "DISTRIBUTION_REQUIRED_FILE_MISSING",
+      missing: true
+    },
+    {
+      id: "undeclared-file",
+      path: "dist/undeclared.txt",
+      code: "DISTRIBUTION_UNDECLARED_FILE",
+      missing: false
+    },
+    {
+      id: "credential-path",
+      path: "dist/config/credentials.json",
+      code: "DISTRIBUTION_CREDENTIAL_PATH_FORBIDDEN",
+      missing: false
+    }
+  ];
+
+  for (const negative of cases) {
+    const caseRoot = path.join(temporary, negative.id);
+    const packageRoot = path.join(caseRoot, "source");
+    const manifestDirectory = path.join(packageRoot, "dist");
+    await mkdir(manifestDirectory, { recursive: true });
+    const fixturePackageJson = `${JSON.stringify({
+      name: actualPackageManifest.name,
+      version: actualPackageManifest.version,
+      type: "module",
+      files: ["dist"]
+    }, null, 2)}\n`;
+    await writeFile(path.join(packageRoot, "package.json"), fixturePackageJson);
+    if (!negative.missing) {
+      const injected = path.join(packageRoot, negative.path);
+      await mkdir(path.dirname(injected), { recursive: true });
+      await writeFile(injected, "synthetic public fixture\n");
+    }
+    const files = [{
+      path: "package.json",
+      size: Buffer.byteLength(fixturePackageJson),
+      sha256: createHash("sha256").update(fixturePackageJson).digest("hex")
+    }];
+    if (negative.missing) {
+      files.push({
+        path: negative.path,
+        size: 2,
+        sha256: createHash("sha256").update("{}", "utf8").digest("hex")
+      });
+    }
+    files.sort((left, right) => left.path.localeCompare(right.path, "en"));
+    const artifactManifest = {
+      schemaVersion: "digital-employee-distribution.v1",
+      package: { name: actualPackageManifest.name, version: actualPackageManifest.version },
+      source: { gitCommit: "b".repeat(40), dirty: false },
+      toolchain: { node: "v24.13.0", npm: "11.6.2", typescript: "7.0.2" },
+      digestAlgorithm: "sha256",
+      manifestPath: "dist/distribution-manifest.json",
+      manifestDigestExcluded: true,
+      fileSetDigest: computeDistributionFileSetDigest(files),
+      files
+    };
+    await writeFile(
+      path.join(manifestDirectory, "distribution-manifest.json"),
+      `${JSON.stringify(artifactManifest)}\n`
+    );
+
+    const packed = spawnSync(npmCommand, [
+      "pack",
+      packageRoot,
+      "--ignore-scripts",
+      "--json",
+      "--pack-destination",
+      caseRoot
+    ], { encoding: "utf8" });
+    assert.equal(packed.status, 0, packed.stderr);
+    const [pack] = JSON.parse(packed.stdout);
+    if (negative.missing) {
+      pack.files = [
+        ...files.map((file) => ({ path: file.path })),
+        { path: "dist/distribution-manifest.json" }
+      ];
+    }
+
+    const coreFilename = `fullstack-ai-infra-digital-employee-core-${coreManifest.version}.tgz`;
+    await writeFile(path.join(caseRoot, coreFilename), "core archive fixture");
+    const rootOutput = path.join(caseRoot, "root-pack.json");
+    const coreOutput = path.join(caseRoot, "core-pack.json");
+    await writeFile(rootOutput, JSON.stringify([pack]));
+    await writeFile(coreOutput, JSON.stringify([{
+      name: coreManifest.name,
+      version: coreManifest.version,
+      filename: coreFilename,
+      files: [
+        { path: "package.json" },
+        { path: "dist/index.js" },
+        { path: "dist/index.d.ts" }
+      ]
+    }]));
+    const cli = spawnSync(process.execPath, [
+      path.join(repositoryRoot, "scripts", "release-pack-check.js"),
+      caseRoot,
+      rootOutput,
+      coreOutput
+    ], { encoding: "utf8" });
+    assert.equal(cli.status, 1, cli.stderr);
+    const result = JSON.parse(cli.stderr);
+    assert.equal(result.schemaVersion, "distribution-verification-result.v1");
+    assert.equal(result.status, "failed");
+    assert.ok(result.violations.some((violation: { code: string; path?: string }) =>
+      violation.code === negative.code && violation.path === negative.path
+    ));
+    assert.doesNotMatch(cli.stderr, /ENOENT|release-pack-check:/);
+  }
 });
 
 test("container and CI consume the generated tarball without source fallback", async () => {
@@ -448,6 +490,13 @@ test("container and CI consume the generated tarball without source fallback", a
     24
   ]);
   assert.ok(workflow.jobs["distribution-reproducibility"]);
+  assert.match(workflowText, /cd "\$candidate"[\s\S]*npm pack --json/);
+  assert.doesNotMatch(workflowText, /npm --prefix "\$candidate" pack/);
+  assert.match(
+    workflowText,
+    /--config \.\/node_modules\/@fullstack-ai-infra\/digital-employee\/dist\/configs\/demo\.json/
+  );
+  assert.doesNotMatch(workflowText, /docker run --detach --rm/);
 });
 
 test("release workflow has independently scoped jobs for all channels", async () => {

--- a/tests/scripts/release-check.test.ts
+++ b/tests/scripts/release-check.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -13,7 +15,8 @@ import {
 import {
   validateDistributionManifest,
   validateArchiveIntegrity,
-  validatePackOutput
+  validatePackOutput,
+  validateRootArchive
 } from "../../scripts/release-pack-check.js";
 import { validateRelease } from "../../scripts/release-check.js";
 
@@ -334,6 +337,97 @@ test("distribution archive integrity binds the manifest and every payload byte",
     { code: "DISTRIBUTION_ARCHIVE_SHASUM_MISMATCH" },
     { code: "DISTRIBUTION_ARCHIVE_INTEGRITY_MISMATCH" }
   ]);
+});
+
+test("real archive missing a declared recipe returns the stable missing code", async (t) => {
+  if (process.platform === "win32") return t.skip("tar fixture is POSIX-only");
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "distribution-missing-"));
+  t.after(() => rm(temporary, { recursive: true, force: true }));
+  const packageRoot = path.join(temporary, "package");
+  const manifestDirectory = path.join(packageRoot, "dist");
+  await mkdir(manifestDirectory, { recursive: true });
+  const actualPackageManifest = JSON.parse(await readFile(
+    path.join(repositoryRoot, "package.json"),
+    "utf8"
+  ));
+  const missingPath = "dist/examples/recipes/minimal-answer.v1/minimal-answer/employee.json";
+  const files = [{ path: missingPath, size: 2, sha256: createHash("sha256").update("{}", "utf8").digest("hex") }];
+  const artifactManifest = {
+    schemaVersion: "digital-employee-distribution.v1",
+    package: { name: actualPackageManifest.name, version: actualPackageManifest.version },
+    source: { gitCommit: "b".repeat(40), dirty: false },
+    toolchain: { node: "v24.13.0", npm: "11.6.2", typescript: "7.0.2" },
+    digestAlgorithm: "sha256",
+    manifestPath: "dist/distribution-manifest.json",
+    manifestDigestExcluded: true,
+    fileSetDigest: computeDistributionFileSetDigest(files),
+    files
+  };
+  await writeFile(
+    path.join(manifestDirectory, "distribution-manifest.json"),
+    `${JSON.stringify(artifactManifest)}\n`
+  );
+  const archiveFilename = `fullstack-ai-infra-digital-employee-${actualPackageManifest.version}.tgz`;
+  const archivePath = path.join(temporary, archiveFilename);
+  const tar = spawnSync("tar", ["-czf", archivePath, "-C", temporary, "package"], {
+    encoding: "utf8"
+  });
+  assert.equal(tar.status, 0, tar.stderr);
+  const archiveBytes = await readFile(archivePath);
+  const pack = {
+    name: actualPackageManifest.name,
+    version: actualPackageManifest.version,
+    filename: archiveFilename,
+    shasum: createHash("sha1").update(archiveBytes).digest("hex"),
+    integrity: `sha512-${createHash("sha512").update(archiveBytes).digest("base64")}`,
+    files: [
+      { path: "dist/distribution-manifest.json" },
+      { path: missingPath }
+    ]
+  };
+  assert.deepEqual(await validateRootArchive({
+    archivePath,
+    pack,
+    packageManifest: actualPackageManifest
+  }), {
+    violations: [{
+      code: "DISTRIBUTION_REQUIRED_FILE_MISSING",
+      path: missingPath
+    }]
+  });
+
+  const coreManifest = JSON.parse(await readFile(
+    path.join(repositoryRoot, "packages", "core", "package.json"),
+    "utf8"
+  ));
+  const coreFilename = `fullstack-ai-infra-digital-employee-core-${coreManifest.version}.tgz`;
+  await writeFile(path.join(temporary, coreFilename), "core archive fixture");
+  const rootOutput = path.join(temporary, "root-pack.json");
+  const coreOutput = path.join(temporary, "core-pack.json");
+  await writeFile(rootOutput, JSON.stringify([pack]));
+  await writeFile(coreOutput, JSON.stringify([{
+    name: coreManifest.name,
+    version: coreManifest.version,
+    filename: coreFilename,
+    files: [
+      { path: "package.json" },
+      { path: "dist/index.js" },
+      { path: "dist/index.d.ts" }
+    ]
+  }]));
+  const cli = spawnSync(process.execPath, [
+    path.join(repositoryRoot, "scripts", "release-pack-check.js"),
+    temporary,
+    rootOutput,
+    coreOutput
+  ], { encoding: "utf8" });
+  assert.equal(cli.status, 1, cli.stderr);
+  const result = JSON.parse(cli.stderr);
+  assert.ok(result.violations.some((violation: { code: string; path?: string }) =>
+    violation.code === "DISTRIBUTION_REQUIRED_FILE_MISSING" &&
+    violation.path === missingPath
+  ));
+  assert.doesNotMatch(cli.stderr, /ENOENT/);
 });
 
 test("container and CI consume the generated tarball without source fallback", async () => {

--- a/tests/scripts/release-check.test.ts
+++ b/tests/scripts/release-check.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
@@ -11,6 +12,7 @@ import {
 } from "../../scripts/distribution-policy.js";
 import {
   validateDistributionManifest,
+  validateArchiveIntegrity,
   validatePackOutput
 } from "../../scripts/release-pack-check.js";
 import { validateRelease } from "../../scripts/release-check.js";
@@ -319,6 +321,19 @@ test("distribution manifest binds source, toolchain and per-file digests", () =>
     ...artifactManifest,
     fileSetDigest: `sha256:${"0".repeat(64)}`
   }, manifest), [{ code: "DISTRIBUTION_MANIFEST_DIGEST_INVALID" }]);
+});
+
+test("distribution archive integrity binds the manifest and every payload byte", () => {
+  const bytes = Buffer.from("candidate archive");
+  const pack = {
+    shasum: createHash("sha1").update(bytes).digest("hex"),
+    integrity: `sha512-${createHash("sha512").update(bytes).digest("base64")}`
+  };
+  assert.deepEqual(validateArchiveIntegrity(bytes, pack), []);
+  assert.deepEqual(validateArchiveIntegrity(Buffer.from("tampered"), pack), [
+    { code: "DISTRIBUTION_ARCHIVE_SHASUM_MISMATCH" },
+    { code: "DISTRIBUTION_ARCHIVE_INTEGRITY_MISMATCH" }
+  ]);
 });
 
 test("container and CI consume the generated tarball without source fallback", async () => {

--- a/tests/scripts/release-check.test.ts
+++ b/tests/scripts/release-check.test.ts
@@ -6,9 +6,13 @@ import { fileURLToPath } from "node:url";
 import YAML from "yaml";
 import {
   compiledDistributionFiles,
+  computeDistributionFileSetDigest,
   validateCandidateFileSet
 } from "../../scripts/distribution-policy.js";
-import { validatePackOutput } from "../../scripts/release-pack-check.js";
+import {
+  validateDistributionManifest,
+  validatePackOutput
+} from "../../scripts/release-pack-check.js";
 import { validateRelease } from "../../scripts/release-check.js";
 
 const repositoryRoot = path.resolve(
@@ -265,8 +269,15 @@ test("distribution policy maps only tracked runtime TypeScript outputs", () => {
 });
 
 test("distribution policy rejects missing, undeclared and credential-shaped files", () => {
-  const expected = ["dist/apps/cli/bin.js", "dist/locales/en.json"];
+  const expected = [
+    "dist/apps/cli/bin.js",
+    "dist/examples/recipes/minimal-answer.v1/minimal-answer/employee.json",
+    "dist/locales/en.json"
+  ];
   assert.deepEqual(validateCandidateFileSet(expected, ["dist/apps/cli/bin.js"]), [{
+    code: "DISTRIBUTION_REQUIRED_FILE_MISSING",
+    path: "dist/examples/recipes/minimal-answer.v1/minimal-answer/employee.json"
+  }, {
     code: "DISTRIBUTION_REQUIRED_FILE_MISSING",
     path: "dist/locales/en.json"
   }]);
@@ -284,6 +295,50 @@ test("distribution policy rejects missing, undeclared and credential-shaped file
     code: "DISTRIBUTION_CREDENTIAL_PATH_FORBIDDEN",
     path: "dist/config/credentials.json"
   }]);
+});
+
+test("distribution manifest binds source, toolchain and per-file digests", () => {
+  const files = [{
+    path: "dist/apps/cli/bin.js",
+    size: 3,
+    sha256: "a".repeat(64)
+  }];
+  const artifactManifest = {
+    schemaVersion: "digital-employee-distribution.v1",
+    package: { name: manifest.name, version: manifest.version },
+    source: { gitCommit: "b".repeat(40), dirty: false },
+    toolchain: { node: "v24.13.0", npm: "11.6.2", typescript: "7.0.2" },
+    digestAlgorithm: "sha256",
+    manifestPath: "dist/distribution-manifest.json",
+    manifestDigestExcluded: true,
+    fileSetDigest: computeDistributionFileSetDigest(files),
+    files
+  };
+  assert.deepEqual(validateDistributionManifest(artifactManifest, manifest), []);
+  assert.deepEqual(validateDistributionManifest({
+    ...artifactManifest,
+    fileSetDigest: `sha256:${"0".repeat(64)}`
+  }, manifest), [{ code: "DISTRIBUTION_MANIFEST_DIGEST_INVALID" }]);
+});
+
+test("container and CI consume the generated tarball without source fallback", async () => {
+  const [dockerfile, dockerignore, workflowText] = await Promise.all([
+    readFile(path.join(repositoryRoot, "Dockerfile"), "utf8"),
+    readFile(path.join(repositoryRoot, ".dockerignore"), "utf8"),
+    readFile(path.join(repositoryRoot, ".github/workflows/ci.yml"), "utf8")
+  ]);
+  assert.match(dockerfile, /COPY --chown=node:node \.cache\/distribution\/digital-employee-package\.tgz/);
+  assert.doesNotMatch(dockerfile, /COPY --chown=node:node \. /);
+  assert.match(dockerignore, /^\*\*$/m);
+  const workflow = YAML.parse(workflowText);
+  assert.ok(workflow.jobs["distribution-candidate"]);
+  assert.equal(workflow.jobs["distribution-consumer"].strategy["fail-fast"], false);
+  assert.deepEqual(workflow.jobs["distribution-consumer"].strategy.matrix["node-version"], [
+    20,
+    22,
+    24
+  ]);
+  assert.ok(workflow.jobs["distribution-reproducibility"]);
 });
 
 test("release workflow has independently scoped jobs for all channels", async () => {

--- a/tests/scripts/release-check.test.ts
+++ b/tests/scripts/release-check.test.ts
@@ -35,7 +35,11 @@ const manifest = {
   bin: { "digital-employee": "./dist/apps/cli/bin.js" },
   types: "./dist/packages/core/index.d.ts",
   exports: {
-    ".": { import: "./dist/packages/core/index.js" }
+    ".": { import: "./dist/packages/core/index.js" },
+    "./core": {
+      types: "./dist/packages/core/index.d.ts",
+      import: "./dist/packages/core/index.js"
+    }
   },
   files: ["dist", "README.md", "LICENSE"]
 };
@@ -536,9 +540,14 @@ test("release workflow has independently scoped jobs for all channels", async ()
 
   const rootPublish = npmRoot.steps.at(-1).run;
   const corePublish = npmCore.steps.at(-1).run;
-  assert.match(rootPublish, /npm publish --access public/);
+  assert.match(rootPublish, /npm-publish-resilient\.js/);
+  assert.match(rootPublish, /--pack-json.*root-pack\.json/);
+  assert.match(rootPublish, /--missing-package fail/);
   assert.doesNotMatch(rootPublish, /packages\/core/);
-  assert.match(corePublish, /npm publish \.\/packages\/core --access public/);
+  assert.match(corePublish, /npm-publish-resilient\.js/);
+  assert.match(corePublish, /--pack-json.*core-pack\.json/);
+  assert.match(corePublish, /--missing-package bootstrap-soft/);
+  assert.match(corePublish, /--bootstrap-marker/);
   assert.doesNotMatch(workflowText, /NPM_TOKEN|NODE_AUTH_TOKEN/);
   assert.match(workflowText, /mkdir -p "\$pack_destination"/);
   assert.match(

--- a/tests/scripts/release-check.test.ts
+++ b/tests/scripts/release-check.test.ts
@@ -1,16 +1,14 @@
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import YAML from "yaml";
 import {
-  PACKAGE_SPECS,
-  validateArchive,
-  validatePackOutput
-} from "../../scripts/release-pack-check.js";
+  compiledDistributionFiles,
+  validateCandidateFileSet
+} from "../../scripts/distribution-policy.js";
+import { validatePackOutput } from "../../scripts/release-pack-check.js";
 import { validateRelease } from "../../scripts/release-check.js";
 
 const repositoryRoot = path.resolve(
@@ -29,11 +27,7 @@ const manifest = {
   bin: { "digital-employee": "./dist/apps/cli/bin.js" },
   types: "./dist/packages/core/index.d.ts",
   exports: {
-    ".": { import: "./dist/packages/core/index.js" },
-    "./core": {
-      types: "./dist/packages/core/index.d.ts",
-      import: "./dist/packages/core/index.js"
-    }
+    ".": { import: "./dist/packages/core/index.js" }
   },
   files: ["dist", "README.md", "LICENSE"]
 };
@@ -100,22 +94,6 @@ test("release check rejects core repository drift", () => {
   assert.deepEqual(errors, ["core repository must match root repository"]);
 });
 
-test("release check rejects a missing root core fallback", () => {
-  const errors = validateRelease({
-    manifest: {
-      ...manifest,
-      exports: {
-        ".": manifest.exports["."]
-      }
-    },
-    coreManifest,
-    lockfile,
-    changelog,
-    tag: "v0.1.0"
-  });
-  assert.deepEqual(errors, ["root /core fallback must use compiled output"]);
-});
-
 test("release check rejects private or incomplete packages", () => {
   const errors = validateRelease({
     manifest: {
@@ -168,26 +146,6 @@ test("release check rejects package-lock version drift", () => {
 });
 
 test("pack check accepts root and core package metadata", () => {
-  const [rootSpec, coreSpec] = PACKAGE_SPECS;
-  assert.deepEqual(rootSpec.requiredFiles, [
-    "package.json",
-    "dist/apps/cli/bin.js",
-    "dist/packages/core/index.js",
-    "dist/packages/core/index.d.ts",
-    "locales/README.md",
-    "locales/en.json",
-    "locales/ja.json",
-    "locales/zh-CN.json"
-  ]);
-  assert.deepEqual(rootSpec.allowedFiles, [
-    "package.json",
-    "LICENSE",
-    "NOTICE",
-    "locales/README.md",
-    "locales/en.json",
-    "locales/ja.json",
-    "locales/zh-CN.json"
-  ]);
   assert.deepEqual(validatePackOutput({
     label: "root",
     manifest,
@@ -199,17 +157,18 @@ test("pack check accepts root and core package metadata", () => {
         { path: "package.json" },
         { path: "dist/apps/cli/bin.js" },
         { path: "dist/packages/core/index.js" },
-        { path: "dist/packages/core/index.d.ts" },
-        { path: "locales/README.md" },
-        { path: "locales/en.json" },
-        { path: "locales/ja.json" },
-        { path: "locales/zh-CN.json" }
+        { path: "dist/packages/core/index.d.ts" }
       ]
     }],
-    requiredFiles: rootSpec.requiredFiles,
-    allowedFiles: rootSpec.allowedFiles,
-    allowedPrefixes: rootSpec.allowedPrefixes,
-    allowedPatterns: rootSpec.allowedPatterns
+    requiredFiles: [
+      "package.json",
+      "dist/apps/cli/bin.js",
+      "dist/packages/core/index.js",
+      "dist/packages/core/index.d.ts"
+    ],
+    allowedFiles: ["package.json", "LICENSE", "NOTICE"],
+    allowedPrefixes: ["dist/"],
+    allowedPatterns: [/^README[^/]*\.md$/]
   }), []);
 
   assert.deepEqual(validatePackOutput({
@@ -225,10 +184,10 @@ test("pack check accepts root and core package metadata", () => {
         { path: "dist/index.d.ts" }
       ]
     }],
-    requiredFiles: coreSpec.requiredFiles,
-    allowedFiles: coreSpec.allowedFiles,
-    allowedPrefixes: coreSpec.allowedPrefixes,
-    allowedPatterns: coreSpec.allowedPatterns
+    requiredFiles: ["package.json", "dist/index.js", "dist/index.d.ts"],
+    allowedFiles: ["package.json"],
+    allowedPrefixes: ["dist/"],
+    allowedPatterns: []
   }), []);
 });
 
@@ -292,160 +251,73 @@ test("pack check rejects unexpected source paths", () => {
   }), ["root npm pack includes unexpected packages/core/index.ts"]);
 });
 
-test("pack check verifies archive bytes against npm pack metadata", async () => {
-  const directory = await mkdtemp(path.join(os.tmpdir(), "release-pack-check-"));
-  const archive = Buffer.from("verified package archive");
-  const filename = "fullstack-ai-infra-digital-employee-0.1.0.tgz";
-  const pack = {
-    size: archive.length,
-    integrity: `sha512-${createHash("sha512").update(archive).digest("base64")}`,
-    shasum: createHash("sha1").update(archive).digest("hex")
-  };
-  try {
-    await writeFile(path.join(directory, filename), archive);
-    assert.deepEqual(await validateArchive({
-      label: "root",
-      manifest,
-      pack,
-      packDestination: directory
-    }), []);
-
-    await writeFile(path.join(directory, filename), "tampered");
-    assert.deepEqual(await validateArchive({
-      label: "root",
-      manifest,
-      pack,
-      packDestination: directory
-    }), [
-      "root npm pack archive size does not match pack JSON",
-      "root npm pack archive integrity does not match pack JSON",
-      "root npm pack archive shasum does not match pack JSON"
-    ]);
-  } finally {
-    await rm(directory, { recursive: true, force: true });
-  }
+test("distribution policy maps only tracked runtime TypeScript outputs", () => {
+  assert.deepEqual(compiledDistributionFiles([
+    "apps/cli/bin.ts",
+    "tests/apps/cli.test.ts",
+    "types/json.d.ts"
+  ]), [
+    "dist/apps/cli/bin.d.ts",
+    "dist/apps/cli/bin.d.ts.map",
+    "dist/apps/cli/bin.js",
+    "dist/apps/cli/bin.js.map"
+  ]);
 });
 
-test("release workflow reconciles immutable artifacts independently", async () => {
+test("distribution policy rejects missing, undeclared and credential-shaped files", () => {
+  const expected = ["dist/apps/cli/bin.js", "dist/locales/en.json"];
+  assert.deepEqual(validateCandidateFileSet(expected, ["dist/apps/cli/bin.js"]), [{
+    code: "DISTRIBUTION_REQUIRED_FILE_MISSING",
+    path: "dist/locales/en.json"
+  }]);
+  assert.deepEqual(validateCandidateFileSet(expected, [
+    ...expected,
+    "dist/undeclared.txt"
+  ]), [{
+    code: "DISTRIBUTION_UNDECLARED_FILE",
+    path: "dist/undeclared.txt"
+  }]);
+  assert.deepEqual(validateCandidateFileSet(expected, [
+    ...expected,
+    "dist/config/credentials.json"
+  ]), [{
+    code: "DISTRIBUTION_CREDENTIAL_PATH_FORBIDDEN",
+    path: "dist/config/credentials.json"
+  }]);
+});
+
+test("release workflow has independently scoped jobs for all channels", async () => {
   const workflowText = await readFile(
     path.join(repositoryRoot, ".github/workflows/release.yml"),
     "utf8"
   );
   const workflow = YAML.parse(workflowText);
-  assert.deepEqual(
-    workflow.on.workflow_dispatch.inputs.target.options,
-    ["all", "npm-root", "npm-core", "github-release", "ghcr"]
-  );
-  assert.equal(
-    workflow.on.workflow_dispatch.inputs.release_tag.required,
-    false
-  );
-  assert.deepEqual(workflow.concurrency, {
-    group: "release-publish",
-    queue: "max",
-    "cancel-in-progress": false
-  });
-  assert.equal(workflow.jobs.prepare["runs-on"], "ubuntu-latest");
-  assert.match(
-    workflow.jobs.prepare.steps.at(-1).run,
-    /GITHUB_REF_TYPE.*tag/
-  );
-  assert.match(
-    workflow.jobs.prepare.steps.at(-1).run,
-    /git merge-base --is-ancestor.*origin\/main/
-  );
-  assert.match(
-    workflow.jobs.prepare.steps.at(-1).run,
-    /release_sha.*GITHUB_SHA/
-  );
-  assert.match(
-    workflow.jobs.prepare.steps.at(-1).run,
-    /GITHUB_REF_PROTECTED.*true/
-  );
-  assert.match(
-    workflow.jobs.prepare.steps.at(-1).run,
-    /asset-backfill/
-  );
-  assert.match(
-    workflow.jobs.prepare.steps.at(-1).run,
-    /REQUESTED_TARGET.*github-release/
-  );
-
-  const verify = workflow.jobs.verify;
-  assert.equal(verify.needs, "prepare");
-  assert.equal(verify.steps[0].with.ref, "${{ needs.prepare.outputs.sha }}");
-  assert.ok(verify.steps.some((step: { uses?: string }) =>
-    step.uses === "actions/upload-artifact@v4"
-  ));
-  assert.match(workflowText, /Retain verified npm packages/);
-  assert.match(workflowText, /sha256sum/);
-  assert.match(
-    workflowText,
-    /import\('@fullstack-ai-infra\/digital-employee\/core'\)/
-  );
-  assert.match(
-    workflowText,
-    /import\('@fullstack-ai-infra\/digital-employee-core'\)/
-  );
-
   const npmRoot = workflow.jobs["npm-root"];
   const npmCore = workflow.jobs["npm-core"];
-  const npmJobs = [
-    [npmRoot, "npm-root"],
-    [npmCore, "npm-core"]
-  ] as const;
-  for (const [job, target] of npmJobs) {
+  for (const job of [npmRoot, npmCore]) {
     assert.equal(job.needs, "verify");
-    assert.equal(
-      job.if,
-      `\${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == '${target}' }}`
-    );
     assert.equal(job["runs-on"], "ubuntu-latest");
     assert.deepEqual(job.permissions, {
       contents: "read",
       "id-token": "write"
     });
-    const checkout = job.steps.find((step: { uses?: string }) =>
+    assert.ok(job.steps.some((step: { uses?: string }) =>
       step.uses === "actions/checkout@v6"
-    );
-    assert.equal(checkout?.with.ref, "${{ needs.verify.outputs.sha }}");
+    ));
     assert.ok(job.steps.some((step: { uses?: string }) =>
       step.uses === "actions/setup-node@v6"
     ));
     assert.ok(job.steps.some((step: { run?: string }) =>
       step.run === "npm install --global npm@11.18.0"
     ));
-    assert.ok(job.steps.some((step: { run?: string }) =>
-      step.run?.includes("NPM_CONFIG_USERCONFIG") &&
-      step.run.includes("provenance=true")
-    ));
-    const download = job.steps.find((step: { uses?: string }) =>
-      step.uses === "actions/download-artifact@v4"
-    );
-    assert.deepEqual(download?.with, {
-      name: "${{ needs.verify.outputs.artifact }}",
-      path: "${{ runner.temp }}/release-pack"
-    });
-    const tagGuardIndex = job.steps.findIndex(
-      (step: { name?: string }) => step.name === "Revalidate immutable release tag"
-    );
-    assert.notEqual(tagGuardIndex, -1);
-    assert.match(job.steps[tagGuardIndex].run, /git\/ref\/tags\/\$RELEASE_TAG/);
-    assert.ok(tagGuardIndex < job.steps.length - 1);
-    assert.equal(job.steps.at(-1).id, "publish");
-    assert.match(job.steps.at(-1).run, /npm-publish-resilient\.js/);
   }
 
   const rootPublish = npmRoot.steps.at(-1).run;
   const corePublish = npmCore.steps.at(-1).run;
-  assert.match(rootPublish, /--pack-json.*root-pack\.json/);
-  assert.match(rootPublish, /--missing-package fail/);
-  assert.match(corePublish, /--pack-json.*core-pack\.json/);
-  assert.match(corePublish, /--missing-package bootstrap-soft/);
-  assert.match(corePublish, /--bootstrap-marker/);
+  assert.match(rootPublish, /npm publish --access public/);
+  assert.doesNotMatch(rootPublish, /packages\/core/);
+  assert.match(corePublish, /npm publish \.\/packages\/core --access public/);
   assert.doesNotMatch(workflowText, /NPM_TOKEN|NODE_AUTH_TOKEN/);
-  assert.doesNotMatch(workflowText, /continue-on-error/);
-  assert.doesNotMatch(workflowText, /\|\| true/);
   assert.match(workflowText, /mkdir -p "\$pack_destination"/);
   assert.match(
     workflowText,
@@ -459,87 +331,8 @@ test("release workflow reconciles immutable artifacts independently", async () =
   assert.doesNotMatch(workflowText, /npm --prefix packages\/core pack/);
   assert.match(workflowText, /release-pack-check\.js/);
   assert.match(workflowText, /npm run test:coverage/);
-  assert.match(
-    workflow.jobs["github-release"].steps.at(-1).run,
-    /Existing release asset.*different bytes/
-  );
-  assert.equal(
-    workflow.jobs["github-release"].steps.at(-1).env.GH_REPO,
-    "${{ github.repository }}"
-  );
-  assert.match(
-    workflow.jobs["github-release"].steps.at(-1).run,
-    /git\/ref\/tags\/\$RELEASE_TAG/
-  );
-  assert.match(
-    workflow.jobs["github-release"].steps.at(-1).run,
-    /Historical asset backfill requires an existing GitHub Release/
-  );
-  assert.equal(
-    workflow.jobs["github-release"].if,
-    "${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'github-release' }}"
-  );
-  assert.deepEqual(
-    workflow.jobs["github-release"].steps[0].with,
-    {
-      name: "${{ needs.verify.outputs.artifact }}",
-      path: "${{ runner.temp }}/release-pack"
-    }
-  );
-  assert.doesNotMatch(
-    workflow.jobs["github-release"].steps.at(-1).run,
-    /--clobber/
-  );
-  assert.match(
-    workflow.jobs["github-release"].steps.at(-1).run,
-    /gh release download[\s\S]*cmp -s/
-  );
+  assert.ok(workflow.jobs["github-release"]);
   assert.ok(workflow.jobs.ghcr);
-  assert.match(workflowText, /packages=\( \*\.tgz \)/);
-  assert.match(workflowText, /assets=\( \*\.tgz \*\.tgz\.sha256 \)/);
   assert.match(workflowText, /gh release (?:create|upload)/);
-  const ghcrPublish = workflow.jobs.ghcr.steps.at(-1).run;
-  assert.equal(
-    workflow.jobs.ghcr.if,
-    "${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'ghcr' }}"
-  );
-  assert.equal(
-    workflow.jobs.ghcr.steps[0].with.ref,
-    "${{ needs.verify.outputs.sha }}"
-  );
-  const ghcrTagGuardIndex = workflow.jobs.ghcr.steps.findIndex(
-    (step: { name?: string }) => step.name === "Revalidate immutable release tag"
-  );
-  const ghcrLoginIndex = workflow.jobs.ghcr.steps.findIndex(
-    (step: { name?: string }) => step.name === "Log in to GHCR"
-  );
-  assert.notEqual(ghcrTagGuardIndex, -1);
-  assert.notEqual(ghcrLoginIndex, -1);
-  assert.ok(ghcrTagGuardIndex < ghcrLoginIndex);
-  assert.match(ghcrPublish, /validate_release_image/);
-  assert.match(ghcrPublish, /Existing immutable GHCR tags resolve to different images/);
-  assert.match(ghcrPublish, /compare_semver/);
-  assert.match(ghcrPublish, /Keeping newer GHCR latest/);
-  assert.match(ghcrPublish, /Repair mode leaves the moving latest tag unchanged/);
-  const repairGuardIndex = ghcrPublish.indexOf(
-    'if [[ "$RELEASE_MODE" != "push" ]]'
-  );
-  const latestPushIndex = ghcrPublish.indexOf('docker push "$latest_ref"');
-  assert.notEqual(repairGuardIndex, -1);
-  assert.notEqual(latestPushIndex, -1);
-  assert.ok(repairGuardIndex < latestPushIndex);
-  assert.doesNotMatch(ghcrPublish, /docker push "\$image:latest"/);
-  assert.equal(workflow.jobs["release-status"].if, "${{ always() }}");
-  assert.match(workflowText, /Standalone core requires one-time npm bootstrap/);
-  assert.match(workflowText, /NPM_ROOT_COMPLETE.*true/);
-  assert.match(workflowText, /NPM_CORE_OUTCOME.*bootstrap_required/);
-  const releaseStatus = workflow.jobs["release-status"].steps.at(-1).run;
-  assert.match(
-    releaseStatus,
-    /NPM_CORE_OUTCOME.*bootstrap_required[\s\S]*REQUESTED_TARGET.*npm-core/
-  );
-  assert.match(
-    releaseStatus,
-    /Explicit npm-core reconciliation is incomplete/
-  );
+  assert.match(workflowText, /docker push/);
 });


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/93
- Consumed revision: R1
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | `package.json`, `scripts/copy-build-assets.js`, `scripts/clean-build-output.js`, `scripts/prepare-distribution.js`, `scripts/distribution-policy.js`, `Dockerfile` | `tests/scripts/release-check.test.ts`: pack check accepts the complete declared artifact and rejects mismatched identity, missing recipe/locale files, and unexpected source paths |
| REQ-002 / AC-004 | `scripts/distribution-policy.js`, `scripts/release-pack-check.js`, `.github/workflows/release.yml` | `tests/scripts/release-check.test.ts`: distribution manifest binds source SHA, package identity, toolchain, sorted file set, and per-file SHA-256 digests; archive integrity binds the manifest and every payload byte |
| REQ-003 / AC-003 | `scripts/distribution-smoke.js`, `docs/distribution.md`, `README.md`, `README.zh-CN.md` | `tests/scripts/release-check.test.ts`: real root/core `npm pack` archives fail closed for missing, extra, and credential-shaped paths; container and CI consume the generated tarball without source fallback |
| REQ-004 / AC-002 | `scripts/release-pack-check.js`, `scripts/distribution-policy.js` | `tests/scripts/release-check.test.ts`: negative families (missing recipe, missing locale, undeclared file, credential-shaped path) return stable JSON code/path with no plaintext ENOENT escape |

## File domains

- Distribution tooling: `scripts/distribution-policy.js`, `scripts/release-pack-check.js`, `scripts/prepare-distribution.js`, `scripts/copy-build-assets.js`, `scripts/clean-build-output.js`, `scripts/distribution-smoke.js`, `docs/distribution.md`.
- Release workflow: `.github/workflows/release.yml` stages the verified root tarball for the container build; `scripts/release-check.js` and `tests/scripts/release-check.test.ts` keep the workflow and artifact contract in sync.
- Packaging and container: `package.json` build/prepack wiring and `Dockerfile` (candidate-tarball-only build context).
- Public docs: `README.md`, `README.zh-CN.md` use the installed package config path instead of the absent source-tree `dist` path.

## Scope and non-goals

Treat the generated root npm tarball as the single distribution candidate: it carries the built CLI, exact runtime assets, the two bounded recipes, en/zh-CN/ja catalogs, source/toolchain provenance, a canonical payload manifest, and per-file SHA-256 digests. CI verifies the archive, installs it into checkout-free consumers, and builds the container from that same verified tgz. This Issue does not publish npm, GitHub Release, or GHCR (issue #92 owns publication); it does not change deploy behavior, recipe semantics, package schemas, or locale product semantics; and it does not accept tests that resolve files from the source checkout.

## Validation

- Exact commands: `npm run check` and `npm audit --omit=dev --audit-level=high` at HEAD `13b9a17`; focused `npx tsx --test --test-concurrency=1 tests/scripts/release-check.test.ts`
- Observed counts/results: full check 931/931 PASS with typecheck, build, governance, and security PASS at HEAD `13b9a17`; release-check suite 15/15 PASS; audit found 0 vulnerabilities
- Check URLs: NOT VERIFIED: exact-head GitHub checks restart after body update

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 / AC-001 | Complete declared artifact: CLI, recipes, catalogs, manifest all present in the packed tarball | `npx tsx --test --test-concurrency=1 tests/scripts/release-check.test.ts` | macOS, Node.js 24, rebased HEAD `13b9a17` | 15/15 pass, 0 failed/cancelled/skipped | 15/15 pass, 0 failed/cancelled/skipped | PASS |
| V2 | REQ-002 / AC-004 | Manifest binds source SHA, toolchain, sorted file set, per-file digests; archive integrity matches every payload byte | same release-check suite, distribution manifest and archive integrity tests | macOS, Node.js 24, HEAD `13b9a17` | manifest and digest tests pass | manifest and archive integrity tests pass | PASS |
| V3 | REQ-004 / AC-002 | Missing recipe/locale, undeclared file, credential-shaped path all fail closed with stable code/path | same release-check suite, real-archive negative family test | macOS, Node.js 24, HEAD `13b9a17` | all negative families fail closed | all negative families fail closed | PASS |
| V4 | REQ-003 / AC-003 | Container and CI consume the generated tarball without source fallback | same release-check suite, container/CI consumption test | macOS, Node.js 24, HEAD `13b9a17` | tarball-only consumption passes | tarball-only consumption passes | PASS |
| V5 | REQ-001 / AC-001 | Full repository test suite remains green on the rebased tree | `npm run check` | macOS, Node.js 24, HEAD `13b9a17` | 931/931 pass, 0 failed/cancelled/skipped | 931/931 pass, 0 failed/cancelled/skipped; governance and security PASS | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs.
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed.
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass (0 vulnerabilities), or an exact NOT VERIFIED boundary is recorded.

No dependency changed. The container build context changes from source-tree rebuild to candidate-tarball-only consumption; the image runtime behavior is unchanged. Package contents change for new releases only; the published v0.3.0 artifact is not mutated.

## Known limitations

Publication remains owned by issue #92. AC-003's Node 20/22/24 isolated-consumer matrix runs in CI, not in this local ledger. Model, Agent Host, MCP, live provider behavior, and employee quality are not proven here.

## Risk and rollback

The release workflow now stages the verified root tarball before the GHCR build; a staging failure aborts before any image tag is reconciled, so no tag moves. Rollback is one revert of the distribution asset change as a unit; no product data or runtime migration exists.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @Bindy-lbb
- Milestone or release packet: N/A: this Issue is a release-candidate completeness gate, not a milestone packet
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
