### PR TITLE
fix: make release publication resilient

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -733,8 +733,14 @@ jobs:
           if selected npm-core; then
             if [[ "$NPM_CORE_RESULT" != "success" ]]; then
               failed=1
-            elif [[ "$NPM_CORE_COMPLETE" != "true" && "$NPM_CORE_OUTCOME" != "bootstrap_required" ]]; then
-              failed=1
+            elif [[ "$NPM_CORE_COMPLETE" != "true" ]]; then
+              if [[ "$NPM_CORE_OUTCOME" != "bootstrap_required" || \
+                    "$REQUESTED_TARGET" == "npm-core" ]]; then
+                if [[ "$NPM_CORE_OUTCOME" == "bootstrap_required" ]]; then
+                  echo "::error::Explicit npm-core reconciliation is incomplete until one-time npm owner bootstrap finishes"
+                fi
+                failed=1
+              fi
             fi
           fi
           if selected ghcr && [[ "$GHCR_RESULT" != "success" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,21 +4,125 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Channel to reconcile from the selected release tag
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - npm-root
+          - npm-core
+          - github-release
+          - ghcr
+      release_tag:
+        description: Existing tag to backfill (default-branch github-release repairs only)
+        required: false
+        type: string
 
 permissions:
   contents: read
 
+# npm and GHCR both mutate moving tags. Serialize releases across versions so
+# an older job cannot finish last and roll latest back.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-publish
+  queue: max
   cancel-in-progress: false
 
 jobs:
-  verify:
+  prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
+      artifact: ${{ steps.release.outputs.artifact }}
+      mode: ${{ steps.release.outputs.mode }}
+      sha: ${{ steps.release.outputs.sha }}
+      tag: ${{ steps.release.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: release
+        name: Resolve and authorize release tag
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
+          REQUESTED_TARGET: ${{ inputs.target }}
+        shell: bash
+        run: |
+          mode="push"
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            if [[ "$GITHUB_REF_PROTECTED" != "true" ]]; then
+              echo "::error::Stable release tags must be covered by an active tag ruleset"
+              exit 1
+            fi
+            if [[ -n "$RELEASE_TAG_INPUT" ]]; then
+              echo "::error::release_tag must be empty when dispatching from a tag ref"
+              exit 1
+            fi
+            release_tag="$GITHUB_REF_NAME"
+            if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+              mode="repair"
+            fi
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && \
+                  "$GITHUB_REF_TYPE" == "branch" && \
+                  "$GITHUB_REF_NAME" == "$DEFAULT_BRANCH" && \
+                  "$REQUESTED_TARGET" == "github-release" && \
+                  -n "$RELEASE_TAG_INPUT" ]]; then
+            # Old tags do not contain this workflow_dispatch definition. Permit
+            # the current default-branch workflow to rebuild only their immutable
+            # GitHub Release assets; no npm or GHCR job is selected in this mode.
+            release_tag="$RELEASE_TAG_INPUT"
+            mode="asset-backfill"
+          else
+            echo "::error::Start releases/repairs from a tag, or request a github-release backfill from the default branch"
+            exit 1
+          fi
+          if [[ ! "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must match vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+          if [[ "$mode" == "asset-backfill" ]]; then
+            git fetch origin "refs/tags/$release_tag:refs/tags/$release_tag" --force
+          fi
+          release_sha="$(git rev-parse --verify "${release_tag}^{commit}")"
+          if [[ "$mode" != "asset-backfill" && "$release_sha" != "$GITHUB_SHA" ]]; then
+            echo "::error::$release_tag no longer resolves to the event commit"
+            exit 1
+          fi
+          git fetch origin main:refs/remotes/origin/main --no-tags
+          if ! git merge-base --is-ancestor "$release_sha" origin/main; then
+            echo "::error::$release_tag is not reachable from origin/main"
+            exit 1
+          fi
+          {
+            echo "artifact=npm-release-packages-$release_tag"
+            echo "mode=$mode"
+            echo "sha=$release_sha"
+            echo "tag=$release_tag"
+          } >> "$GITHUB_OUTPUT"
+
+  verify:
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: source
+    outputs:
+      artifact: ${{ needs.prepare.outputs.artifact }}
+      mode: ${{ needs.prepare.outputs.mode }}
+      sha: ${{ needs.prepare.outputs.sha }}
+      tag: ${{ needs.prepare.outputs.tag }}
       version: ${{ steps.package.outputs.version }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          path: source
+          ref: ${{ needs.prepare.outputs.sha }}
       - uses: actions/setup-node@v6
         with:
           # Node 24's experimental test coverage reporter can end with a JSON
@@ -30,61 +134,168 @@ jobs:
       - run: npm run check
       - run: npm run test:coverage
       - run: npm audit --omit=dev --audit-level=high
-      - run: npm run release:check -- --tag "$GITHUB_REF_NAME"
-      - name: Verify npm package archives
+      - name: Verify release metadata
+        env:
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+        run: npm run release:check -- --tag "$RELEASE_TAG"
+      - name: Build and verify immutable npm package archives
         run: |
           pack_destination="$RUNNER_TEMP/release-pack"
           mkdir -p "$pack_destination"
-          npm pack --json --pack-destination "$pack_destination" > "$RUNNER_TEMP/root-pack.json"
-          npm pack ./packages/core --json --pack-destination "$pack_destination" > "$RUNNER_TEMP/core-pack.json"
+          npm pack --json --pack-destination "$pack_destination" > "$pack_destination/root-pack.json"
+          npm pack ./packages/core --json --pack-destination "$pack_destination" > "$pack_destination/core-pack.json"
           node ./scripts/release-pack-check.js \
             "$pack_destination" \
-            "$RUNNER_TEMP/root-pack.json" \
-            "$RUNNER_TEMP/core-pack.json"
+            "$pack_destination/root-pack.json" \
+            "$pack_destination/core-pack.json"
+          root_package="$(node --input-type=module -e "import fs from 'node:fs'; const [entry] = JSON.parse(fs.readFileSync('$pack_destination/root-pack.json', 'utf8')); process.stdout.write(entry.filename)")"
+          core_package="$(node --input-type=module -e "import fs from 'node:fs'; const [entry] = JSON.parse(fs.readFileSync('$pack_destination/core-pack.json', 'utf8')); process.stdout.write(entry.filename)")"
+          root_consumer="$RUNNER_TEMP/root-package-consumer"
+          core_consumer="$RUNNER_TEMP/core-package-consumer"
+          mkdir -p "$root_consumer" "$core_consumer"
+          npm install --prefix "$root_consumer" \
+            --ignore-scripts \
+            "$pack_destination/$root_package"
+          (
+            cd "$root_consumer"
+            node --input-type=module -e "await import('@fullstack-ai-infra/digital-employee/core')"
+          )
+          npm install --prefix "$core_consumer" \
+            --ignore-scripts \
+            "$pack_destination/$core_package"
+          (
+            cd "$core_consumer"
+            node --input-type=module -e "await import('@fullstack-ai-infra/digital-employee-core')"
+          )
+          shopt -s nullglob
+          packages=( "$pack_destination"/*.tgz )
+          if [[ "${#packages[@]}" -ne 2 ]]; then
+            echo "::error::Expected exactly two npm package archives"
+            exit 1
+          fi
+          for package_file in "${packages[@]}"; do
+            (
+              cd "$pack_destination"
+              sha256sum "$(basename "$package_file")" > "$(basename "$package_file").sha256"
+            )
+          done
+      - name: Retain verified npm packages for every release channel
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ needs.prepare.outputs.artifact }}
+          path: ${{ runner.temp }}/release-pack
+          if-no-files-found: error
+          retention-days: 30
       - id: package
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
   github-release:
+    if: ${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'github-release' }}
     needs: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - name: Download verified npm packages
+        uses: actions/download-artifact@v4
         with:
-          node-version: 24
-          package-manager-cache: false
-      - run: npm ci
-      - id: package
-        shell: bash
-        run: |
-          npm pack --json > package-output.json
-          package_file="$(node --input-type=module -e "import fs from 'node:fs'; const [entry] = JSON.parse(fs.readFileSync('package-output.json', 'utf8')); process.stdout.write(entry.filename)")"
-          sha256sum "$package_file" > "$package_file.sha256"
-          echo "file=$package_file" >> "$GITHUB_OUTPUT"
-      - name: Create or update GitHub Release
+          name: ${{ needs.verify.outputs.artifact }}
+          path: ${{ runner.temp }}/release-pack
+      - name: Create or reconcile immutable GitHub Release assets
         env:
           GH_TOKEN: ${{ github.token }}
-          PACKAGE_FILE: ${{ steps.package.outputs.file }}
+          GH_REPO: ${{ github.repository }}
+          PACK_DIR: ${{ runner.temp }}/release-pack
+          RELEASE_MODE: ${{ needs.verify.outputs.mode }}
+          RELEASE_SHA: ${{ needs.verify.outputs.sha }}
+          RELEASE_TAG: ${{ needs.verify.outputs.tag }}
+        shell: bash
         run: |
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" "$PACKAGE_FILE" "$PACKAGE_FILE.sha256" --clobber
-          else
-            gh release create "$GITHUB_REF_NAME" "$PACKAGE_FILE" "$PACKAGE_FILE.sha256" \
+          read -r remote_object_type remote_object_sha < <(
+            gh api "repos/$GH_REPO/git/ref/tags/$RELEASE_TAG" \
+              --jq '.object | [.type, .sha] | @tsv'
+          )
+          peel_count=0
+          while [[ "$remote_object_type" == "tag" ]]; do
+            ((peel_count += 1))
+            if [[ "$peel_count" -gt 5 ]]; then
+              echo "::error::$RELEASE_TAG has an unexpectedly deep annotated-tag chain"
+              exit 1
+            fi
+            read -r remote_object_type remote_object_sha < <(
+              gh api "repos/$GH_REPO/git/tags/$remote_object_sha" \
+                --jq '.object | [.type, .sha] | @tsv'
+            )
+          done
+          if [[ "$remote_object_type" != "commit" || \
+                "$remote_object_sha" != "$RELEASE_SHA" ]]; then
+            echo "::error::$RELEASE_TAG moved after release preparation"
+            exit 1
+          fi
+          cd "$PACK_DIR"
+          shopt -s nullglob
+          packages=( *.tgz )
+          if [[ "${#packages[@]}" -ne 2 ]]; then
+            echo "::error::Expected exactly two verified npm package archives"
+            exit 1
+          fi
+          for package_file in "${packages[@]}"; do
+            sha256sum -c "$package_file.sha256"
+          done
+          assets=( *.tgz *.tgz.sha256 )
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            if [[ "$RELEASE_MODE" == "asset-backfill" ]]; then
+              echo "::error::Historical asset backfill requires an existing GitHub Release"
+              exit 1
+            fi
+            gh release create "$RELEASE_TAG" "${assets[@]}" \
               --verify-tag \
               --generate-notes \
-              --title "Digital Employee $GITHUB_REF_NAME"
+              --title "Digital Employee $RELEASE_TAG"
+            exit 0
+          fi
+
+          existing_names="$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name')"
+          mkdir -p "$RUNNER_TEMP/existing-release-assets"
+          missing_assets=()
+          for asset in "${assets[@]}"; do
+            asset_name="$(basename "$asset")"
+            if grep -Fxq "$asset_name" <<< "$existing_names"; then
+              gh release download "$RELEASE_TAG" \
+                --pattern "$asset_name" \
+                --dir "$RUNNER_TEMP/existing-release-assets"
+              if ! cmp -s "$asset" "$RUNNER_TEMP/existing-release-assets/$asset_name"; then
+                echo "::error::Existing release asset $asset_name has different bytes"
+                exit 1
+              fi
+            else
+              missing_assets+=( "$asset" )
+            fi
+          done
+          if [[ "${#missing_assets[@]}" -gt 0 ]]; then
+            gh release upload "$RELEASE_TAG" "${missing_assets[@]}"
           fi
 
   npm-root:
+    if: ${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'npm-root' }}
     needs: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: source
+    outputs:
+      complete: ${{ steps.publish.outputs.complete }}
+      outcome: ${{ steps.publish.outputs.outcome }}
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          path: source
+          ref: ${{ needs.verify.outputs.sha }}
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -92,25 +303,79 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Install npm with trusted publishing support
         run: npm install --global npm@11.18.0
-      - run: npm ci
-      - name: Publish root npm package
+      - name: Isolate tokenless npm publishing configuration
+        shell: bash
         run: |
-          package_name="$(node -p "require('./package.json').name")"
-          package_version="$(node -p "require('./package.json').version")"
-          if npm view "$package_name@$package_version" version >/dev/null 2>&1; then
-            echo "$package_name@$package_version is already published"
-            exit 0
+          oidc_npmrc="$RUNNER_TEMP/oidc-npmrc"
+          printf 'registry=https://registry.npmjs.org/\nprovenance=true\n' > "$oidc_npmrc"
+          echo "NPM_CONFIG_USERCONFIG=$oidc_npmrc" >> "$GITHUB_ENV"
+      - name: Download verified npm packages
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.verify.outputs.artifact }}
+          path: ${{ runner.temp }}/release-pack
+      - name: Revalidate immutable release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_SHA: ${{ needs.verify.outputs.sha }}
+          RELEASE_TAG: ${{ needs.verify.outputs.tag }}
+        shell: bash
+        run: |
+          read -r remote_object_type remote_object_sha < <(
+            gh api "repos/$GH_REPO/git/ref/tags/$RELEASE_TAG" \
+              --jq '.object | [.type, .sha] | @tsv'
+          )
+          peel_count=0
+          while [[ "$remote_object_type" == "tag" ]]; do
+            ((peel_count += 1))
+            if [[ "$peel_count" -gt 5 ]]; then
+              echo "::error::$RELEASE_TAG has an unexpectedly deep annotated-tag chain"
+              exit 1
+            fi
+            read -r remote_object_type remote_object_sha < <(
+              gh api "repos/$GH_REPO/git/tags/$remote_object_sha" \
+                --jq '.object | [.type, .sha] | @tsv'
+            )
+          done
+          if [[ "$remote_object_type" != "commit" || \
+                "$remote_object_sha" != "$RELEASE_SHA" ]]; then
+            echo "::error::$RELEASE_TAG moved after release preparation"
+            exit 1
           fi
-          npm publish --access public
+      - id: publish
+        name: Reconcile root npm package
+        env:
+          NPM_DIST_TAG: ${{ github.event_name == 'push' && 'latest' || 'repair' }}
+          RELEASE_TAG: ${{ needs.verify.outputs.tag }}
+        run: |
+          node ./scripts/npm-publish-resilient.js \
+            --manifest ./package.json \
+            --pack-json "$RUNNER_TEMP/release-pack/root-pack.json" \
+            --expected-name @fullstack-ai-infra/digital-employee \
+            --release-tag "$RELEASE_TAG" \
+            --missing-package fail \
+            --dist-tag "$NPM_DIST_TAG"
 
   npm-core:
+    if: ${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'npm-core' }}
     needs: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: source
+    outputs:
+      complete: ${{ steps.publish.outputs.complete }}
+      outcome: ${{ steps.publish.outputs.outcome }}
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          path: source
+          ref: ${{ needs.verify.outputs.sha }}
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -118,42 +383,367 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Install npm with trusted publishing support
         run: npm install --global npm@11.18.0
-      - run: npm ci
-      - name: Publish core npm package
+      - name: Isolate tokenless npm publishing configuration
+        shell: bash
         run: |
-          package_name="$(node -p "require('./packages/core/package.json').name")"
-          package_version="$(node -p "require('./packages/core/package.json').version")"
-          if npm view "$package_name@$package_version" version >/dev/null 2>&1; then
-            echo "$package_name@$package_version is already published"
-            exit 0
+          oidc_npmrc="$RUNNER_TEMP/oidc-npmrc"
+          printf 'registry=https://registry.npmjs.org/\nprovenance=true\n' > "$oidc_npmrc"
+          echo "NPM_CONFIG_USERCONFIG=$oidc_npmrc" >> "$GITHUB_ENV"
+      - name: Download verified npm packages
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.verify.outputs.artifact }}
+          path: ${{ runner.temp }}/release-pack
+      - name: Revalidate immutable release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_SHA: ${{ needs.verify.outputs.sha }}
+          RELEASE_TAG: ${{ needs.verify.outputs.tag }}
+        shell: bash
+        run: |
+          read -r remote_object_type remote_object_sha < <(
+            gh api "repos/$GH_REPO/git/ref/tags/$RELEASE_TAG" \
+              --jq '.object | [.type, .sha] | @tsv'
+          )
+          peel_count=0
+          while [[ "$remote_object_type" == "tag" ]]; do
+            ((peel_count += 1))
+            if [[ "$peel_count" -gt 5 ]]; then
+              echo "::error::$RELEASE_TAG has an unexpectedly deep annotated-tag chain"
+              exit 1
+            fi
+            read -r remote_object_type remote_object_sha < <(
+              gh api "repos/$GH_REPO/git/tags/$remote_object_sha" \
+                --jq '.object | [.type, .sha] | @tsv'
+            )
+          done
+          if [[ "$remote_object_type" != "commit" || \
+                "$remote_object_sha" != "$RELEASE_SHA" ]]; then
+            echo "::error::$RELEASE_TAG moved after release preparation"
+            exit 1
           fi
-          npm publish ./packages/core --access public
+      - id: publish
+        name: Reconcile standalone core npm package
+        env:
+          NPM_DIST_TAG: ${{ github.event_name == 'push' && 'latest' || 'repair' }}
+          RELEASE_TAG: ${{ needs.verify.outputs.tag }}
+        run: |
+          node ./scripts/npm-publish-resilient.js \
+            --manifest ./packages/core/package.json \
+            --pack-json "$RUNNER_TEMP/release-pack/core-pack.json" \
+            --expected-name @fullstack-ai-infra/digital-employee-core \
+            --release-tag "$RELEASE_TAG" \
+            --missing-package bootstrap-soft \
+            --bootstrap-marker ./packages/core/.npm-bootstrap-pending \
+            --dist-tag "$NPM_DIST_TAG"
 
   ghcr:
+    if: ${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'ghcr' }}
     needs: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: source
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          path: source
+          ref: ${{ needs.verify.outputs.sha }}
+      - name: Revalidate immutable release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_SHA: ${{ needs.verify.outputs.sha }}
+          RELEASE_TAG: ${{ needs.verify.outputs.tag }}
+        shell: bash
+        run: |
+          read -r remote_object_type remote_object_sha < <(
+            gh api "repos/$GH_REPO/git/ref/tags/$RELEASE_TAG" \
+              --jq '.object | [.type, .sha] | @tsv'
+          )
+          peel_count=0
+          while [[ "$remote_object_type" == "tag" ]]; do
+            ((peel_count += 1))
+            if [[ "$peel_count" -gt 5 ]]; then
+              echo "::error::$RELEASE_TAG has an unexpectedly deep annotated-tag chain"
+              exit 1
+            fi
+            read -r remote_object_type remote_object_sha < <(
+              gh api "repos/$GH_REPO/git/tags/$remote_object_sha" \
+                --jq '.object | [.type, .sha] | @tsv'
+            )
+          done
+          if [[ "$remote_object_type" != "commit" || \
+                "$remote_object_sha" != "$RELEASE_SHA" ]]; then
+            echo "::error::$RELEASE_TAG moved after release preparation"
+            exit 1
+          fi
       - name: Log in to GHCR
         env:
           GHCR_TOKEN: ${{ github.token }}
         run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
-      - name: Build and publish image
+      - name: Reconcile immutable image tags and monotonic latest
         env:
+          RELEASE_MODE: ${{ needs.verify.outputs.mode }}
+          RELEASE_SHA: ${{ needs.verify.outputs.sha }}
+          RELEASE_TAG: ${{ needs.verify.outputs.tag }}
           VERSION: ${{ needs.verify.outputs.version }}
+        shell: bash
         run: |
           image="ghcr.io/${GITHUB_REPOSITORY,,}"
-          docker build \
-            --label "org.opencontainers.image.revision=$GITHUB_SHA" \
-            --label "org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
-            --label "org.opencontainers.image.version=$VERSION" \
-            --tag "$image:$GITHUB_REF_NAME" \
-            --tag "$image:$VERSION" \
-            --tag "$image:latest" \
-            .
-          docker push "$image:$GITHUB_REF_NAME"
-          docker push "$image:$VERSION"
-          docker push "$image:latest"
+          release_ref="$image:$RELEASE_TAG"
+          version_ref="$image:$VERSION"
+          latest_ref="$image:latest"
+          expected_source="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
+
+          if [[ "$RELEASE_TAG" != "v$VERSION" ]]; then
+            echo "::error::Image version does not match the release tag"
+            exit 1
+          fi
+
+          pull_if_present() {
+            local reference="$1"
+            local pull_output
+            if pull_output="$(docker pull "$reference" 2>&1)"; then
+              return 0
+            fi
+            if grep -Eqi 'manifest unknown|manifest[^:]*not found' <<< "$pull_output"; then
+              return 1
+            fi
+            printf '%s\n' "$pull_output" >&2
+            return 2
+          }
+
+          image_label() {
+            docker image inspect "$1" --format "{{ index .Config.Labels \"$2\" }}"
+          }
+
+          validate_release_image() {
+            local reference="$1"
+            local actual_revision actual_source actual_version
+            actual_revision="$(image_label "$reference" org.opencontainers.image.revision)"
+            actual_source="$(image_label "$reference" org.opencontainers.image.source)"
+            actual_version="$(image_label "$reference" org.opencontainers.image.version)"
+            if [[ "$actual_revision" != "$RELEASE_SHA" || \
+                  "$actual_source" != "$expected_source" || \
+                  "$actual_version" != "$VERSION" ]]; then
+              echo "::error::Existing immutable image $reference has conflicting identity labels"
+              return 1
+            fi
+          }
+
+          same_image() {
+            [[ "$(docker image inspect "$1" --format '{{.Id}}')" == \
+               "$(docker image inspect "$2" --format '{{.Id}}')" ]]
+          }
+
+          compare_semver() {
+            local left_major left_minor left_patch
+            local right_major right_minor right_patch
+            IFS=. read -r left_major left_minor left_patch <<< "$1"
+            IFS=. read -r right_major right_minor right_patch <<< "$2"
+            if (( 10#$left_major != 10#$right_major )); then
+              (( 10#$left_major < 10#$right_major )) && printf '%s' -1 || printf '%s' 1
+            elif (( 10#$left_minor != 10#$right_minor )); then
+              (( 10#$left_minor < 10#$right_minor )) && printf '%s' -1 || printf '%s' 1
+            elif (( 10#$left_patch != 10#$right_patch )); then
+              (( 10#$left_patch < 10#$right_patch )) && printf '%s' -1 || printf '%s' 1
+            else
+              printf '%s' 0
+            fi
+          }
+
+          release_exists=false
+          if pull_if_present "$release_ref"; then
+            release_exists=true
+          else
+            pull_status=$?
+            if [[ "$pull_status" -ne 1 ]]; then
+              exit "$pull_status"
+            fi
+          fi
+
+          version_exists=false
+          if pull_if_present "$version_ref"; then
+            version_exists=true
+          else
+            pull_status=$?
+            if [[ "$pull_status" -ne 1 ]]; then
+              exit "$pull_status"
+            fi
+          fi
+
+          if [[ "$release_exists" == "true" ]]; then
+            validate_release_image "$release_ref"
+          fi
+          if [[ "$version_exists" == "true" ]]; then
+            validate_release_image "$version_ref"
+          fi
+
+          if [[ "$release_exists" == "true" && "$version_exists" == "true" ]]; then
+            if ! same_image "$release_ref" "$version_ref"; then
+              echo "::error::Existing immutable GHCR tags resolve to different images"
+              exit 1
+            fi
+            canonical_ref="$release_ref"
+          elif [[ "$release_exists" == "true" ]]; then
+            canonical_ref="$release_ref"
+            docker tag "$canonical_ref" "$version_ref"
+            docker push "$version_ref"
+          elif [[ "$version_exists" == "true" ]]; then
+            canonical_ref="$version_ref"
+            docker tag "$canonical_ref" "$release_ref"
+            docker push "$release_ref"
+          else
+            canonical_ref="$release_ref"
+            docker build \
+              --label "org.opencontainers.image.revision=$RELEASE_SHA" \
+              --label "org.opencontainers.image.source=$expected_source" \
+              --label "org.opencontainers.image.version=$VERSION" \
+              --tag "$release_ref" \
+              .
+            docker tag "$release_ref" "$version_ref"
+            docker push "$release_ref"
+            docker push "$version_ref"
+          fi
+
+          docker pull "$release_ref" >/dev/null
+          docker pull "$version_ref" >/dev/null
+          validate_release_image "$release_ref"
+          validate_release_image "$version_ref"
+          if ! same_image "$release_ref" "$version_ref"; then
+            echo "::error::Immutable GHCR tag reconciliation did not converge"
+            exit 1
+          fi
+          canonical_ref="$release_ref"
+
+          if [[ "$RELEASE_MODE" != "push" ]]; then
+            echo "Repair mode leaves the moving latest tag unchanged"
+            exit 0
+          fi
+
+          latest_exists=false
+          if pull_if_present "$latest_ref"; then
+            latest_exists=true
+          else
+            pull_status=$?
+            if [[ "$pull_status" -ne 1 ]]; then
+              exit "$pull_status"
+            fi
+          fi
+
+          update_latest=false
+          if [[ "$latest_exists" != "true" ]]; then
+            update_latest=true
+          else
+            latest_source="$(image_label "$latest_ref" org.opencontainers.image.source)"
+            latest_version="$(image_label "$latest_ref" org.opencontainers.image.version)"
+            if [[ "$latest_source" != "$expected_source" || \
+                  ! "$latest_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Existing latest image has unverifiable release identity"
+              exit 1
+            fi
+            version_order="$(compare_semver "$VERSION" "$latest_version")"
+            if [[ "$version_order" == "1" ]]; then
+              update_latest=true
+            elif [[ "$version_order" == "-1" ]]; then
+              echo "::warning::Keeping newer GHCR latest $latest_version; current release is $VERSION"
+            elif ! same_image "$canonical_ref" "$latest_ref"; then
+              echo "::error::GHCR latest for $VERSION conflicts with its immutable image"
+              exit 1
+            fi
+          fi
+
+          if [[ "$update_latest" == "true" ]]; then
+            docker tag "$canonical_ref" "$latest_ref"
+            docker push "$latest_ref"
+            docker pull "$latest_ref" >/dev/null
+            if ! same_image "$canonical_ref" "$latest_ref"; then
+              echo "::error::GHCR latest readback does not match the release image"
+              exit 1
+            fi
+          fi
+
+  release-status:
+    if: ${{ always() }}
+    needs:
+      - prepare
+      - verify
+      - github-release
+      - npm-root
+      - npm-core
+      - ghcr
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Summarize requested release channels
+        env:
+          GHCR_RESULT: ${{ needs.ghcr.result }}
+          GITHUB_RELEASE_RESULT: ${{ needs.github-release.result }}
+          NPM_CORE_COMPLETE: ${{ needs.npm-core.outputs.complete }}
+          NPM_CORE_OUTCOME: ${{ needs.npm-core.outputs.outcome }}
+          NPM_CORE_RESULT: ${{ needs.npm-core.result }}
+          NPM_ROOT_COMPLETE: ${{ needs.npm-root.outputs.complete }}
+          NPM_ROOT_OUTCOME: ${{ needs.npm-root.outputs.outcome }}
+          NPM_ROOT_RESULT: ${{ needs.npm-root.result }}
+          PREPARE_RESULT: ${{ needs.prepare.result }}
+          REQUESTED_TARGET: ${{ github.event_name == 'push' && 'all' || inputs.target }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+        shell: bash
+        run: |
+          selected() {
+            [[ "$REQUESTED_TARGET" == "all" || "$REQUESTED_TARGET" == "$1" ]]
+          }
+          channel_status() {
+            if selected "$1"; then
+              printf '%s' "$2"
+            else
+              printf 'not-requested'
+            fi
+          }
+          {
+            echo "## Release reconciliation"
+            echo
+            echo "| Channel | Result | Outcome |"
+            echo "| --- | --- | --- |"
+            echo "| prepare | $PREPARE_RESULT | tag authorization |"
+            echo "| verify | $VERIFY_RESULT | immutable artifacts |"
+            echo "| GitHub Release | $(channel_status github-release "$GITHUB_RELEASE_RESULT") | immutable assets |"
+            echo "| npm root | $(channel_status npm-root "$NPM_ROOT_RESULT") | ${NPM_ROOT_OUTCOME:-n/a} |"
+            echo "| npm core | $(channel_status npm-core "$NPM_CORE_RESULT") | ${NPM_CORE_OUTCOME:-n/a} |"
+            echo "| GHCR | $(channel_status ghcr "$GHCR_RESULT") | versioned image |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          if [[ "$PREPARE_RESULT" != "success" || "$VERIFY_RESULT" != "success" ]]; then
+            failed=1
+          fi
+          if selected github-release && [[ "$GITHUB_RELEASE_RESULT" != "success" ]]; then
+            failed=1
+          fi
+          if selected npm-root && \
+            [[ "$NPM_ROOT_RESULT" != "success" || "$NPM_ROOT_COMPLETE" != "true" ]]; then
+            failed=1
+          fi
+          if selected npm-core; then
+            if [[ "$NPM_CORE_RESULT" != "success" ]]; then
+              failed=1
+            elif [[ "$NPM_CORE_COMPLETE" != "true" && "$NPM_CORE_OUTCOME" != "bootstrap_required" ]]; then
+              failed=1
+            fi
+          fi
+          if selected ghcr && [[ "$GHCR_RESULT" != "success" ]]; then
+            failed=1
+          fi
+          if [[ "$failed" -ne 0 ]]; then
+            echo "::error::One or more requested release channels failed reconciliation"
+            exit 1
+          fi
+          if selected npm-core && [[ "$NPM_CORE_COMPLETE" != "true" ]]; then
+            echo "::warning::Standalone core requires one-time npm bootstrap; root /core and GitHub Release tgz remain available"
+          fi

--- a/README.md
+++ b/README.md
@@ -144,11 +144,20 @@ be terminated and verified before a terminal event is published.
 
 ## Release status
 
-The current source is a local `0.3.0` release candidate for the Agent-native
-commands and Runner kernel above. It has **not** been published to npm, GHCR,
-or GitHub Releases; use this source checkout until all release channels
-complete. Do not claim that `0.3.0` is publicly installable, and do not retag or
-overwrite `0.1.0`.
+The tagged `0.3.0` release is public through the root npm package, GHCR, and
+GitHub Releases:
+
+| Channel | Command or download |
+| --- | --- |
+| npm | `npm install --global @fullstack-ai-infra/digital-employee@0.3.0` |
+| GHCR | `docker pull ghcr.io/fullstack-ai-infra/digital-employee:0.3.0` |
+| GitHub Release | Download the root package and checksum from [`v0.3.0`](https://github.com/fullstack-ai-infra/digital-employee/releases/tag/v0.3.0) |
+
+The standalone `@fullstack-ai-infra/digital-employee-core` npm package still
+requires its one-time registry bootstrap. Until then, install the root package
+and import `@fullstack-ai-infra/digital-employee/core`. The current `main`
+branch contains changes made after the tag and is not itself a published
+release. Do not retag or overwrite `0.3.0` or `0.1.0`.
 
 The frozen `0.1.0` compatibility release is distributed through three public
 channels:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,7 +73,15 @@ V0.3 源码已经提供可嵌入的 one-shot Runner 执行内核和签名续租�
 
 ## 版本状态
 
-当前源码是包含上述 Agent-native 命令和 Runner 执行内核的本地 `0.3.0` 发布候选；它**尚未**发布到 npm、GHCR 或 GitHub Releases。在所有发布渠道完成前，请从当前源码运行和集成，不要宣称 `0.3.0` 已可公开安装，也不要覆盖或重新标记 `0.1.0`。
+标签版本 `0.3.0` 已通过 root npm 包、GHCR 和 GitHub Releases 公开发布：
+
+| 渠道 | 安装或下载方式 |
+| --- | --- |
+| npm | `npm install --global @fullstack-ai-infra/digital-employee@0.3.0` |
+| GHCR | `docker pull ghcr.io/fullstack-ai-infra/digital-employee:0.3.0` |
+| GitHub Release | 从 [`v0.3.0`](https://github.com/fullstack-ai-infra/digital-employee/releases/tag/v0.3.0) 下载 root 包和校验文件 |
+
+独立的 `@fullstack-ai-infra/digital-employee-core` npm 包仍需完成一次性 registry bootstrap；在此之前，请安装 root 包并导入 `@fullstack-ai-infra/digital-employee/core`。当前 `main` 已包含标签之后的改动，本身不代表一个已发布版本。不要覆盖或重新标记 `0.3.0` 或 `0.1.0`。
 
 冻结的 `0.1.0` 兼容版本通过三个公开渠道分发：
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,89 @@
+# Release operations
+
+Stable tags (`vMAJOR.MINOR.PATCH`) are the only release entry point. The
+release workflow verifies that the tag still resolves to the event commit and
+that the commit is reachable from `origin/main`. It then builds the root and
+standalone core npm archives once. npm and GitHub Releases consume those exact
+verified archives; they do not rebuild them.
+
+## Normal release
+
+1. Merge a commit whose root/core package versions and changelog agree.
+2. Create the matching stable tag on that commit.
+3. Let `.github/workflows/release.yml` reconcile npm, GitHub Releases, and
+   GHCR. Release runs share the maximum GitHub Actions concurrency queue (up
+   to 100 pending runs) instead of replacing the previous pending release.
+4. Read the `release-status` job summary. A green run means every requested
+   channel is complete, except the explicitly reported `bootstrap_required`
+   state described below.
+
+Registry authentication uses npm Trusted Publishing (GitHub OIDC). Do not add
+an `NPM_TOKEN` or `NODE_AUTH_TOKEN` repository secret.
+
+Repository administrators must protect `refs/tags/v*` from update and deletion
+with a tag ruleset. Every registry-writing job revalidates the remote tag
+immediately before its write, but only server-side tag protection closes the
+remaining check/write race.
+
+## Repair one channel
+
+Run repairs from the release tag itself so the workflow identity, checked-out
+source, and provenance all refer to the same commit:
+
+```bash
+gh workflow run release.yml \
+  --ref vX.Y.Z \
+  -f target=npm-core
+```
+
+Valid targets are `all`, `npm-root`, `npm-core`, `github-release`, and `ghcr`.
+Repair runs use a non-`latest` npm dist-tag and do not update GHCR `latest`.
+Existing GitHub Release assets and immutable GHCR version tags are reused only
+when their bytes or release identity match; conflicts fail closed.
+
+GHCR reconciliation currently treats repository package-write access as a
+trusted boundary. It compares the two version aliases by image digest and
+checks revision/source/version OCI labels, but those labels are not a
+cryptographic build attestation. Do not describe `v0.3.0` as attested: its
+historical image has no GitHub or OCI attestation, and provenance cannot be
+truthfully added after the build. A future version should use a two-phase flow
+(push by digest, attest and verify, then promote version and `latest` tags).
+
+The dispatch definition must already exist at the selected tag. In particular,
+the historical `v0.3.0` tag predates this repair entry point. Its missing
+GitHub Release assets can be reconstructed by the current default-branch CI:
+
+```bash
+gh workflow run release.yml \
+  --ref main \
+  -f target=github-release \
+  -f release_tag=v0.3.0
+```
+
+This exceptional path only operates on an existing stable tag and existing
+GitHub Release. It verifies that the tag is reachable from `main`, rebuilds at
+the tag commit, refuses changed existing assets, and uploads only missing
+assets. npm and GHCR jobs are not selected. After resolving the external npm
+bootstrap, rerun the original failed `npm-core` job for `v0.3.0`.
+
+## Standalone core bootstrap
+
+npm Trusted Publishing cannot create a package's first public version. While
+`packages/core/.npm-bootstrap-pending` exists, repeated package-level 404s for
+`@fullstack-ai-infra/digital-employee-core` produce the visible, incomplete
+`bootstrap_required` outcome without failing unrelated release channels.
+Consumers can meanwhile use:
+
+```text
+@fullstack-ai-infra/digital-employee/core
+```
+
+The hardened workflow retains both verified `.tgz` files and their SHA-256
+checksums. The historical `v0.3.0` core asset appears after the backfill command
+above completes.
+
+An npm scope owner must perform the one-time authenticated publication from the
+verified GitHub Release core archive, then configure this repository and
+`release.yml` as the package's Trusted Publisher. Only after the public package
+exists and the trust binding is verified should the marker be removed. All
+subsequent versions publish from CI without a long-lived npm credential.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,6 +20,13 @@ verified archives; they do not rebuild them.
 Registry authentication uses npm Trusted Publishing (GitHub OIDC). Do not add
 an `NPM_TOKEN` or `NODE_AUTH_TOKEN` repository secret.
 
+Trusted Publishing authenticates `npm publish`, but it does not authenticate
+`npm dist-tag`. If an exact version already exists while `latest` is missing,
+invalid, or points to an older version, the workflow fails closed instead of
+guessing or introducing a long-lived token. An npm owner must first verify the
+target version and then repair the tag interactively with `npm dist-tag add`;
+the CI repair can be rerun afterward. A newer valid `latest` is always retained.
+
 Repository administrators must protect `refs/tags/v*` from update and deletion
 with a tag ruleset. Every registry-writing job revalidates the remote tag
 immediately before its write, but only server-side tag protection closes the
@@ -87,3 +94,10 @@ verified GitHub Release core archive, then configure this repository and
 `release.yml` as the package's Trusted Publisher. Only after the public package
 exists and the trust binding is verified should the marker be removed. All
 subsequent versions publish from CI without a long-lived npm credential.
+
+If the owner publication succeeds before the marker-removal change is merged,
+a rerun accepts only an exact registry-integrity match and reports
+`bootstrap_verified_marker_cleanup_required`. It never republishes that version.
+If the package exists but the target version is absent, the stale marker still
+blocks CI publication until the trust binding is confirmed and the marker is
+removed.

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "employee:init": "npm run build --silent && node ./dist/apps/cli/bin.js init",
     "employee:validate": "npm run build --silent && node ./dist/apps/cli/bin.js validate",
     "employee:run": "npm run build --silent && node ./dist/apps/cli/bin.js run",
-    "test": "tsx --test tests/**/*.test.ts",
+    "test": "tsx --test --test-concurrency=1 tests/**/*.test.ts",
     "test:integration:signed-task-e2e": "tsx --test tests/integration/signed-task-e2e.test.ts",
     "test:coverage": "tsx --test --experimental-test-coverage --test-concurrency=1 --test-coverage-include='apps/**/*.ts' --test-coverage-include='connectors/**/*.ts' --test-coverage-include='packages/**/*.ts' --test-coverage-include='profiles/**/*.ts' --test-coverage-include='scripts/**/*.js' --test-coverage-lines=85 --test-coverage-branches=65 --test-coverage-functions=80 tests/**/*.test.ts",
     "security:check": "node ./scripts/security-check.js",

--- a/packages/core/.npm-bootstrap-pending
+++ b/packages/core/.npm-bootstrap-pending
@@ -1,0 +1,9 @@
+The standalone core package has not completed its first authenticated npm publish.
+
+While this marker exists, a registry-level package 404 is reported as
+bootstrap_required instead of failing the entire multi-channel release. The
+verified core tgz is still attached to the GitHub Release, and consumers can use
+@fullstack-ai-infra/digital-employee/core from the root package.
+
+Remove this marker only after the package exists on npm and its Trusted
+Publisher is bound to fullstack-ai-infra/digital-employee and release.yml.

--- a/scripts/npm-publish-resilient.js
+++ b/scripts/npm-publish-resilient.js
@@ -1,0 +1,1067 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  appendFile,
+  lstat,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const STABLE_SEMVER = /^\d+\.\d+\.\d+$/;
+const ALLOWED_MISSING_POLICIES = new Set(["fail", "bootstrap-soft"]);
+const TRANSIENT_HTTP_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const TRANSIENT_CODES = new Set([
+  "E408",
+  "E425",
+  "E429",
+  "E500",
+  "E502",
+  "E503",
+  "E504",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "EPIPE",
+  "ESOCKETTIMEDOUT",
+  "ETIMEDOUT",
+  "FETCH_ERROR",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET"
+]);
+const AUTH_CODES = new Set(["E401", "E403", "ENEEDAUTH", "EOTP"]);
+const CONFLICT_CODES = new Set(["E409", "EPUBLISHCONFLICT"]);
+const DEFAULT_VERIFY_DELAYS_MS = [0, 1_000, 3_000, 8_000, 18_000];
+const DEFAULT_REGISTRY_RETRY_DELAYS_MS = [0, 500, 1_500, 4_000];
+const MAX_CAPTURED_OUTPUT = 1024 * 1024;
+const OFFICIAL_NPM_REGISTRY = "https://registry.npmjs.org/";
+
+const USAGE = `usage: npm-publish-resilient.js \\
+  --manifest <package.json> \\
+  --pack-json <npm-pack-output.json> \\
+  --expected-name <package-name> \\
+  --release-tag <vX.Y.Z> \\
+  --dist-tag <npm-dist-tag> \\
+  --missing-package <fail|bootstrap-soft> \\
+  [--bootstrap-marker <path>]\n`;
+
+export class ReleaseInputError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ReleaseInputError";
+  }
+}
+
+export class RegistryReadError extends Error {
+  constructor(message, { status, transient = false } = {}) {
+    super(message);
+    this.name = "RegistryReadError";
+    this.status = status;
+    this.transient = transient;
+  }
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function sha(buffer, algorithm, encoding) {
+  return createHash(algorithm).update(buffer).digest(encoding);
+}
+
+function stablePackageUrl(name, version) {
+  return name && version
+    ? `https://www.npmjs.com/package/${name}/v/${version}`
+    : "";
+}
+
+async function readJson(filename, label) {
+  let text;
+  try {
+    text = await readFile(filename, "utf8");
+  } catch (error) {
+    throw new ReleaseInputError(
+      `${label} cannot be read: ${error?.code || "read_error"}`
+    );
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new ReleaseInputError(`${label} must contain valid JSON`);
+  }
+}
+
+export async function loadReleaseArtifact({
+  manifestPath,
+  packJsonPath,
+  expectedName,
+  releaseTag
+}) {
+  const resolvedManifest = path.resolve(manifestPath);
+  const resolvedPackJson = path.resolve(packJsonPath);
+  const [manifest, packOutput] = await Promise.all([
+    readJson(resolvedManifest, "manifest"),
+    readJson(resolvedPackJson, "pack JSON")
+  ]);
+
+  if (!expectedName || manifest.name !== expectedName) {
+    throw new ReleaseInputError("manifest name does not match --expected-name");
+  }
+  if (!STABLE_SEMVER.test(String(manifest.version || ""))) {
+    throw new ReleaseInputError("manifest version must be a stable x.y.z version");
+  }
+  if (releaseTag !== `v${manifest.version}`) {
+    throw new ReleaseInputError(
+      `release tag ${releaseTag || "<missing>"} does not match v${manifest.version}`
+    );
+  }
+  if (manifest.private === true) {
+    throw new ReleaseInputError("manifest must not be private");
+  }
+  if (manifest.publishConfig?.access !== "public") {
+    throw new ReleaseInputError("manifest publishConfig.access must be public");
+  }
+  if (!Array.isArray(packOutput) || packOutput.length !== 1) {
+    throw new ReleaseInputError("pack JSON must contain exactly one package");
+  }
+
+  const [pack] = packOutput;
+  if (pack?.name !== manifest.name || pack?.version !== manifest.version) {
+    throw new ReleaseInputError("pack JSON name and version must match manifest");
+  }
+  if (typeof pack.filename !== "string" || !pack.filename.endsWith(".tgz")) {
+    throw new ReleaseInputError("pack JSON must contain a .tgz filename");
+  }
+  if (path.isAbsolute(pack.filename)) {
+    throw new ReleaseInputError("pack filename must be relative to the pack JSON");
+  }
+  if (path.basename(pack.filename) !== pack.filename) {
+    throw new ReleaseInputError(
+      "relative pack filename must be next to the pack JSON"
+    );
+  }
+  if (
+    typeof pack.integrity !== "string" ||
+    !/^sha512-[A-Za-z0-9+/]+={0,2}$/.test(pack.integrity)
+  ) {
+    throw new ReleaseInputError("pack JSON must contain a sha512 integrity digest");
+  }
+  if (pack.shasum !== undefined && !/^[a-f\d]{40}$/i.test(pack.shasum)) {
+    throw new ReleaseInputError("pack JSON shasum must be a SHA-1 hex digest");
+  }
+
+  const tarballPath = path.resolve(path.dirname(resolvedPackJson), pack.filename);
+  let archive;
+  let archiveStat;
+  try {
+    [archive, archiveStat] = await Promise.all([
+      readFile(tarballPath),
+      lstat(tarballPath)
+    ]);
+  } catch (error) {
+    throw new ReleaseInputError(
+      `packed tarball cannot be read: ${error?.code || "read_error"}`
+    );
+  }
+  if (archiveStat.isSymbolicLink() || !archiveStat.isFile() || archive.length === 0) {
+    throw new ReleaseInputError("packed tarball must be a non-empty regular file");
+  }
+  if (Number.isFinite(pack.size) && pack.size !== archive.length) {
+    throw new ReleaseInputError("packed tarball size does not match pack JSON");
+  }
+
+  const integrity = `sha512-${sha(archive, "sha512", "base64")}`;
+  const shasum = sha(archive, "sha1", "hex");
+  if (integrity !== pack.integrity) {
+    throw new ReleaseInputError("packed tarball integrity does not match pack JSON");
+  }
+  if (pack.shasum !== undefined && shasum !== pack.shasum.toLowerCase()) {
+    throw new ReleaseInputError("packed tarball shasum does not match pack JSON");
+  }
+
+  return {
+    name: manifest.name,
+    version: manifest.version,
+    integrity,
+    shasum,
+    filename: path.basename(tarballPath),
+    tarballPath,
+    manifestPath: resolvedManifest,
+    packJsonPath: resolvedPackJson,
+    archive,
+    packageUrl: stablePackageUrl(manifest.name, manifest.version)
+  };
+}
+
+function encodedPackageName(name) {
+  return encodeURIComponent(name).replace(/^%40/i, "@");
+}
+
+function configuredRegistryUrl() {
+  return process.env.NPM_CONFIG_REGISTRY ||
+    process.env.npm_config_registry ||
+    OFFICIAL_NPM_REGISTRY;
+}
+
+function officialRegistryUrl(registryUrl) {
+  let candidate;
+  try {
+    candidate = new URL(registryUrl);
+  } catch {
+    throw new RegistryReadError("npm registry URL is invalid");
+  }
+  if (
+    candidate.protocol !== "https:" ||
+    candidate.hostname !== "registry.npmjs.org" ||
+    candidate.port !== "" ||
+    candidate.username !== "" ||
+    candidate.password !== "" ||
+    candidate.pathname !== "/" ||
+    candidate.search !== "" ||
+    candidate.hash !== ""
+  ) {
+    throw new RegistryReadError(
+      `npm registry must be ${OFFICIAL_NPM_REGISTRY}`
+    );
+  }
+  return OFFICIAL_NPM_REGISTRY;
+}
+
+function isTransientFetchFailure(error) {
+  const code = error?.code || error?.cause?.code;
+  return error?.name === "AbortError" ||
+    error?.name === "TimeoutError" ||
+    TRANSIENT_CODES.has(code) ||
+    error instanceof TypeError;
+}
+
+export async function readRegistryState({
+  name,
+  version,
+  registryUrl = configuredRegistryUrl(),
+  fetchImpl = globalThis.fetch,
+  sleep = delay,
+  retryDelays = DEFAULT_REGISTRY_RETRY_DELAYS_MS
+}) {
+  const baseUrl = officialRegistryUrl(registryUrl);
+  const registryOrigin = new URL(baseUrl).origin;
+  let url;
+  try {
+    url = new URL(encodedPackageName(name), baseUrl);
+  } catch {
+    throw new RegistryReadError("npm registry URL is invalid");
+  }
+
+  let lastError;
+  for (const [index, wait] of retryDelays.entries()) {
+    if (wait > 0) await sleep(wait);
+    try {
+      const response = await fetchImpl(url, {
+        cache: "no-store",
+        redirect: "manual",
+        headers: {
+          accept: "application/json",
+          "cache-control": "no-cache"
+        },
+        signal: AbortSignal.timeout(15_000)
+      });
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers?.get?.("location");
+        if (location) {
+          let redirectUrl;
+          try {
+            redirectUrl = new URL(location, url);
+          } catch {
+            throw new RegistryReadError(
+              "npm registry returned an invalid redirect URL",
+              { status: response.status }
+            );
+          }
+          if (redirectUrl.origin !== registryOrigin) {
+            throw new RegistryReadError(
+              "npm registry redirected to a different origin",
+              { status: response.status }
+            );
+          }
+        }
+        throw new RegistryReadError("npm registry redirects are not allowed", {
+          status: response.status
+        });
+      }
+      if (response.status === 404) {
+        if (index < retryDelays.length - 1) continue;
+        return {
+          packageExists: false,
+          versionExists: false,
+          integrity: null,
+          shasum: null,
+          latestVersion: null,
+          latestVersionExists: false
+        };
+      }
+      if (!response.ok) {
+        const transient = TRANSIENT_HTTP_STATUSES.has(response.status);
+        lastError = new RegistryReadError(
+          `npm registry returned HTTP ${response.status}`,
+          { status: response.status, transient }
+        );
+        if (transient && index < retryDelays.length - 1) continue;
+        throw lastError;
+      }
+
+      let packument;
+      try {
+        packument = await response.json();
+      } catch {
+        throw new RegistryReadError("npm registry returned invalid JSON", {
+          transient: true
+        });
+      }
+      if (
+        !packument ||
+        typeof packument !== "object" ||
+        Array.isArray(packument) ||
+        packument.name !== name ||
+        !packument.versions ||
+        typeof packument.versions !== "object" ||
+        Array.isArray(packument.versions) ||
+        !packument["dist-tags"] ||
+        typeof packument["dist-tags"] !== "object" ||
+        Array.isArray(packument["dist-tags"])
+      ) {
+        throw new RegistryReadError(
+          "npm registry returned an invalid package document",
+          { transient: true }
+        );
+      }
+      const versionMetadata = packument?.versions?.[version];
+      const latestVersion = packument?.["dist-tags"]?.latest || null;
+      return {
+        packageExists: true,
+        versionExists: Boolean(versionMetadata),
+        integrity: versionMetadata?.dist?.integrity || null,
+        shasum: versionMetadata?.dist?.shasum || null,
+        latestVersion,
+        latestVersionExists: typeof latestVersion === "string" &&
+          Boolean(packument.versions[latestVersion])
+      };
+    } catch (error) {
+      if (error instanceof RegistryReadError) {
+        lastError = error;
+        if (error.transient && index < retryDelays.length - 1) continue;
+        throw error;
+      }
+      const transient = isTransientFetchFailure(error);
+      lastError = new RegistryReadError(
+        `npm registry request failed: ${error?.code || error?.cause?.code || error?.name || "network_error"}`,
+        { transient }
+      );
+      if (transient && index < retryDelays.length - 1) continue;
+      throw lastError;
+    }
+  }
+  throw lastError || new RegistryReadError("npm registry request failed");
+}
+
+function appendCaptured(current, chunk) {
+  const combined = `${current}${chunk}`;
+  return combined.length > MAX_CAPTURED_OUTPUT
+    ? combined.slice(combined.length - MAX_CAPTURED_OUTPUT)
+    : combined;
+}
+
+async function createVerifiedPublishCopy(artifact) {
+  if (!Buffer.isBuffer(artifact.archive) || artifact.archive.length === 0) {
+    throw new ReleaseInputError("verified packed tarball bytes are unavailable");
+  }
+  if (
+    `sha512-${sha(artifact.archive, "sha512", "base64")}` !== artifact.integrity ||
+    sha(artifact.archive, "sha1", "hex") !== artifact.shasum
+  ) {
+    throw new ReleaseInputError("verified packed tarball bytes changed in memory");
+  }
+  if (
+    typeof artifact.filename !== "string" ||
+    path.basename(artifact.filename) !== artifact.filename ||
+    !artifact.filename.endsWith(".tgz")
+  ) {
+    throw new ReleaseInputError("verified packed tarball filename is invalid");
+  }
+
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "npm-publish-resilient-")
+  );
+  const filename = path.join(directory, artifact.filename);
+  try {
+    await writeFile(filename, artifact.archive, {
+      flag: "wx",
+      mode: 0o600
+    });
+  } catch (error) {
+    await rm(directory, { recursive: true, force: true }).catch(() => {});
+    throw error;
+  }
+  return { directory, filename };
+}
+
+export async function runNpmPublish(
+  artifact,
+  {
+    distTag = "latest",
+    registryUrl = configuredRegistryUrl(),
+    spawnImpl = spawn,
+    timeoutMs = 180_000,
+    killGraceMs = 10_000
+  } = {}
+) {
+  const normalizedRegistryUrl = officialRegistryUrl(registryUrl);
+  const publishCopy = await createVerifiedPublishCopy(artifact);
+  const npmExecutable = process.platform === "win32" ? "npm.cmd" : "npm";
+  const args = [
+    "publish",
+    publishCopy.filename,
+    "--access",
+    "public",
+    "--tag",
+    distTag,
+    "--registry",
+    normalizedRegistryUrl,
+    "--provenance",
+    "--json"
+  ];
+  const publishEnvironment = { ...process.env };
+  // Trusted Publishing must use GitHub's short-lived OIDC identity. Do not let
+  // an accidentally inherited legacy token silently replace that identity.
+  delete publishEnvironment.NODE_AUTH_TOKEN;
+  delete publishEnvironment.NPM_TOKEN;
+  delete publishEnvironment.npm_config_token;
+  delete publishEnvironment.NPM_CONFIG_TOKEN;
+
+  try {
+    return await new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+    let child;
+    let timeoutTimer;
+    let killTimer;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutTimer);
+      clearTimeout(killTimer);
+      resolve({ stdout, stderr, timedOut, ...result });
+    };
+
+    try {
+      child = spawnImpl(npmExecutable, args, {
+        cwd: path.dirname(artifact.manifestPath),
+        env: publishEnvironment,
+        shell: false,
+        stdio: ["ignore", "pipe", "pipe"]
+      });
+    } catch (error) {
+      resolve({
+        exitCode: null,
+        signal: null,
+        errorCode: error?.code || "SPAWN_ERROR",
+        stdout,
+        stderr,
+        timedOut
+      });
+      return;
+    }
+
+    timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // Continue to the forced timeout settlement below.
+      }
+      killTimer = setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // The child may already be gone without having emitted close.
+        }
+        child.stdout?.destroy?.();
+        child.stderr?.destroy?.();
+        child.unref?.();
+        finish({
+          exitCode: null,
+          signal: "SIGKILL",
+          errorCode: "ETIMEDOUT"
+        });
+      }, killGraceMs);
+    }, timeoutMs);
+    child.stdout?.on("data", (chunk) => {
+      stdout = appendCaptured(stdout, chunk.toString());
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr = appendCaptured(stderr, chunk.toString());
+    });
+    child.on("error", (error) => {
+      finish({
+        exitCode: null,
+        signal: null,
+        errorCode: error?.code || "SPAWN_ERROR"
+      });
+    });
+    child.on("close", (exitCode, signal) => {
+      finish({
+        exitCode,
+        signal,
+        errorCode: timedOut ? "ETIMEDOUT" : null
+      });
+    });
+    });
+  } finally {
+    await rm(publishCopy.directory, { recursive: true, force: true }).catch(
+      () => {}
+    );
+  }
+}
+
+function parseJsonErrorCode(output) {
+  for (const candidate of [output.stdout, output.stderr]) {
+    try {
+      const parsed = JSON.parse(candidate);
+      const code = parsed?.error?.code || parsed?.code;
+      if (typeof code === "string") return code.toUpperCase();
+    } catch {
+      // npm does not guarantee JSON-formatted failures on every version.
+    }
+  }
+  return null;
+}
+
+export function classifyPublishFailure(output) {
+  if (output.timedOut) return { kind: "transient", code: "ETIMEDOUT" };
+  const text = `${output.stdout || ""}\n${output.stderr || ""}`;
+  const codeMatch = text.match(/npm (?:error|ERR!) code ([A-Z][A-Z0-9_]*)/i);
+  const code = String(
+    output.errorCode || parseJsonErrorCode(output) || codeMatch?.[1] || ""
+  ).toUpperCase() || null;
+  const statusMatch = text.match(
+    /\b(401|403|404|408|409|425|429|500|502|503|504)\s+(?:Bad Request|Unauthorized|Forbidden|Not Found|Request Timeout|Conflict|Too Many Requests|Internal Server Error|Bad Gateway|Service Unavailable|Gateway Timeout)/i
+  );
+  const status = statusMatch ? Number(statusMatch[1]) : null;
+
+  if (AUTH_CODES.has(code)) {
+    return { kind: "authentication", code };
+  }
+  if (code === "E404") return { kind: "not-found", code };
+  if (CONFLICT_CODES.has(code)) {
+    return { kind: "conflict", code };
+  }
+  if (TRANSIENT_CODES.has(code)) {
+    return { kind: "transient", code };
+  }
+  if (status === 401 || status === 403) {
+    return { kind: "authentication", code: `HTTP_${status}` };
+  }
+  if (status === 404) return { kind: "not-found", code: "E404" };
+  if (status === 409) return { kind: "conflict", code: "HTTP_409" };
+  if (TRANSIENT_HTTP_STATUSES.has(status)) {
+    return { kind: "transient", code: `HTTP_${status}` };
+  }
+  return { kind: "unknown", code: code || "UNKNOWN" };
+}
+
+function makeResult(
+  artifact,
+  outcome,
+  {
+    complete = false,
+    published = false,
+    verified = false,
+    bootstrapRequired = false,
+    distTag = artifact.distTag || "",
+    publishAttempts = 0,
+    reason = outcome,
+    exitCode = 1
+  } = {}
+) {
+  return {
+    outcome,
+    complete,
+    published,
+    verified,
+    bootstrapRequired,
+    distTag,
+    packageName: artifact.name,
+    packageVersion: artifact.version,
+    packageUrl: artifact.packageUrl || stablePackageUrl(artifact.name, artifact.version),
+    tarballPath: artifact.tarballPath || "",
+    publishAttempts,
+    reason,
+    exitCode
+  };
+}
+
+function compareObservedVersion(state, artifact) {
+  if (!state.versionExists) return "absent";
+  return state.integrity === artifact.integrity ? "match" : "mismatch";
+}
+
+function inspectLatestState(state, artifact, distTag) {
+  if (distTag !== "latest") return { acceptable: true, reason: "not_requested" };
+  if (!state.latestVersionExists) {
+    return { acceptable: false, reason: "registry_latest_missing_or_invalid" };
+  }
+  const order = compareStableVersions(state.latestVersion, artifact.version);
+  if (order === null) {
+    return { acceptable: false, reason: "registry_latest_missing_or_invalid" };
+  }
+  if (order < 0) {
+    return { acceptable: false, reason: "registry_latest_is_older" };
+  }
+  return {
+    acceptable: true,
+    reason: order === 0 ? "registry_latest_matches" : "registry_latest_is_newer"
+  };
+}
+
+async function observePublishedVersion(
+  readRegistry,
+  sleep,
+  verifyDelays,
+  artifact,
+  distTag
+) {
+  let state;
+  for (const wait of verifyDelays) {
+    if (wait > 0) await sleep(wait);
+    state = await readRegistry();
+    const comparison = compareObservedVersion(state, artifact);
+    if (comparison === "mismatch") break;
+    if (
+      comparison === "match" &&
+      inspectLatestState(state, artifact, distTag).acceptable
+    ) break;
+  }
+  return state;
+}
+
+function compareStableVersions(left, right) {
+  if (!STABLE_SEMVER.test(String(left || "")) || !STABLE_SEMVER.test(String(right || ""))) {
+    return null;
+  }
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] < rightParts[index] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+async function existingBootstrapMarker(markerPath) {
+  if (!markerPath) return false;
+  try {
+    const marker = await stat(path.resolve(markerPath));
+    return marker.isFile();
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+export async function publishWithFallback(
+  artifact,
+  options,
+  dependencies = {}
+) {
+  const { missingPackage, bootstrapMarkerPath, distTag } = options;
+  if (!ALLOWED_MISSING_POLICIES.has(missingPackage)) {
+    throw new ReleaseInputError(
+      "--missing-package must be fail or bootstrap-soft"
+    );
+  }
+  if (!/^[a-z][a-z0-9._-]*$/i.test(String(distTag || ""))) {
+    throw new ReleaseInputError("--dist-tag must be a non-empty npm tag");
+  }
+
+  const sleep = dependencies.sleep || delay;
+  const verifyDelays = dependencies.verifyDelays || DEFAULT_VERIFY_DELAYS_MS;
+  const markerExists = dependencies.markerExists || existingBootstrapMarker;
+  const registryUrl = dependencies.readRegistry && dependencies.runPublish
+    ? OFFICIAL_NPM_REGISTRY
+    : officialRegistryUrl(
+      dependencies.registryUrl || configuredRegistryUrl()
+    );
+  const readRegistry = dependencies.readRegistry || (() => readRegistryState({
+    name: artifact.name,
+    version: artifact.version,
+    registryUrl,
+    sleep
+  }));
+  const runPublish = dependencies.runPublish || (() => runNpmPublish(artifact, {
+    distTag,
+    registryUrl
+  }));
+
+  const initialState = await readRegistry();
+  const bootstrapMarkerExists = missingPackage === "bootstrap-soft" &&
+    await markerExists(bootstrapMarkerPath);
+  if (initialState.packageExists && bootstrapMarkerExists) {
+    return makeResult(artifact, "stale_bootstrap_marker", {
+      distTag,
+      reason: "remove_bootstrap_marker_after_trusted_publisher_setup"
+    });
+  }
+  const initialComparison = compareObservedVersion(initialState, artifact);
+  if (initialComparison === "match") {
+    const latestState = inspectLatestState(initialState, artifact, distTag);
+    if (!latestState.acceptable) {
+      return makeResult(artifact, "dist_tag_verification_failed", {
+        distTag,
+        reason: latestState.reason
+      });
+    }
+    return makeResult(artifact, "already_published", {
+      complete: true,
+      published: true,
+      verified: true,
+      distTag,
+      reason: "registry_integrity_matches",
+      exitCode: 0
+    });
+  }
+  if (initialComparison === "mismatch") {
+    return makeResult(artifact, "version_conflict", {
+      distTag,
+      reason: "registry_integrity_mismatch"
+    });
+  }
+  if (!initialState.packageExists) {
+    if (bootstrapMarkerExists) {
+      return makeResult(artifact, "bootstrap_required", {
+        bootstrapRequired: true,
+        distTag,
+        reason: "package_bootstrap_or_scope_access_required",
+        exitCode: 0
+      });
+    }
+    return makeResult(artifact, "package_missing", {
+      distTag,
+      reason: missingPackage === "bootstrap-soft"
+        ? "bootstrap_marker_missing"
+        : "package_does_not_exist"
+    });
+  }
+
+  if (
+    distTag === "latest" &&
+    compareStableVersions(artifact.version, initialState.latestVersion) === -1
+  ) {
+    return makeResult(artifact, "backfill_latest_blocked", {
+      distTag,
+      reason: "target_version_is_older_than_registry_latest"
+    });
+  }
+
+  const publishAttempts = 1;
+  const publishOutput = await runPublish();
+  const observation = await observePublishedVersion(
+    readRegistry,
+    sleep,
+    verifyDelays,
+    artifact,
+    distTag
+  );
+  const comparison = compareObservedVersion(observation, artifact);
+  if (comparison === "match") {
+    const latestState = inspectLatestState(observation, artifact, distTag);
+    if (!latestState.acceptable) {
+      return makeResult(artifact, "dist_tag_verification_failed", {
+        distTag,
+        publishAttempts,
+        reason: latestState.reason
+      });
+    }
+    const outcome = publishOutput.exitCode === 0
+      ? "published"
+      : "published_after_ambiguous_error";
+    return makeResult(artifact, outcome, {
+      complete: true,
+      published: true,
+      verified: true,
+      distTag,
+      publishAttempts,
+      reason: "registry_integrity_matches",
+      exitCode: 0
+    });
+  }
+  if (comparison === "mismatch") {
+    return makeResult(artifact, "version_conflict", {
+      distTag,
+      publishAttempts,
+      reason: "registry_integrity_mismatch"
+    });
+  }
+  if (publishOutput.exitCode === 0) {
+    return makeResult(artifact, "verification_failed", {
+      distTag,
+      publishAttempts,
+      reason: "published_version_not_observed"
+    });
+  }
+
+  const failure = classifyPublishFailure(publishOutput);
+  if (failure.kind === "not-found") {
+    return makeResult(artifact, "publisher_misconfigured", {
+      distTag,
+      publishAttempts,
+      reason: "trusted_publisher_or_package_permission_mismatch"
+    });
+  }
+  if (failure.kind === "authentication") {
+    return makeResult(artifact, "authentication_failed", {
+      distTag,
+      publishAttempts,
+      reason: failure.code.toLowerCase()
+    });
+  }
+  if (failure.kind === "conflict") {
+    return makeResult(artifact, "version_conflict", {
+      distTag,
+      publishAttempts,
+      reason: "publish_conflict_without_matching_registry_version"
+    });
+  }
+  if (failure.kind === "transient") {
+    return makeResult(artifact, "transient_failure", {
+      distTag,
+      publishAttempts,
+      reason: `${failure.code.toLowerCase()}_readback_absent`
+    });
+  }
+  return makeResult(artifact, "publish_failed", {
+    distTag,
+    publishAttempts,
+    reason: failure.code.toLowerCase()
+  });
+}
+
+function singleLine(value) {
+  return String(value ?? "").replace(/[\r\n]+/g, " ");
+}
+
+function markdownCell(value) {
+  return singleLine(value).replaceAll("|", "\\|");
+}
+
+function annotationValue(value, property = false) {
+  let encoded = String(value ?? "")
+    .replaceAll("%", "%25")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A");
+  if (property) {
+    encoded = encoded.replaceAll(":", "%3A").replaceAll(",", "%2C");
+  }
+  return encoded;
+}
+
+export function renderGitHubSummary(result) {
+  const lines = [
+    `### npm publish: \`${markdownCell(result.packageName)}@${markdownCell(result.packageVersion)}\``,
+    "",
+    "| Outcome | Dist tag | Complete | Registry verified | Publish attempts |",
+    "| --- | --- | --- | --- | ---: |",
+    `| \`${markdownCell(result.outcome)}\` | \`${markdownCell(result.distTag)}\` | ${result.complete ? "yes" : "no"} | ${result.verified ? "yes" : "no"} | ${result.publishAttempts} |`,
+    "",
+    `[View package version](${result.packageUrl})`
+  ];
+  if (result.bootstrapRequired) {
+    lines.push(
+      "",
+      "> [!WARNING]",
+      "> This package does not yet exist in the public registry. An npm scope owner must publish the verified tarball once, then configure Trusted Publishing for this workflow.",
+      `> Verified tarball: \`${markdownCell(path.basename(result.tarballPath))}\``,
+      "> Until bootstrap completes, use `@fullstack-ai-infra/digital-employee/core` or install the matching root/core `.tgz` asset from the GitHub Release."
+    );
+  } else if (result.exitCode !== 0) {
+    lines.push(
+      "",
+      "> [!CAUTION]",
+      `> npm publication is incomplete: \`${markdownCell(result.reason)}\`.`
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export async function writeGitHubReport(
+  result,
+  {
+    outputPath = process.env.GITHUB_OUTPUT,
+    summaryPath = process.env.GITHUB_STEP_SUMMARY,
+    annotate = process.env.GITHUB_ACTIONS === "true"
+  } = {}
+) {
+  const outputs = {
+    outcome: result.outcome,
+    complete: result.complete,
+    published: result.published,
+    verified: result.verified,
+    bootstrap_required: result.bootstrapRequired,
+    dist_tag: result.distTag,
+    package_name: result.packageName,
+    package_version: result.packageVersion,
+    package_url: result.packageUrl,
+    tarball_path: result.tarballPath,
+    publish_attempts: result.publishAttempts,
+    reason: result.reason
+  };
+  if (outputPath) {
+    const serialized = Object.entries(outputs)
+      .map(([key, value]) => `${key}=${singleLine(value)}`)
+      .join("\n");
+    await appendFile(outputPath, `${serialized}\n`, "utf8");
+  }
+  if (summaryPath) {
+    await appendFile(summaryPath, renderGitHubSummary(result), "utf8");
+  }
+  if (annotate && result.bootstrapRequired) {
+    process.stdout.write(
+      `::warning title=${annotationValue("npm bootstrap required", true)}::${annotationValue(`${result.packageName}@${result.packageVersion} requires one-time npm owner publication`)}\n`
+    );
+  } else if (annotate && result.exitCode !== 0) {
+    process.stdout.write(
+      `::error title=${annotationValue("npm publish incomplete", true)}::${annotationValue(result.reason)}\n`
+    );
+  }
+}
+
+export function parseArguments(argv) {
+  if (argv.includes("--help") || argv.includes("-h")) return { help: true };
+  const allowed = new Set([
+    "--manifest",
+    "--pack-json",
+    "--expected-name",
+    "--release-tag",
+    "--dist-tag",
+    "--missing-package",
+    "--bootstrap-marker"
+  ]);
+  const required = new Set([
+    "--manifest",
+    "--pack-json",
+    "--expected-name",
+    "--release-tag",
+    "--dist-tag",
+    "--missing-package"
+  ]);
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!allowed.has(flag)) {
+      throw new ReleaseInputError(`unknown argument ${flag || "<missing>"}`);
+    }
+    if (!value || value.startsWith("--")) {
+      throw new ReleaseInputError(`${flag} requires a value`);
+    }
+    if (values[flag] !== undefined) {
+      throw new ReleaseInputError(`${flag} may only be specified once`);
+    }
+    values[flag] = value;
+  }
+  for (const flag of required) {
+    if (values[flag] === undefined) {
+      throw new ReleaseInputError(`${flag} is required`);
+    }
+  }
+  if (!ALLOWED_MISSING_POLICIES.has(values["--missing-package"])) {
+    throw new ReleaseInputError(
+      "--missing-package must be fail or bootstrap-soft"
+    );
+  }
+  if (!/^[a-z][a-z0-9._-]*$/i.test(values["--dist-tag"])) {
+    throw new ReleaseInputError("--dist-tag must be a non-empty npm tag");
+  }
+  return {
+    manifestPath: values["--manifest"],
+    packJsonPath: values["--pack-json"],
+    expectedName: values["--expected-name"],
+    releaseTag: values["--release-tag"],
+    distTag: values["--dist-tag"],
+    missingPackage: values["--missing-package"],
+    bootstrapMarkerPath: values["--bootstrap-marker"]
+  };
+}
+
+function fallbackArtifact(options = {}) {
+  const version = String(options.releaseTag || "").replace(/^v/, "");
+  return {
+    name: options.expectedName || "unknown-package",
+    version,
+    packageUrl: stablePackageUrl(options.expectedName, version),
+    tarballPath: "",
+    distTag: options.distTag || ""
+  };
+}
+
+export async function runCli(argv = process.argv.slice(2)) {
+  let options;
+  let artifact;
+  let result;
+  try {
+    options = parseArguments(argv);
+    if (options.help) {
+      process.stdout.write(USAGE);
+      return 0;
+    }
+    artifact = await loadReleaseArtifact(options);
+    result = await publishWithFallback(artifact, {
+      missingPackage: options.missingPackage,
+      bootstrapMarkerPath: options.bootstrapMarkerPath,
+      distTag: options.distTag
+    });
+  } catch (error) {
+    const inputFailure = error instanceof ReleaseInputError;
+    artifact ||= fallbackArtifact(options);
+    result = makeResult(
+      artifact,
+      inputFailure ? "input_invalid" : "registry_or_internal_failure",
+      {
+        reason: inputFailure
+          ? "release_input_invalid"
+          : error instanceof RegistryReadError
+            ? "registry_read_failed"
+            : "unexpected_error",
+        exitCode: inputFailure ? 2 : 1
+      }
+    );
+    process.stderr.write(`npm-publish-resilient: ${error?.message || "unexpected error"}\n`);
+  }
+
+  await writeGitHubReport(result);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  return result.exitCode;
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  runCli().then((exitCode) => {
+    process.exitCode = exitCode;
+  }).catch((error) => {
+    process.stderr.write(
+      `npm-publish-resilient: ${error?.message || "unexpected error"}\n`
+    );
+    process.exitCode = 1;
+  });
+}

--- a/scripts/npm-publish-resilient.js
+++ b/scripts/npm-publish-resilient.js
@@ -588,6 +588,7 @@ function makeResult(
     published = false,
     verified = false,
     bootstrapRequired = false,
+    markerCleanupRequired = false,
     distTag = artifact.distTag || "",
     publishAttempts = 0,
     reason = outcome,
@@ -600,6 +601,7 @@ function makeResult(
     published,
     verified,
     bootstrapRequired,
+    markerCleanupRequired,
     distTag,
     packageName: artifact.name,
     packageVersion: artifact.version,
@@ -717,12 +719,6 @@ export async function publishWithFallback(
   const initialState = await readRegistry();
   const bootstrapMarkerExists = missingPackage === "bootstrap-soft" &&
     await markerExists(bootstrapMarkerPath);
-  if (initialState.packageExists && bootstrapMarkerExists) {
-    return makeResult(artifact, "stale_bootstrap_marker", {
-      distTag,
-      reason: "remove_bootstrap_marker_after_trusted_publisher_setup"
-    });
-  }
   const initialComparison = compareObservedVersion(initialState, artifact);
   if (initialComparison === "match") {
     const latestState = inspectLatestState(initialState, artifact, distTag);
@@ -732,19 +728,34 @@ export async function publishWithFallback(
         reason: latestState.reason
       });
     }
-    return makeResult(artifact, "already_published", {
-      complete: true,
-      published: true,
-      verified: true,
-      distTag,
-      reason: "registry_integrity_matches",
-      exitCode: 0
-    });
+    return makeResult(
+      artifact,
+      bootstrapMarkerExists
+        ? "bootstrap_verified_marker_cleanup_required"
+        : "already_published",
+      {
+        complete: true,
+        published: true,
+        verified: true,
+        markerCleanupRequired: bootstrapMarkerExists,
+        distTag,
+        reason: bootstrapMarkerExists
+          ? "registry_integrity_matches_remove_bootstrap_marker"
+          : "registry_integrity_matches",
+        exitCode: 0
+      }
+    );
   }
   if (initialComparison === "mismatch") {
     return makeResult(artifact, "version_conflict", {
       distTag,
       reason: "registry_integrity_mismatch"
+    });
+  }
+  if (initialState.packageExists && bootstrapMarkerExists) {
+    return makeResult(artifact, "stale_bootstrap_marker", {
+      distTag,
+      reason: "remove_bootstrap_marker_after_trusted_publisher_setup"
     });
   }
   if (!initialState.packageExists) {
@@ -764,14 +775,23 @@ export async function publishWithFallback(
     });
   }
 
-  if (
-    distTag === "latest" &&
-    compareStableVersions(artifact.version, initialState.latestVersion) === -1
-  ) {
-    return makeResult(artifact, "backfill_latest_blocked", {
-      distTag,
-      reason: "target_version_is_older_than_registry_latest"
-    });
+  if (distTag === "latest" && initialState.latestVersion !== null) {
+    const latestOrder = compareStableVersions(
+      artifact.version,
+      initialState.latestVersion
+    );
+    if (!initialState.latestVersionExists || latestOrder === null) {
+      return makeResult(artifact, "dist_tag_preflight_failed", {
+        distTag,
+        reason: "registry_latest_is_invalid_or_non_stable"
+      });
+    }
+    if (latestOrder === -1) {
+      return makeResult(artifact, "backfill_latest_blocked", {
+        distTag,
+        reason: "target_version_is_older_than_registry_latest"
+      });
+    }
   }
 
   const publishAttempts = 1;
@@ -894,6 +914,13 @@ export function renderGitHubSummary(result) {
       `> Verified tarball: \`${markdownCell(path.basename(result.tarballPath))}\``,
       "> Until bootstrap completes, use `@fullstack-ai-infra/digital-employee/core` or install the matching root/core `.tgz` asset from the GitHub Release."
     );
+  } else if (result.markerCleanupRequired) {
+    lines.push(
+      "",
+      "> [!WARNING]",
+      "> The exact package version is present and verified, so this rerun has converged.",
+      "> Confirm Trusted Publishing is configured, then remove the bootstrap marker before the next release."
+    );
   } else if (result.exitCode !== 0) {
     lines.push(
       "",
@@ -918,6 +945,7 @@ export async function writeGitHubReport(
     published: result.published,
     verified: result.verified,
     bootstrap_required: result.bootstrapRequired,
+    marker_cleanup_required: result.markerCleanupRequired,
     dist_tag: result.distTag,
     package_name: result.packageName,
     package_version: result.packageVersion,
@@ -938,6 +966,10 @@ export async function writeGitHubReport(
   if (annotate && result.bootstrapRequired) {
     process.stdout.write(
       `::warning title=${annotationValue("npm bootstrap required", true)}::${annotationValue(`${result.packageName}@${result.packageVersion} requires one-time npm owner publication`)}\n`
+    );
+  } else if (annotate && result.markerCleanupRequired) {
+    process.stdout.write(
+      `::warning title=${annotationValue("npm bootstrap marker cleanup required", true)}::${annotationValue(`${result.packageName}@${result.packageVersion} is verified; confirm Trusted Publishing and remove the marker before the next release`)}\n`
     );
   } else if (annotate && result.exitCode !== 0) {
     process.stdout.write(

--- a/scripts/release-check.js
+++ b/scripts/release-check.js
@@ -42,6 +42,14 @@ export function validateRelease({
   if (manifest.exports?.["."]?.import !== "./dist/packages/core/index.js") {
     errors.push("root package export must use compiled runtime output");
   }
+  if (
+    manifest.exports?.["./core"]?.types !==
+      "./dist/packages/core/index.d.ts" ||
+    manifest.exports?.["./core"]?.import !==
+      "./dist/packages/core/index.js"
+  ) {
+    errors.push("root /core fallback must use compiled output");
+  }
   if (!Array.isArray(manifest.files) || !manifest.files.includes("dist")) {
     errors.push("published files must include compiled distribution artifacts");
   }

--- a/scripts/release-pack-check.js
+++ b/scripts/release-pack-check.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
-import { readFile, stat } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { lstat, readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const PACKAGE_SPECS = [
+export const PACKAGE_SPECS = [
   {
     label: "root",
     manifestPath: "package.json",
@@ -12,9 +13,21 @@ const PACKAGE_SPECS = [
       "package.json",
       "dist/apps/cli/bin.js",
       "dist/packages/core/index.js",
-      "dist/packages/core/index.d.ts"
+      "dist/packages/core/index.d.ts",
+      "locales/README.md",
+      "locales/en.json",
+      "locales/ja.json",
+      "locales/zh-CN.json"
     ],
-    allowedFiles: ["package.json", "LICENSE", "NOTICE"],
+    allowedFiles: [
+      "package.json",
+      "LICENSE",
+      "NOTICE",
+      "locales/README.md",
+      "locales/en.json",
+      "locales/ja.json",
+      "locales/zh-CN.json"
+    ],
     allowedPrefixes: ["dist/"],
     allowedPatterns: [/^README[^/]*\.md$/]
   },
@@ -84,16 +97,49 @@ export function validatePackOutput({
   return errors;
 }
 
-async function validateArchive({ label, manifest, packDestination }) {
+function digest(buffer, algorithm, encoding) {
+  return createHash(algorithm).update(buffer).digest(encoding);
+}
+
+export async function validateArchive({
+  label,
+  manifest,
+  pack,
+  packDestination
+}) {
+  const errors = [];
+  let archive;
   try {
-    const archive = await stat(
-      path.join(packDestination, expectedFilename(manifest))
-    );
-    if (archive.isFile() && archive.size > 0) return [];
+    const archivePath = path.join(packDestination, expectedFilename(manifest));
+    const [archiveStat, archiveBytes] = await Promise.all([
+      lstat(archivePath),
+      readFile(archivePath)
+    ]);
+    if (
+      archiveStat.isSymbolicLink() ||
+      !archiveStat.isFile() ||
+      archiveBytes.length === 0
+    ) {
+      return [`${label} npm pack archive must be a non-empty regular file`];
+    }
+    archive = archiveBytes;
   } catch (error) {
     if (error?.code !== "ENOENT") throw error;
+    return [`${label} npm pack archive is missing or empty`];
   }
-  return [`${label} npm pack archive is missing or empty`];
+
+  if (!Number.isSafeInteger(pack?.size) || pack.size !== archive.length) {
+    errors.push(`${label} npm pack archive size does not match pack JSON`);
+  }
+  const integrity = `sha512-${digest(archive, "sha512", "base64")}`;
+  if (pack?.integrity !== integrity) {
+    errors.push(`${label} npm pack archive integrity does not match pack JSON`);
+  }
+  const shasum = digest(archive, "sha1", "hex");
+  if (pack?.shasum !== shasum) {
+    errors.push(`${label} npm pack archive shasum does not match pack JSON`);
+  }
+  return errors;
 }
 
 async function main() {
@@ -128,6 +174,7 @@ async function main() {
     errors.push(...await validateArchive({
       label: spec.label,
       manifest,
+      pack: output[0],
       packDestination
     }));
   }

--- a/tests/apps/deploy-i18n.test.ts
+++ b/tests/apps/deploy-i18n.test.ts
@@ -3,26 +3,31 @@ import test from "node:test"
 
 import { detectSystemLocale, setLocale, t, getLocale, getAvailableLocales, getLocaleDisplayName } from "../../apps/cli/deploy/i18n.js"
 
-test("detectSystemLocale returns zh-CN for zh locale", () => {
-  const original = process.env.LANG
-  process.env.LANG = "zh_CN.UTF-8"
+function withLang<T>(lang: string, callback: () => T): T {
+  const originalLang = process.env.LANG
+  const originalLcAll = process.env.LC_ALL
+  delete process.env.LC_ALL
+  process.env.LANG = lang
   try {
-    assert.equal(detectSystemLocale(), "zh-CN")
+    return callback()
   } finally {
-    if (original !== undefined) process.env.LANG = original
+    if (originalLang !== undefined) process.env.LANG = originalLang
     else delete process.env.LANG
+    if (originalLcAll !== undefined) process.env.LC_ALL = originalLcAll
+    else delete process.env.LC_ALL
   }
+}
+
+test("detectSystemLocale returns zh-CN for zh locale", () => {
+  withLang("zh_CN.UTF-8", () => {
+    assert.equal(detectSystemLocale(), "zh-CN")
+  })
 })
 
 test("detectSystemLocale returns en for non-zh locale", () => {
-  const original = process.env.LANG
-  process.env.LANG = "en_US.UTF-8"
-  try {
+  withLang("en_US.UTF-8", () => {
     assert.equal(detectSystemLocale(), "en")
-  } finally {
-    if (original !== undefined) process.env.LANG = original
-    else delete process.env.LANG
-  }
+  })
 })
 
 test("setLocale loads English messages", () => {
@@ -86,12 +91,7 @@ test("missing key in non-English locale falls back to English", () => {
 })
 
 test("detectSystemLocale returns ja for Japanese locale", () => {
-  const original = process.env.LANG
-  process.env.LANG = "ja_JP.UTF-8"
-  try {
+  withLang("ja_JP.UTF-8", () => {
     assert.equal(detectSystemLocale(), "ja")
-  } finally {
-    if (original !== undefined) process.env.LANG = original
-    else delete process.env.LANG
-  }
+  })
 })

--- a/tests/apps/fixtures/fake-claude.mjs
+++ b/tests/apps/fixtures/fake-claude.mjs
@@ -23,6 +23,9 @@ if (args.includes("--version")) {
 }
 
 const mode = option("--fixture-mode") || "success"
+// A pending promise alone does not keep Node alive. Give the deadline fixture
+// a real event-loop handle so it cannot race a natural exit with the adapter.
+if (mode === "hang") setInterval(() => {}, 1_000)
 const capture = option("--capture")
 const orphanPidFile = option("--orphan-pid-file")
 const launchLog = option("--launch-log")

--- a/tests/apps/fixtures/fake-codebuddy.mjs
+++ b/tests/apps/fixtures/fake-codebuddy.mjs
@@ -33,6 +33,9 @@ if (args.includes("--version")) {
 }
 
 const mode = option("--fixture-mode") || "success"
+// A pending promise alone does not keep Node alive. Give the deadline fixture
+// a real event-loop handle so it cannot race a natural exit with the adapter.
+if (mode === "hang") setInterval(() => {}, 1_000)
 const capture = option("--capture")
 const launchLog = option("--launch-log")
 if (launchLog) {

--- a/tests/apps/fixtures/fake-qwen.mjs
+++ b/tests/apps/fixtures/fake-qwen.mjs
@@ -16,6 +16,9 @@ if (args.includes("--version")) {
 }
 
 const mode = option("--fixture-mode") || "success"
+// A pending promise alone does not keep Node alive. Give the deadline fixture
+// a real event-loop handle so it cannot race a natural exit with the adapter.
+if (mode === "hang") setInterval(() => {}, 1_000)
 const capture = option("--capture")
 const launchLog = option("--launch-log")
 if (launchLog) {

--- a/tests/integration/signed-task-e2e.test.ts
+++ b/tests/integration/signed-task-e2e.test.ts
@@ -68,9 +68,9 @@ import type { UsageEvidenceRecord } from "../../packages/core/src/runner-usage-e
 // ---------------------------------------------------------------------------
 
 interface PlatformSimulator {
-  platformKeyPair: ReturnType<typeof generateKeyPairSync>
+  platformKeyPair: ReturnType<typeof generateEd25519KeyPair>
   platformKeyId: string
-  runnerKeyPair: ReturnType<typeof generateKeyPairSync>
+  runnerKeyPair: ReturnType<typeof generateEd25519KeyPair>
   runnerKeyId: string
   signTask(task: RunnerTaskPayload): SignedEnvelope
   verifyReceipt(envelope: unknown): RunnerReceiptPayload
@@ -88,9 +88,13 @@ interface PlatformSimulator {
   recordUsage(receipt: RunnerReceiptPayload): UsageEvidenceRecord
 }
 
+function generateEd25519KeyPair() {
+  return generateKeyPairSync("ed25519")
+}
+
 function createPlatformSimulator(): PlatformSimulator {
-  const platformKeyPair = generateKeyPairSync("ed25519")
-  const runnerKeyPair = generateKeyPairSync("ed25519")
+  const platformKeyPair = generateEd25519KeyPair()
+  const runnerKeyPair = generateEd25519KeyPair()
   const platformKeyId = "platform-sim-key-1"
   const runnerKeyId = "runner-sim-key-1"
 

--- a/tests/scripts/npm-publish-resilient.test.ts
+++ b/tests/scripts/npm-publish-resilient.test.ts
@@ -545,7 +545,35 @@ test("returns bootstrap-required without publishing when marker-backed package i
   assert.equal(publishCalls, 0);
 });
 
-test("fails closed when a bootstrap marker remains after the package exists", async () => {
+test("converges when bootstrap published the exact verified version but marker cleanup remains", async () => {
+  let publishCalls = 0;
+  const result = await publishWithFallback(
+    artifact(),
+    {
+      missingPackage: "bootstrap-soft",
+      bootstrapMarkerPath: "/tmp/bootstrap-marker",
+      distTag: "latest"
+    },
+    {
+      readRegistry: async () => registryVersion(),
+      runPublish: async () => {
+        publishCalls += 1;
+        return publishSuccess();
+      },
+      markerExists: async () => true,
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "bootstrap_verified_marker_cleanup_required");
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.complete, true);
+  assert.equal(result.verified, true);
+  assert.equal(result.markerCleanupRequired, true);
+  assert.equal(publishCalls, 0);
+});
+
+test("fails closed before a future version while a bootstrap marker remains", async () => {
   let publishCalls = 0;
   const result = await publishWithFallback(
     artifact(),
@@ -715,6 +743,56 @@ test("blocks a historical version from moving the latest dist-tag backwards", as
   assert.equal(publishCalls, 0);
 });
 
+test("blocks a non-stable latest tag before publishing a stable version", async () => {
+  let publishCalls = 0;
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: async () => ({
+        ...absentVersion,
+        latestVersion: "1.0.0-beta.1",
+        latestVersionExists: true
+      }),
+      runPublish: async () => {
+        publishCalls += 1;
+        return publishSuccess();
+      },
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "dist_tag_preflight_failed");
+  assert.equal(result.reason, "registry_latest_is_invalid_or_non_stable");
+  assert.equal(result.exitCode, 1);
+  assert.equal(publishCalls, 0);
+});
+
+test("blocks a dangling latest tag before publishing a stable version", async () => {
+  let publishCalls = 0;
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: async () => ({
+        ...absentVersion,
+        latestVersion: "0.2.0",
+        latestVersionExists: false
+      }),
+      runPublish: async () => {
+        publishCalls += 1;
+        return publishSuccess();
+      },
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "dist_tag_preflight_failed");
+  assert.equal(result.reason, "registry_latest_is_invalid_or_non_stable");
+  assert.equal(result.exitCode, 1);
+  assert.equal(publishCalls, 0);
+});
+
 test("parses an explicit repair tag and bootstrap marker", () => {
   const parsed = parseArguments([
     "--manifest", "packages/core/package.json",
@@ -787,6 +865,7 @@ test("writes machine outputs and a conspicuous bootstrap summary", async () => {
       published: false,
       verified: false,
       bootstrapRequired: true,
+      markerCleanupRequired: false,
       distTag: "latest",
       packageName,
       packageVersion: version,
@@ -808,6 +887,7 @@ test("writes machine outputs and a conspicuous bootstrap summary", async () => {
     assert.match(outputs, /^outcome=bootstrap_required$/m);
     assert.match(outputs, /^complete=false$/m);
     assert.match(outputs, /^bootstrap_required=true$/m);
+    assert.match(outputs, /^marker_cleanup_required=false$/m);
     assert.match(outputs, /^dist_tag=latest$/m);
     assert.match(outputs, /^tarball_path=/m);
     assert.match(summary, /\[!WARNING\]/);

--- a/tests/scripts/npm-publish-resilient.test.ts
+++ b/tests/scripts/npm-publish-resilient.test.ts
@@ -1,0 +1,819 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+import {
+  classifyPublishFailure,
+  loadReleaseArtifact,
+  parseArguments,
+  publishWithFallback,
+  readRegistryState,
+  runNpmPublish,
+  writeGitHubReport
+} from "../../scripts/npm-publish-resilient.js";
+
+const packageName = "@fullstack-ai-infra/digital-employee-core";
+const version = "0.3.0";
+const localIntegrity = "sha512-bG9jYWw=";
+
+const absentPackage = {
+  packageExists: false,
+  versionExists: false,
+  integrity: null,
+  shasum: null,
+  latestVersion: null,
+  latestVersionExists: false
+};
+const absentVersion = {
+  packageExists: true,
+  versionExists: false,
+  integrity: null,
+  shasum: null,
+  latestVersion: null,
+  latestVersionExists: false
+};
+
+function registryVersion(
+  integrity = localIntegrity,
+  latestVersion = version,
+  latestVersionExists = true
+) {
+  return {
+    packageExists: true,
+    versionExists: true,
+    integrity,
+    shasum: "a".repeat(40),
+    latestVersion,
+    latestVersionExists
+  };
+}
+
+function artifact() {
+  return {
+    name: packageName,
+    version,
+    integrity: localIntegrity,
+    shasum: "a".repeat(40),
+    filename: "digital-employee-core-0.3.0.tgz",
+    tarballPath: "/tmp/digital-employee-core-0.3.0.tgz",
+    manifestPath: "/tmp/package.json",
+    packJsonPath: "/tmp/core-pack.json",
+    packageUrl: `https://www.npmjs.com/package/${packageName}/v/${version}`
+  };
+}
+
+function publishableArtifact() {
+  const archive = Buffer.from("immutable verified publish bytes");
+  return {
+    ...artifact(),
+    archive,
+    integrity: `sha512-${createHash("sha512").update(archive).digest("base64")}`,
+    shasum: createHash("sha1").update(archive).digest("hex")
+  };
+}
+
+function publishFailure(code: string, status: number, phrase: string) {
+  return {
+    exitCode: 1,
+    signal: null,
+    errorCode: null,
+    timedOut: false,
+    stdout: "",
+    stderr: `npm error code ${code}\nnpm error ${status} ${phrase}\n`
+  };
+}
+
+function publishSuccess() {
+  return {
+    exitCode: 0,
+    signal: null,
+    errorCode: null,
+    timedOut: false,
+    stdout: JSON.stringify({ id: `${packageName}@${version}` }),
+    stderr: ""
+  };
+}
+
+function sequence<T>(values: T[]) {
+  let index = 0;
+  return async () => {
+    const value = values[Math.min(index, values.length - 1)];
+    index += 1;
+    return value;
+  };
+}
+
+const immediate = async () => {};
+
+class NonClosingChild extends EventEmitter {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly signals: string[] = [];
+  unrefCalled = false;
+
+  kill(signal: string) {
+    this.signals.push(signal);
+    return true;
+  }
+
+  unref() {
+    this.unrefCalled = true;
+  }
+}
+
+test("loads the exact packed tarball and verifies its digests", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "npm-publish-resilient-"));
+  try {
+    const archive = Buffer.from("verified release archive");
+    const filename = "digital-employee-core-0.3.0.tgz";
+    const integrity = `sha512-${createHash("sha512").update(archive).digest("base64")}`;
+    const shasum = createHash("sha1").update(archive).digest("hex");
+    const manifestPath = path.join(root, "package.json");
+    const packJsonPath = path.join(root, "core-pack.json");
+    await Promise.all([
+      writeFile(manifestPath, JSON.stringify({
+        name: packageName,
+        version,
+        publishConfig: { access: "public" }
+      })),
+      writeFile(path.join(root, filename), archive),
+      writeFile(packJsonPath, JSON.stringify([{
+        name: packageName,
+        version,
+        filename,
+        size: archive.length,
+        integrity,
+        shasum
+      }]))
+    ]);
+
+    const loaded = await loadReleaseArtifact({
+      manifestPath,
+      packJsonPath,
+      expectedName: packageName,
+      releaseTag: `v${version}`
+    });
+    assert.equal(loaded.integrity, integrity);
+    assert.equal(loaded.shasum, shasum);
+    assert.equal(loaded.tarballPath, path.join(root, filename));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a tarball whose bytes no longer match pack JSON", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "npm-publish-resilient-"));
+  try {
+    const filename = "digital-employee-core-0.3.0.tgz";
+    const manifestPath = path.join(root, "package.json");
+    const packJsonPath = path.join(root, "core-pack.json");
+    await Promise.all([
+      writeFile(manifestPath, JSON.stringify({
+        name: packageName,
+        version,
+        publishConfig: { access: "public" }
+      })),
+      writeFile(path.join(root, filename), "tampered"),
+      writeFile(packJsonPath, JSON.stringify([{
+        name: packageName,
+        version,
+        filename,
+        integrity: "sha512-ZXhwZWN0ZWQ=",
+        shasum: "a".repeat(40)
+      }]))
+    ]);
+    await assert.rejects(
+      loadReleaseArtifact({
+        manifestPath,
+        packJsonPath,
+        expectedName: packageName,
+        releaseTag: `v${version}`
+      }),
+      /integrity does not match/
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a symlinked packed tarball", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "npm-publish-resilient-"));
+  try {
+    const archive = Buffer.from("verified release archive");
+    const filename = "digital-employee-core-0.3.0.tgz";
+    const target = path.join(root, "archive-target.tgz");
+    const integrity = `sha512-${createHash("sha512").update(archive).digest("base64")}`;
+    const manifestPath = path.join(root, "package.json");
+    const packJsonPath = path.join(root, "core-pack.json");
+    await Promise.all([
+      writeFile(manifestPath, JSON.stringify({
+        name: packageName,
+        version,
+        publishConfig: { access: "public" }
+      })),
+      writeFile(target, archive),
+      writeFile(packJsonPath, JSON.stringify([{
+        name: packageName,
+        version,
+        filename,
+        integrity,
+        shasum: createHash("sha1").update(archive).digest("hex")
+      }]))
+    ]);
+    await symlink(target, path.join(root, filename));
+    await assert.rejects(
+      loadReleaseArtifact({
+        manifestPath,
+        packJsonPath,
+        expectedName: packageName,
+        releaseTag: `v${version}`
+      }),
+      /non-empty regular file/
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("uses only the canonical official npm registry for reads", async () => {
+  let requestedUrl = "";
+  let redirectMode = "";
+  const state = await readRegistryState({
+    name: packageName,
+    version,
+    registryUrl: "https://registry.npmjs.org",
+    retryDelays: [0],
+    fetchImpl: async (input: string | URL | Request, init?: RequestInit) => {
+      requestedUrl = String(input);
+      redirectMode = String(init?.redirect);
+      return new Response(JSON.stringify({
+        name: packageName,
+        versions: {
+          [version]: {
+            dist: {
+              integrity: localIntegrity,
+              shasum: "a".repeat(40)
+            }
+          }
+        },
+        "dist-tags": { latest: version }
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    }
+  });
+  assert.equal(
+    requestedUrl,
+    "https://registry.npmjs.org/@fullstack-ai-infra%2Fdigital-employee-core"
+  );
+  assert.equal(redirectMode, "manual");
+  assert.equal(state.integrity, localIntegrity);
+
+  await assert.rejects(
+    readRegistryState({
+      name: packageName,
+      version,
+      registryUrl: "https://registry.example.test/",
+      retryDelays: [0]
+    }),
+    /must be https:\/\/registry\.npmjs\.org\//
+  );
+});
+
+test("requires repeated official-registry 404s before declaring a package absent", async () => {
+  let recoveredCalls = 0;
+  const recovered = await readRegistryState({
+    name: packageName,
+    version,
+    retryDelays: [0, 0],
+    sleep: immediate,
+    fetchImpl: async () => {
+      recoveredCalls += 1;
+      if (recoveredCalls === 1) return new Response(null, { status: 404 });
+      return new Response(JSON.stringify({
+        name: packageName,
+        versions: {},
+        "dist-tags": { latest: "0.2.0" }
+      }), { status: 200 });
+    }
+  });
+  assert.equal(recovered.packageExists, true);
+  assert.equal(recoveredCalls, 2);
+
+  let absentCalls = 0;
+  const absent = await readRegistryState({
+    name: packageName,
+    version,
+    retryDelays: [0, 0, 0],
+    sleep: immediate,
+    fetchImpl: async () => {
+      absentCalls += 1;
+      return new Response(null, { status: 404 });
+    }
+  });
+  assert.equal(absent.packageExists, false);
+  assert.equal(absentCalls, 3);
+});
+
+test("retries malformed package documents and requires the expected identity", async () => {
+  let calls = 0;
+  const state = await readRegistryState({
+    name: packageName,
+    version,
+    retryDelays: [0, 0],
+    sleep: immediate,
+    fetchImpl: async () => {
+      calls += 1;
+      return new Response(calls === 1
+        ? "not-json"
+        : JSON.stringify({
+          name: packageName,
+          versions: {},
+          "dist-tags": {}
+        }), { status: 200 });
+    }
+  });
+  assert.equal(state.packageExists, true);
+  assert.equal(calls, 2);
+});
+
+test("rejects registry redirects to a different origin", async () => {
+  await assert.rejects(
+    readRegistryState({
+      name: packageName,
+      version,
+      retryDelays: [0],
+      fetchImpl: async () => new Response(null, {
+        status: 302,
+        headers: { location: "https://registry.example.test/package" }
+      })
+    }),
+    /redirected to a different origin/
+  );
+});
+
+test("publishes through the canonical registry and force-settles a stuck child", async () => {
+  const child = new NonClosingChild();
+  let publishArguments: string[] = [];
+  let publishedBytes = Buffer.alloc(0);
+  const fakeSpawn = ((_command: string, args: string[]) => {
+    publishArguments = args;
+    publishedBytes = readFileSync(args[1]);
+    return child;
+  }) as unknown as typeof spawn;
+  const verifiedArtifact = publishableArtifact();
+  const result = await runNpmPublish(verifiedArtifact, {
+    distTag: "latest",
+    registryUrl: "https://registry.npmjs.org",
+    timeoutMs: 5,
+    killGraceMs: 5,
+    spawnImpl: fakeSpawn
+  });
+
+  assert.deepEqual(child.signals, ["SIGTERM", "SIGKILL"]);
+  assert.equal(child.unrefCalled, true);
+  assert.equal(result.timedOut, true);
+  assert.equal(result.errorCode, "ETIMEDOUT");
+  assert.equal(result.signal, "SIGKILL");
+  const registryFlag = publishArguments.indexOf("--registry");
+  assert.notEqual(registryFlag, -1);
+  assert.equal(
+    publishArguments[registryFlag + 1],
+    "https://registry.npmjs.org/"
+  );
+  assert.ok(publishArguments.includes("--provenance"));
+  assert.notEqual(publishArguments[1], verifiedArtifact.tarballPath);
+  assert.deepEqual(publishedBytes, verifiedArtifact.archive);
+  await assert.rejects(readFile(publishArguments[1]), /ENOENT/);
+});
+
+test("treats an identical existing version as an idempotent success", async () => {
+  let publishCalls = 0;
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: async () => registryVersion(),
+      runPublish: async () => {
+        publishCalls += 1;
+        return publishSuccess();
+      },
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "already_published");
+  assert.equal(result.complete, true);
+  assert.equal(result.verified, true);
+  assert.equal(publishCalls, 0);
+});
+
+test("fails when an immutable version has different registry integrity", async () => {
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: async () => registryVersion("sha512-ZGlmZmVyZW50"),
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "version_conflict");
+  assert.equal(result.exitCode, 1);
+});
+
+test("fails closed when an existing version has an older latest tag", async () => {
+  let publishCalls = 0;
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: async () => registryVersion(
+        localIntegrity,
+        "0.2.0",
+        true
+      ),
+      runPublish: async () => {
+        publishCalls += 1;
+        return publishSuccess();
+      },
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "dist_tag_verification_failed");
+  assert.equal(result.reason, "registry_latest_is_older");
+  assert.equal(result.exitCode, 1);
+  assert.equal(publishCalls, 0);
+});
+
+test("accepts an identical version when latest already points newer", async () => {
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: async () => registryVersion(
+        localIntegrity,
+        "0.4.0",
+        true
+      ),
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "already_published");
+  assert.equal(result.complete, true);
+});
+
+test("hard-fails a wholly missing package under the fail policy", async () => {
+  let publishCalls = 0;
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: async () => absentPackage,
+      runPublish: async () => {
+        publishCalls += 1;
+        return publishSuccess();
+      },
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "package_missing");
+  assert.equal(result.exitCode, 1);
+  assert.equal(publishCalls, 0);
+});
+
+test("hard-fails bootstrap-soft when its explicit marker is absent", async () => {
+  let publishCalls = 0;
+  const result = await publishWithFallback(
+    artifact(),
+    {
+      missingPackage: "bootstrap-soft",
+      distTag: "latest"
+    },
+    {
+      readRegistry: async () => absentPackage,
+      runPublish: async () => {
+        publishCalls += 1;
+        return publishFailure("E404", 404, "Not Found");
+      },
+      markerExists: async () => false,
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "package_missing");
+  assert.equal(result.reason, "bootstrap_marker_missing");
+  assert.equal(result.exitCode, 1);
+  assert.equal(publishCalls, 0);
+});
+
+test("returns bootstrap-required without publishing when marker-backed package is absent", async () => {
+  let publishCalls = 0;
+  const result = await publishWithFallback(
+    artifact(),
+    {
+      missingPackage: "bootstrap-soft",
+      bootstrapMarkerPath: "/tmp/bootstrap-marker",
+      distTag: "latest"
+    },
+    {
+      readRegistry: async () => absentPackage,
+      runPublish: async () => {
+        publishCalls += 1;
+        return publishFailure("E404", 404, "Not Found");
+      },
+      markerExists: async () => true,
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "bootstrap_required");
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.complete, false);
+  assert.equal(result.bootstrapRequired, true);
+  assert.equal(result.publishAttempts, 0);
+  assert.equal(publishCalls, 0);
+});
+
+test("fails closed when a bootstrap marker remains after the package exists", async () => {
+  let publishCalls = 0;
+  const result = await publishWithFallback(
+    artifact(),
+    {
+      missingPackage: "bootstrap-soft",
+      bootstrapMarkerPath: "/tmp/bootstrap-marker",
+      distTag: "latest"
+    },
+    {
+      readRegistry: async () => absentVersion,
+      runPublish: async () => {
+        publishCalls += 1;
+        return publishSuccess();
+      },
+      markerExists: async () => true,
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "stale_bootstrap_marker");
+  assert.equal(result.exitCode, 1);
+  assert.equal(publishCalls, 0);
+});
+
+test("keeps E404 hard when the package already exists", async () => {
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "bootstrap-soft", distTag: "latest" },
+    {
+      readRegistry: sequence([absentVersion, absentVersion]),
+      runPublish: async () => publishFailure("E404", 404, "Not Found"),
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "publisher_misconfigured");
+  assert.equal(result.exitCode, 1);
+});
+
+test("accepts a matching readback after an ambiguous publish error", async () => {
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: sequence([absentVersion, registryVersion()]),
+      runPublish: async () => ({
+        ...publishFailure("ETIMEDOUT", 504, "Gateway Timeout"),
+        timedOut: true
+      }),
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "published_after_ambiguous_error");
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.verified, true);
+});
+
+test("publishes once and completes after a matching successful readback", async () => {
+  let publishCalls = 0;
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: sequence([absentVersion, registryVersion()]),
+      runPublish: async () => {
+        publishCalls += 1;
+        return publishSuccess();
+      },
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "published");
+  assert.equal(result.complete, true);
+  assert.equal(result.verified, true);
+  assert.equal(result.publishAttempts, 1);
+  assert.equal(publishCalls, 1);
+});
+
+test("repair publishes a missing historical version without moving latest", async () => {
+  const newerLatest = {
+    ...absentVersion,
+    latestVersion: "0.4.0",
+    latestVersionExists: true
+  };
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "repair" },
+    {
+      readRegistry: sequence([
+        newerLatest,
+        registryVersion(localIntegrity, "0.4.0", true)
+      ]),
+      runPublish: async () => publishSuccess(),
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "published");
+  assert.equal(result.complete, true);
+  assert.equal(result.distTag, "repair");
+});
+
+test("waits for latest readback and fails if it remains older after publish", async () => {
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: sequence([
+        absentVersion,
+        registryVersion(localIntegrity, "0.2.0", true),
+        registryVersion(localIntegrity, "0.2.0", true)
+      ]),
+      runPublish: async () => publishSuccess(),
+      sleep: immediate,
+      verifyDelays: [0, 0]
+    }
+  );
+  assert.equal(result.outcome, "dist_tag_verification_failed");
+  assert.equal(result.reason, "registry_latest_is_older");
+  assert.equal(result.publishAttempts, 1);
+  assert.equal(result.exitCode, 1);
+});
+
+test("does not blindly retry a transient publish after an absent readback", async () => {
+  let publishCalls = 0;
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: sequence([absentVersion, absentVersion]),
+      runPublish: async () => {
+        publishCalls += 1;
+        return publishFailure("E503", 503, "Service Unavailable");
+      },
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "transient_failure");
+  assert.equal(result.publishAttempts, 1);
+  assert.equal(publishCalls, 1);
+});
+
+test("blocks a historical version from moving the latest dist-tag backwards", async () => {
+  let publishCalls = 0;
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: async () => ({
+        ...absentVersion,
+        latestVersion: "0.4.0",
+        latestVersionExists: true
+      }),
+      runPublish: async () => {
+        publishCalls += 1;
+        return publishSuccess();
+      },
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "backfill_latest_blocked");
+  assert.equal(result.exitCode, 1);
+  assert.equal(publishCalls, 0);
+});
+
+test("parses an explicit repair tag and bootstrap marker", () => {
+  const parsed = parseArguments([
+    "--manifest", "packages/core/package.json",
+    "--pack-json", "/tmp/core-pack.json",
+    "--expected-name", packageName,
+    "--release-tag", "v0.3.0",
+    "--dist-tag", "repair",
+    "--missing-package", "bootstrap-soft",
+    "--bootstrap-marker", "packages/core/.npm-bootstrap-pending"
+  ]);
+  assert.equal(parsed.distTag, "repair");
+  assert.equal(parsed.bootstrapMarkerPath, "packages/core/.npm-bootstrap-pending");
+});
+
+test("does not retry an authentication failure", async () => {
+  let publishCalls = 0;
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: sequence([absentVersion, absentVersion]),
+      runPublish: async () => {
+        publishCalls += 1;
+        return publishFailure("ENEEDAUTH", 401, "Unauthorized");
+      },
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "authentication_failed");
+  assert.equal(result.exitCode, 1);
+  assert.equal(publishCalls, 1);
+});
+
+test("structured npm authentication codes outrank incidental status text", () => {
+  const failure = classifyPublishFailure({
+    exitCode: 1,
+    signal: null,
+    errorCode: null,
+    timedOut: false,
+    stdout: "",
+    stderr: "npm error code E401\nnpm error 404 Not Found"
+  });
+  assert.deepEqual(failure, { kind: "authentication", code: "E401" });
+});
+
+test("fails verification when npm exits successfully but the version stays absent", async () => {
+  const result = await publishWithFallback(
+    artifact(),
+    { missingPackage: "fail", distTag: "latest" },
+    {
+      readRegistry: sequence([absentVersion, absentVersion]),
+      runPublish: async () => publishSuccess(),
+      sleep: immediate,
+      verifyDelays: [0]
+    }
+  );
+  assert.equal(result.outcome, "verification_failed");
+  assert.equal(result.exitCode, 1);
+});
+
+test("writes machine outputs and a conspicuous bootstrap summary", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "npm-publish-resilient-"));
+  try {
+    const outputPath = path.join(root, "github-output.txt");
+    const summaryPath = path.join(root, "github-summary.md");
+    const result = {
+      outcome: "bootstrap_required",
+      complete: false,
+      published: false,
+      verified: false,
+      bootstrapRequired: true,
+      distTag: "latest",
+      packageName,
+      packageVersion: version,
+      packageUrl: `https://www.npmjs.com/package/${packageName}/v/${version}`,
+      tarballPath: `/tmp/${packageName.split("/").at(-1)}-${version}.tgz`,
+      publishAttempts: 1,
+      reason: "package_bootstrap_or_scope_access_required",
+      exitCode: 0
+    };
+    await writeGitHubReport(result, {
+      outputPath,
+      summaryPath,
+      annotate: false
+    });
+    const [outputs, summary] = await Promise.all([
+      readFile(outputPath, "utf8"),
+      readFile(summaryPath, "utf8")
+    ]);
+    assert.match(outputs, /^outcome=bootstrap_required$/m);
+    assert.match(outputs, /^complete=false$/m);
+    assert.match(outputs, /^bootstrap_required=true$/m);
+    assert.match(outputs, /^dist_tag=latest$/m);
+    assert.match(outputs, /^tarball_path=/m);
+    assert.match(summary, /\[!WARNING\]/);
+    assert.match(summary, /Trusted Publishing/);
+    assert.match(summary, /Verified tarball/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tests/scripts/release-check.test.ts
+++ b/tests/scripts/release-check.test.ts
@@ -1,10 +1,16 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import YAML from "yaml";
-import { validatePackOutput } from "../../scripts/release-pack-check.js";
+import {
+  PACKAGE_SPECS,
+  validateArchive,
+  validatePackOutput
+} from "../../scripts/release-pack-check.js";
 import { validateRelease } from "../../scripts/release-check.js";
 
 const repositoryRoot = path.resolve(
@@ -23,7 +29,11 @@ const manifest = {
   bin: { "digital-employee": "./dist/apps/cli/bin.js" },
   types: "./dist/packages/core/index.d.ts",
   exports: {
-    ".": { import: "./dist/packages/core/index.js" }
+    ".": { import: "./dist/packages/core/index.js" },
+    "./core": {
+      types: "./dist/packages/core/index.d.ts",
+      import: "./dist/packages/core/index.js"
+    }
   },
   files: ["dist", "README.md", "LICENSE"]
 };
@@ -90,6 +100,22 @@ test("release check rejects core repository drift", () => {
   assert.deepEqual(errors, ["core repository must match root repository"]);
 });
 
+test("release check rejects a missing root core fallback", () => {
+  const errors = validateRelease({
+    manifest: {
+      ...manifest,
+      exports: {
+        ".": manifest.exports["."]
+      }
+    },
+    coreManifest,
+    lockfile,
+    changelog,
+    tag: "v0.1.0"
+  });
+  assert.deepEqual(errors, ["root /core fallback must use compiled output"]);
+});
+
 test("release check rejects private or incomplete packages", () => {
   const errors = validateRelease({
     manifest: {
@@ -142,6 +168,26 @@ test("release check rejects package-lock version drift", () => {
 });
 
 test("pack check accepts root and core package metadata", () => {
+  const [rootSpec, coreSpec] = PACKAGE_SPECS;
+  assert.deepEqual(rootSpec.requiredFiles, [
+    "package.json",
+    "dist/apps/cli/bin.js",
+    "dist/packages/core/index.js",
+    "dist/packages/core/index.d.ts",
+    "locales/README.md",
+    "locales/en.json",
+    "locales/ja.json",
+    "locales/zh-CN.json"
+  ]);
+  assert.deepEqual(rootSpec.allowedFiles, [
+    "package.json",
+    "LICENSE",
+    "NOTICE",
+    "locales/README.md",
+    "locales/en.json",
+    "locales/ja.json",
+    "locales/zh-CN.json"
+  ]);
   assert.deepEqual(validatePackOutput({
     label: "root",
     manifest,
@@ -153,18 +199,17 @@ test("pack check accepts root and core package metadata", () => {
         { path: "package.json" },
         { path: "dist/apps/cli/bin.js" },
         { path: "dist/packages/core/index.js" },
-        { path: "dist/packages/core/index.d.ts" }
+        { path: "dist/packages/core/index.d.ts" },
+        { path: "locales/README.md" },
+        { path: "locales/en.json" },
+        { path: "locales/ja.json" },
+        { path: "locales/zh-CN.json" }
       ]
     }],
-    requiredFiles: [
-      "package.json",
-      "dist/apps/cli/bin.js",
-      "dist/packages/core/index.js",
-      "dist/packages/core/index.d.ts"
-    ],
-    allowedFiles: ["package.json", "LICENSE", "NOTICE"],
-    allowedPrefixes: ["dist/"],
-    allowedPatterns: [/^README[^/]*\.md$/]
+    requiredFiles: rootSpec.requiredFiles,
+    allowedFiles: rootSpec.allowedFiles,
+    allowedPrefixes: rootSpec.allowedPrefixes,
+    allowedPatterns: rootSpec.allowedPatterns
   }), []);
 
   assert.deepEqual(validatePackOutput({
@@ -180,10 +225,10 @@ test("pack check accepts root and core package metadata", () => {
         { path: "dist/index.d.ts" }
       ]
     }],
-    requiredFiles: ["package.json", "dist/index.js", "dist/index.d.ts"],
-    allowedFiles: ["package.json"],
-    allowedPrefixes: ["dist/"],
-    allowedPatterns: []
+    requiredFiles: coreSpec.requiredFiles,
+    allowedFiles: coreSpec.allowedFiles,
+    allowedPrefixes: coreSpec.allowedPrefixes,
+    allowedPatterns: coreSpec.allowedPatterns
   }), []);
 });
 
@@ -247,38 +292,160 @@ test("pack check rejects unexpected source paths", () => {
   }), ["root npm pack includes unexpected packages/core/index.ts"]);
 });
 
-test("release workflow has independently scoped jobs for all channels", async () => {
+test("pack check verifies archive bytes against npm pack metadata", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "release-pack-check-"));
+  const archive = Buffer.from("verified package archive");
+  const filename = "fullstack-ai-infra-digital-employee-0.1.0.tgz";
+  const pack = {
+    size: archive.length,
+    integrity: `sha512-${createHash("sha512").update(archive).digest("base64")}`,
+    shasum: createHash("sha1").update(archive).digest("hex")
+  };
+  try {
+    await writeFile(path.join(directory, filename), archive);
+    assert.deepEqual(await validateArchive({
+      label: "root",
+      manifest,
+      pack,
+      packDestination: directory
+    }), []);
+
+    await writeFile(path.join(directory, filename), "tampered");
+    assert.deepEqual(await validateArchive({
+      label: "root",
+      manifest,
+      pack,
+      packDestination: directory
+    }), [
+      "root npm pack archive size does not match pack JSON",
+      "root npm pack archive integrity does not match pack JSON",
+      "root npm pack archive shasum does not match pack JSON"
+    ]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("release workflow reconciles immutable artifacts independently", async () => {
   const workflowText = await readFile(
     path.join(repositoryRoot, ".github/workflows/release.yml"),
     "utf8"
   );
   const workflow = YAML.parse(workflowText);
+  assert.deepEqual(
+    workflow.on.workflow_dispatch.inputs.target.options,
+    ["all", "npm-root", "npm-core", "github-release", "ghcr"]
+  );
+  assert.equal(
+    workflow.on.workflow_dispatch.inputs.release_tag.required,
+    false
+  );
+  assert.deepEqual(workflow.concurrency, {
+    group: "release-publish",
+    queue: "max",
+    "cancel-in-progress": false
+  });
+  assert.equal(workflow.jobs.prepare["runs-on"], "ubuntu-latest");
+  assert.match(
+    workflow.jobs.prepare.steps.at(-1).run,
+    /GITHUB_REF_TYPE.*tag/
+  );
+  assert.match(
+    workflow.jobs.prepare.steps.at(-1).run,
+    /git merge-base --is-ancestor.*origin\/main/
+  );
+  assert.match(
+    workflow.jobs.prepare.steps.at(-1).run,
+    /release_sha.*GITHUB_SHA/
+  );
+  assert.match(
+    workflow.jobs.prepare.steps.at(-1).run,
+    /GITHUB_REF_PROTECTED.*true/
+  );
+  assert.match(
+    workflow.jobs.prepare.steps.at(-1).run,
+    /asset-backfill/
+  );
+  assert.match(
+    workflow.jobs.prepare.steps.at(-1).run,
+    /REQUESTED_TARGET.*github-release/
+  );
+
+  const verify = workflow.jobs.verify;
+  assert.equal(verify.needs, "prepare");
+  assert.equal(verify.steps[0].with.ref, "${{ needs.prepare.outputs.sha }}");
+  assert.ok(verify.steps.some((step: { uses?: string }) =>
+    step.uses === "actions/upload-artifact@v4"
+  ));
+  assert.match(workflowText, /Retain verified npm packages/);
+  assert.match(workflowText, /sha256sum/);
+  assert.match(
+    workflowText,
+    /import\('@fullstack-ai-infra\/digital-employee\/core'\)/
+  );
+  assert.match(
+    workflowText,
+    /import\('@fullstack-ai-infra\/digital-employee-core'\)/
+  );
+
   const npmRoot = workflow.jobs["npm-root"];
   const npmCore = workflow.jobs["npm-core"];
-  for (const job of [npmRoot, npmCore]) {
+  const npmJobs = [
+    [npmRoot, "npm-root"],
+    [npmCore, "npm-core"]
+  ] as const;
+  for (const [job, target] of npmJobs) {
     assert.equal(job.needs, "verify");
+    assert.equal(
+      job.if,
+      `\${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == '${target}' }}`
+    );
     assert.equal(job["runs-on"], "ubuntu-latest");
     assert.deepEqual(job.permissions, {
       contents: "read",
       "id-token": "write"
     });
-    assert.ok(job.steps.some((step: { uses?: string }) =>
+    const checkout = job.steps.find((step: { uses?: string }) =>
       step.uses === "actions/checkout@v6"
-    ));
+    );
+    assert.equal(checkout?.with.ref, "${{ needs.verify.outputs.sha }}");
     assert.ok(job.steps.some((step: { uses?: string }) =>
       step.uses === "actions/setup-node@v6"
     ));
     assert.ok(job.steps.some((step: { run?: string }) =>
       step.run === "npm install --global npm@11.18.0"
     ));
+    assert.ok(job.steps.some((step: { run?: string }) =>
+      step.run?.includes("NPM_CONFIG_USERCONFIG") &&
+      step.run.includes("provenance=true")
+    ));
+    const download = job.steps.find((step: { uses?: string }) =>
+      step.uses === "actions/download-artifact@v4"
+    );
+    assert.deepEqual(download?.with, {
+      name: "${{ needs.verify.outputs.artifact }}",
+      path: "${{ runner.temp }}/release-pack"
+    });
+    const tagGuardIndex = job.steps.findIndex(
+      (step: { name?: string }) => step.name === "Revalidate immutable release tag"
+    );
+    assert.notEqual(tagGuardIndex, -1);
+    assert.match(job.steps[tagGuardIndex].run, /git\/ref\/tags\/\$RELEASE_TAG/);
+    assert.ok(tagGuardIndex < job.steps.length - 1);
+    assert.equal(job.steps.at(-1).id, "publish");
+    assert.match(job.steps.at(-1).run, /npm-publish-resilient\.js/);
   }
 
   const rootPublish = npmRoot.steps.at(-1).run;
   const corePublish = npmCore.steps.at(-1).run;
-  assert.match(rootPublish, /npm publish --access public/);
-  assert.doesNotMatch(rootPublish, /packages\/core/);
-  assert.match(corePublish, /npm publish \.\/packages\/core --access public/);
+  assert.match(rootPublish, /--pack-json.*root-pack\.json/);
+  assert.match(rootPublish, /--missing-package fail/);
+  assert.match(corePublish, /--pack-json.*core-pack\.json/);
+  assert.match(corePublish, /--missing-package bootstrap-soft/);
+  assert.match(corePublish, /--bootstrap-marker/);
   assert.doesNotMatch(workflowText, /NPM_TOKEN|NODE_AUTH_TOKEN/);
+  assert.doesNotMatch(workflowText, /continue-on-error/);
+  assert.doesNotMatch(workflowText, /\|\| true/);
   assert.match(workflowText, /mkdir -p "\$pack_destination"/);
   assert.match(
     workflowText,
@@ -292,8 +459,78 @@ test("release workflow has independently scoped jobs for all channels", async ()
   assert.doesNotMatch(workflowText, /npm --prefix packages\/core pack/);
   assert.match(workflowText, /release-pack-check\.js/);
   assert.match(workflowText, /npm run test:coverage/);
-  assert.ok(workflow.jobs["github-release"]);
+  assert.match(
+    workflow.jobs["github-release"].steps.at(-1).run,
+    /Existing release asset.*different bytes/
+  );
+  assert.equal(
+    workflow.jobs["github-release"].steps.at(-1).env.GH_REPO,
+    "${{ github.repository }}"
+  );
+  assert.match(
+    workflow.jobs["github-release"].steps.at(-1).run,
+    /git\/ref\/tags\/\$RELEASE_TAG/
+  );
+  assert.match(
+    workflow.jobs["github-release"].steps.at(-1).run,
+    /Historical asset backfill requires an existing GitHub Release/
+  );
+  assert.equal(
+    workflow.jobs["github-release"].if,
+    "${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'github-release' }}"
+  );
+  assert.deepEqual(
+    workflow.jobs["github-release"].steps[0].with,
+    {
+      name: "${{ needs.verify.outputs.artifact }}",
+      path: "${{ runner.temp }}/release-pack"
+    }
+  );
+  assert.doesNotMatch(
+    workflow.jobs["github-release"].steps.at(-1).run,
+    /--clobber/
+  );
+  assert.match(
+    workflow.jobs["github-release"].steps.at(-1).run,
+    /gh release download[\s\S]*cmp -s/
+  );
   assert.ok(workflow.jobs.ghcr);
+  assert.match(workflowText, /packages=\( \*\.tgz \)/);
+  assert.match(workflowText, /assets=\( \*\.tgz \*\.tgz\.sha256 \)/);
   assert.match(workflowText, /gh release (?:create|upload)/);
-  assert.match(workflowText, /docker push/);
+  const ghcrPublish = workflow.jobs.ghcr.steps.at(-1).run;
+  assert.equal(
+    workflow.jobs.ghcr.if,
+    "${{ github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'ghcr' }}"
+  );
+  assert.equal(
+    workflow.jobs.ghcr.steps[0].with.ref,
+    "${{ needs.verify.outputs.sha }}"
+  );
+  const ghcrTagGuardIndex = workflow.jobs.ghcr.steps.findIndex(
+    (step: { name?: string }) => step.name === "Revalidate immutable release tag"
+  );
+  const ghcrLoginIndex = workflow.jobs.ghcr.steps.findIndex(
+    (step: { name?: string }) => step.name === "Log in to GHCR"
+  );
+  assert.notEqual(ghcrTagGuardIndex, -1);
+  assert.notEqual(ghcrLoginIndex, -1);
+  assert.ok(ghcrTagGuardIndex < ghcrLoginIndex);
+  assert.match(ghcrPublish, /validate_release_image/);
+  assert.match(ghcrPublish, /Existing immutable GHCR tags resolve to different images/);
+  assert.match(ghcrPublish, /compare_semver/);
+  assert.match(ghcrPublish, /Keeping newer GHCR latest/);
+  assert.match(ghcrPublish, /Repair mode leaves the moving latest tag unchanged/);
+  const repairGuardIndex = ghcrPublish.indexOf(
+    'if [[ "$RELEASE_MODE" != "push" ]]'
+  );
+  const latestPushIndex = ghcrPublish.indexOf('docker push "$latest_ref"');
+  assert.notEqual(repairGuardIndex, -1);
+  assert.notEqual(latestPushIndex, -1);
+  assert.ok(repairGuardIndex < latestPushIndex);
+  assert.doesNotMatch(ghcrPublish, /docker push "\$image:latest"/);
+  assert.equal(workflow.jobs["release-status"].if, "${{ always() }}");
+  assert.match(workflowText, /Standalone core requires one-time npm bootstrap/);
+  assert.match(workflowText, /NPM_ROOT_COMPLETE.*true/);
+  assert.match(workflowText, /NPM_CORE_OUTCOME.*bootstrap_required/);
 });

--- a/tests/scripts/release-check.test.ts
+++ b/tests/scripts/release-check.test.ts
@@ -533,4 +533,13 @@ test("release workflow reconciles immutable artifacts independently", async () =
   assert.match(workflowText, /Standalone core requires one-time npm bootstrap/);
   assert.match(workflowText, /NPM_ROOT_COMPLETE.*true/);
   assert.match(workflowText, /NPM_CORE_OUTCOME.*bootstrap_required/);
+  const releaseStatus = workflow.jobs["release-status"].steps.at(-1).run;
+  assert.match(
+    releaseStatus,
+    /NPM_CORE_OUTCOME.*bootstrap_required[\s\S]*REQUESTED_TARGET.*npm-core/
+  );
+  assert.match(
+    releaseStatus,
+    /Explicit npm-core reconciliation is incomplete/
+  );
 });


### PR DESCRIPTION
## What

- Build the root and standalone core npm archives once, verify them, and reconcile npm, GitHub Release, and GHCR from those exact artifacts.
- Add an idempotent npm registry state machine with an explicit one-time bootstrap fallback for the new standalone core package.
- Add tag-safe repair and historical `v0.3.0` GitHub Release asset backfill paths, backed by protected stable tags.
- Stabilize Node 20/22/24 CI typing, locale isolation, test execution, and deadline fixtures, and correct the release documentation.
- Converge safely when the exact core bootstrap version already exists but marker cleanup is still pending; block non-stable or dangling `latest` before any publish.
- Allow aggregate releases to report the explicit core bootstrap degradation without losing other channels, while keeping an explicitly targeted `npm-core` reconciliation failed until core is actually complete.

## Why

The `v0.3.0` release published the root npm package, GHCR image, and GitHub Release, but the standalone core publish failed with npm `E404` because that package did not yet exist. The previous jobs also rebuilt artifacts independently and did not fail closed strongly enough around partial state, mutable tags, existing assets, or moving dist-tags.

## Impact

- Existing npm packages publish through GitHub OIDC; no repository `NPM_TOKEN` is introduced.
- The one-time core bootstrap remains explicit and incomplete instead of hiding a failed channel; users can continue using `@fullstack-ai-infra/digital-employee/core`.
- A correct owner bootstrap converges on rerun even before marker cleanup lands; a missing future version remains blocked until Trusted Publishing is confirmed.
- Existing immutable artifacts are byte-compared and never overwritten; repair runs never roll back npm `latest`.
- Invalid, dangling, older, and newer `latest` states are handled explicitly before mutation.
- A default-branch CI dispatch can safely backfill the historical `v0.3.0` core release asset without rebuilding the release.
- Stable `v*` tag updates and deletions are blocked by the repository ruleset, and every registry write revalidates the tag SHA.

## Checks

- [Final PR CI run 31257286831](https://github.com/fullstack-ai-infra/digital-employee/actions/runs/31257286831) — container, Node 20/22/24, and coverage all passed on head `9b9bb03`
- GitHub-hosted Node 22 coverage — 844/844; lines 90.55%, branches 76.21%, functions 88.67%
- npm publication state tests — 31/31 passed
- Deadline/cancellation regression tests — 10 consecutive passes on Node 22 and 10 on Node 24 for all three host fixtures
- `npm audit --omit=dev --audit-level=high` — passed in every Node matrix job
- actionlint — clean, excluding only the current GitHub `concurrency.queue` key from the stable actionlint schema check
- Exact pack/install/import verification for both root and standalone core archives
- Live `v0.3.0` registry reconciliation: root = `already_published`; core = explicit `bootstrap_required`

## Authentication boundary

npm Trusted Publishing authenticates `npm publish` and `npm stage publish`, but not `npm dist-tag`. If a previously published exact version has a broken or older `latest`, tokenless CI fails closed and gives the npm owner an interactive repair step instead of adding a long-lived credential.

## Known boundary

The historical `v0.3.0` GHCR image has no cryptographic build attestation. This change validates its digest aliases and OCI labels but does not claim to retrofit an attestation; a future attested release needs a separate two-phase digest promotion flow.