### PR TITLE
chore: complete standalone core npm bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,18 +144,19 @@ be terminated and verified before a terminal event is published.
 
 ## Release status
 
-The tagged `0.3.0` release is public through the root npm package, GHCR, and
-GitHub Releases:
+The tagged `0.3.0` release is public through the root and core npm packages,
+GHCR, and GitHub Releases:
 
 | Channel | Command or download |
 | --- | --- |
-| npm | `npm install --global @fullstack-ai-infra/digital-employee@0.3.0` |
+| npm (CLI) | `npm install --global @fullstack-ai-infra/digital-employee@0.3.0` |
+| npm (core) | `npm install @fullstack-ai-infra/digital-employee-core@0.3.0` |
 | GHCR | `docker pull ghcr.io/fullstack-ai-infra/digital-employee:0.3.0` |
-| GitHub Release | Download the root package and checksum from [`v0.3.0`](https://github.com/fullstack-ai-infra/digital-employee/releases/tag/v0.3.0) |
+| GitHub Release | Download the root/core packages and checksums from [`v0.3.0`](https://github.com/fullstack-ai-infra/digital-employee/releases/tag/v0.3.0) |
 
-The standalone `@fullstack-ai-infra/digital-employee-core` npm package still
-requires its one-time registry bootstrap. Until then, install the root package
-and import `@fullstack-ai-infra/digital-employee/core`. The current `main`
+The standalone `@fullstack-ai-infra/digital-employee-core@0.3.0` package is
+public. Its one-time registry bootstrap is complete, and subsequent versions
+publish from `release.yml` through npm Trusted Publishing. The current `main`
 branch contains changes made after the tag and is not itself a published
 release. Do not retag or overwrite `0.3.0` or `0.1.0`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,15 +73,16 @@ V0.3 源码已经提供可嵌入的 one-shot Runner 执行内核和签名续租�
 
 ## 版本状态
 
-标签版本 `0.3.0` 已通过 root npm 包、GHCR 和 GitHub Releases 公开发布：
+标签版本 `0.3.0` 已通过 root/core npm 包、GHCR 和 GitHub Releases 公开发布：
 
 | 渠道 | 安装或下载方式 |
 | --- | --- |
-| npm | `npm install --global @fullstack-ai-infra/digital-employee@0.3.0` |
+| npm（CLI） | `npm install --global @fullstack-ai-infra/digital-employee@0.3.0` |
+| npm（core） | `npm install @fullstack-ai-infra/digital-employee-core@0.3.0` |
 | GHCR | `docker pull ghcr.io/fullstack-ai-infra/digital-employee:0.3.0` |
-| GitHub Release | 从 [`v0.3.0`](https://github.com/fullstack-ai-infra/digital-employee/releases/tag/v0.3.0) 下载 root 包和校验文件 |
+| GitHub Release | 从 [`v0.3.0`](https://github.com/fullstack-ai-infra/digital-employee/releases/tag/v0.3.0) 下载 root/core 包和校验文件 |
 
-独立的 `@fullstack-ai-infra/digital-employee-core` npm 包仍需完成一次性 registry bootstrap；在此之前，请安装 root 包并导入 `@fullstack-ai-infra/digital-employee/core`。当前 `main` 已包含标签之后的改动，本身不代表一个已发布版本。不要覆盖或重新标记 `0.3.0` 或 `0.1.0`。
+独立的 `@fullstack-ai-infra/digital-employee-core@0.3.0` npm 包已经公开。一次性 registry bootstrap 已完成，后续版本由 `release.yml` 通过 npm Trusted Publishing 发布。当前 `main` 已包含标签之后的改动，本身不代表一个已发布版本。不要覆盖或重新标记 `0.3.0` 或 `0.1.0`。
 
 冻结的 `0.1.0` 兼容版本通过三个公开渠道分发：
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -14,8 +14,7 @@ verified archives; they do not rebuild them.
    GHCR. Release runs share the maximum GitHub Actions concurrency queue (up
    to 100 pending runs) instead of replacing the previous pending release.
 4. Read the `release-status` job summary. A green run means every requested
-   channel is complete, except the explicitly reported `bootstrap_required`
-   state described below.
+   channel is complete.
 
 Registry authentication uses npm Trusted Publishing (GitHub OIDC). Do not add
 an `NPM_TOKEN` or `NODE_AUTH_TOKEN` repository secret.
@@ -71,33 +70,33 @@ This exceptional path only operates on an existing stable tag and existing
 GitHub Release. It verifies that the tag is reachable from `main`, rebuilds at
 the tag commit, refuses changed existing assets, and uploads only missing
 assets. npm and GHCR jobs are not selected. After resolving the external npm
-bootstrap, rerun the original failed `npm-core` job for `v0.3.0`.
+bootstrap, the original failed `npm-core` job for `v0.3.0` was rerun and
+completed successfully.
 
-## Standalone core bootstrap
+## Completed standalone core bootstrap
 
-npm Trusted Publishing cannot create a package's first public version. While
-`packages/core/.npm-bootstrap-pending` exists, repeated package-level 404s for
-`@fullstack-ai-infra/digital-employee-core` produce the visible, incomplete
-`bootstrap_required` outcome without failing unrelated release channels.
-Consumers can meanwhile use:
+npm Trusted Publishing cannot create a package's first public version. The
+one-time bootstrap for
+`@fullstack-ai-infra/digital-employee-core@0.3.0` is complete, and this
+repository's `release.yml` is registered as the package's Trusted Publisher.
+`packages/core/.npm-bootstrap-pending` has therefore been removed. All
+subsequent versions publish from CI without a long-lived npm credential.
+
+The removed marker was a temporary bootstrap state. While it existed,
+package-level 404s produced the visible, incomplete `bootstrap_required`
+outcome without failing unrelated release channels. It must not be recreated
+for routine release failures. A missing package now fails hard; an absent
+target version follows the normal CI publish path, while authentication or
+publication errors fail hard.
+
+Consumers can install the standalone package or import the root-package
+subpath:
 
 ```text
+@fullstack-ai-infra/digital-employee-core
 @fullstack-ai-infra/digital-employee/core
 ```
 
 The hardened workflow retains both verified `.tgz` files and their SHA-256
-checksums. The historical `v0.3.0` core asset appears after the backfill command
-above completes.
-
-An npm scope owner must perform the one-time authenticated publication from the
-verified GitHub Release core archive, then configure this repository and
-`release.yml` as the package's Trusted Publisher. Only after the public package
-exists and the trust binding is verified should the marker be removed. All
-subsequent versions publish from CI without a long-lived npm credential.
-
-If the owner publication succeeds before the marker-removal change is merged,
-a rerun accepts only an exact registry-integrity match and reports
-`bootstrap_verified_marker_cleanup_required`. It never republishes that version.
-If the package exists but the target version is absent, the stale marker still
-blocks CI publication until the trust binding is confirmed and the marker is
-removed.
+checksums. The historical `v0.3.0` GitHub Release contains the root and core
+archives plus both checksums.

--- a/packages/core/.npm-bootstrap-pending
+++ b/packages/core/.npm-bootstrap-pending
@@ -1,9 +1,0 @@
-The standalone core package has not completed its first authenticated npm publish.
-
-While this marker exists, a registry-level package 404 is reported as
-bootstrap_required instead of failing the entire multi-channel release. The
-verified core tgz is still attached to the GitHub Release, and consumers can use
-@fullstack-ai-infra/digital-employee/core from the root package.
-
-Remove this marker only after the package exists on npm and its Trusted
-Publisher is bound to fullstack-ai-infra/digital-employee and release.yml.


### PR DESCRIPTION
## Summary

- remove the one-time standalone core bootstrap marker
- document the public core 0.3.0 package and Trusted Publisher handoff
- record the successful v0.3.0 npm-core rerun and release assets

## Verification

- npm run check (844 tests passed)
- npm run test:coverage (844 tests passed; 90.51% lines, 76.04% branches, 88.67% functions)
- npm run release:check -- --tag v0.3.0
- public registry install/import verification for core 0.3.0
- historical Release run 31139432246 attempt 2 succeeded