### PR TITLE
feat(host): qualify Qoder structured output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Qoder CLI 1.1.x now advertises `structured_output` from Adapter-specific
+  deterministic conformance fixtures under the common Adapter-enforced
+  terminal-validity contract. A checked-in employee package
+  that keeps `requiredCapabilities: ["structured_output"]` can pass the normal
+  package-aware Qoder preflight; unverified Qoder versions remain fail closed.
+  Deterministic fixtures cover matching JSON, malformed/fenced/prose/truncated
+  output, Schema mismatch and additional properties, unstructured output,
+  buffered cancellation, and the independent deadline path.
+
 - Real-local Phase A path (#42): a `component-matrix.v1` contract that pins
   the exact `mem` and `doc` service commits as the sole version authority, a
   deterministic `real-local-stdio-host` Agent Host fixture that resumes
@@ -19,6 +28,21 @@ All notable changes to this project will be documented in this file.
   the synthetic `mcp_*` codes.
 
 ### Security
+
+- Employee-package inspection and the generic run/eval boundaries now reject
+  asynchronous JSON Schemas. Claude, Qwen, and CodeBuddy also prepare one
+  immutable Schema snapshot per run, reject `$async` before Host execution,
+  and require synchronous validators to return exactly `true`; this closes the
+  Ajv Promise-truthiness path across every built-in structured-output Adapter.
+  All built-ins validate the unchanged terminal JSON before safety scrubbing;
+  repair, coercion, defaults, field removal, or redaction cannot manufacture a
+  passing value, and a required post-validation mutation fails closed.
+
+- Qoder JSON Schemas are serialized, capped at 16 KiB, and compiled before
+  any run-workspace projection or Qoder subprocess, including the bounded
+  version probe; invalid, oversized, or asynchronous Schemas therefore cannot
+  reach a paid model invocation. Invalid, oversized, or asynchronous Schema and
+  unsafe terminal output produce typed failures.
 
 - Qoder assistant text is now buffered until successful process and cleanup
   completion, then scrubbed as one value with the exact service credential.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,17 @@ empty MCP/Skill/plugin sets. Qoder assistant text is held until process and
 credential cleanup succeeds, then scrubbed as one value with the exact service
 credential. Tool values are scrubbed before truncation, credential-bearing tool
 identifiers and keys are rejected, and schema-bound structured output that
-would require credential or pattern redaction fails closed.
+would require credential or pattern redaction fails closed. Across all
+built-in Adapters, `structured_output` means Adapter-enforced terminal validity
+against one bounded, immutable, synchronous Schema snapshot, not Host-native
+constrained generation. Every Adapter validates the unchanged terminal JSON:
+repair, coercion, defaults, field removal, or redaction cannot manufacture a
+passing value, and any post-validation safety scrub that would mutate a
+schema-bound value fails closed. Qoder additionally accepts only synchronous
+Schemas of at most 16 KiB and compiles them before projection or any Qoder
+subprocess. An invalid, oversized, or asynchronous Schema therefore
+short-circuits before even the bounded, credential-free `--version` readiness
+probe.
 
 These paths are local/single-tenant technical previews, not a marketplace-ready
 online employee service. All four reject MCP, attachments, session resume,

--- a/apps/cli/agent-run.ts
+++ b/apps/cli/agent-run.ts
@@ -229,7 +229,11 @@ function compileValidator(schema: Record<string, unknown>) {
     strict: false,
     validateSchema: true,
   })
-  return ajv.compile(schema)
+  const validate = ajv.compile(schema)
+  if ("$async" in validate && validate.$async === true) {
+    throw new TypeError("employee_async_json_schema_unsupported")
+  }
+  return validate
 }
 
 function asSafeValue(value: unknown): SafeValue {
@@ -385,7 +389,7 @@ export async function runEmployeePackage(
   } catch {
     return failed(identity, "employee_input_schema_invalid")
   }
-  if (!validateInput(options.input)) {
+  if (validateInput(options.input) !== true) {
     return failed(identity, "employee_input_schema_mismatch")
   }
 
@@ -584,7 +588,7 @@ export async function runEmployeePackage(
 
   try {
     const validateOutput = compileValidator(inspection.artifacts.outputSchema)
-    if (!validateOutput(terminal.output)) {
+    if (validateOutput(terminal.output) !== true) {
       return failed(identity, "employee_output_schema_mismatch")
     }
   } catch {

--- a/apps/cli/claude-agent-host.ts
+++ b/apps/cli/claude-agent-host.ts
@@ -102,7 +102,12 @@ interface ActiveRun {
 
 interface PreparedRun {
   assets: InlineAgentAsset[]
-  schemaJson?: string
+  outputSchema?: PreparedOutputSchema
+}
+
+interface PreparedOutputSchema {
+  json: string
+  value: SafeValue
 }
 
 export interface ClaudeAgentHostAdapterOptions {
@@ -200,7 +205,9 @@ function validateIdentifier(value: string, code: string): void {
   }
 }
 
-function serializeAndValidateSchema(schema: SafeValue | undefined): string | undefined {
+function serializeAndValidateSchema(
+  schema: SafeValue | undefined,
+): PreparedOutputSchema | undefined {
   if (schema === undefined) return undefined
   let serialized: string | undefined
   try {
@@ -214,15 +221,21 @@ function serializeAndValidateSchema(schema: SafeValue | undefined): string | und
       strict: false,
       validateSchema: true,
     })
-    ajv.compile(schema as object)
+    const value = JSON.parse(serialized) as SafeValue
+    const validate = ajv.compile(value as object)
+    if ("$async" in validate && validate.$async === true) {
+      throw new ClaudeAdapterError("claude_output_schema_invalid")
+    }
+    return { json: serialized, value }
   } catch (error) {
     if (error instanceof ClaudeAdapterError) throw error
     throw new ClaudeAdapterError("claude_output_schema_invalid")
   }
-  return serialized
 }
 
-function validateRequestShape(request: AgentHostRunRequest): string | undefined {
+function validateRequestShape(
+  request: AgentHostRunRequest,
+): PreparedOutputSchema | undefined {
   validateIdentifier(request.runId, "claude_invalid_run_id")
   validateIdentifier(request.employeeId, "claude_invalid_employee_id")
   if (!request.prompt.trim() || byteLength(request.prompt) > MAX_PROMPT_BYTES) {
@@ -234,7 +247,7 @@ function validateRequestShape(request: AgentHostRunRequest): string | undefined 
   ) {
     throw new ClaudeAdapterError("claude_instructions_too_large")
   }
-  const schemaJson = serializeAndValidateSchema(request.outputSchema)
+  const outputSchema = serializeAndValidateSchema(request.outputSchema)
   if (request.policy.tools.default !== "deny") {
     throw new ClaudeAdapterError("claude_tool_policy_must_default_deny")
   }
@@ -289,17 +302,17 @@ function validateRequestShape(request: AgentHostRunRequest): string | undefined 
       throw new ClaudeAdapterError("claude_deadline_elapsed")
     }
   }
-  return schemaJson
+  return outputSchema
 }
 
 async function prepareRun(
   request: AgentHostRunRequest,
   beforeOpen?: (sourcePath: string) => Promise<void>,
 ): Promise<PreparedRun> {
-  const schemaJson = validateRequestShape(request)
+  const outputSchema = validateRequestShape(request)
   try {
     const assets = await readInlineAgentAssets(request, beforeOpen)
-    return { assets, ...(schemaJson ? { schemaJson } : {}) }
+    return { assets, ...(outputSchema ? { outputSchema } : {}) }
   } catch (error) {
     if (error instanceof InlineAgentProjectionError) {
       throw new ClaudeAdapterError(`claude_${error.code}`)
@@ -472,13 +485,14 @@ function scrubOutput(
 function createTaskInput(
   request: AgentHostRunRequest,
   assets: InlineAgentAsset[],
+  outputSchema: PreparedOutputSchema | undefined,
 ): string {
   const envelope = {
     schemaVersion: "digital-employee-context.v1",
     task: request.prompt,
     assets,
-    ...(request.outputSchema !== undefined
-      ? { outputSchema: request.outputSchema }
+    ...(outputSchema !== undefined
+      ? { outputSchema: outputSchema.value }
       : {}),
   }
   const input = [
@@ -724,12 +738,16 @@ export class ClaudeAgentHostAdapter implements AgentHostAdapter {
           systemPromptPath,
           createSystemPrompt(
             request.instructions,
-            prepared.schemaJson !== undefined,
+            prepared.outputSchema !== undefined,
           ),
           { flag: "wx", mode: 0o600 },
         ),
       ])
-      const taskInput = createTaskInput(request, prepared.assets)
+      const taskInput = createTaskInput(
+        request,
+        prepared.assets,
+        prepared.outputSchema,
+      )
       const expectedCwd = await realpath(workspace)
       const args = [
         ...this.commandPrefixArgs,
@@ -891,7 +909,7 @@ export class ClaudeAgentHostAdapter implements AgentHostAdapter {
 
       let completion
       try {
-        completion = normalizer.finish(request.outputSchema)
+        completion = normalizer.finish(prepared.outputSchema?.value)
       } catch (error) {
         if (error instanceof ClaudeStreamProtocolError) {
           throw new ClaudeAdapterError(error.code, error.retryable)
@@ -906,7 +924,7 @@ export class ClaudeAgentHostAdapter implements AgentHostAdapter {
         output: scrubOutput(
           completion.output,
           credential,
-          request.outputSchema !== undefined,
+          prepared.outputSchema !== undefined,
         ),
       }
     } catch (error) {

--- a/apps/cli/claude-stream-agent-host.ts
+++ b/apps/cli/claude-stream-agent-host.ts
@@ -82,7 +82,9 @@ function normalizeOutputValue(
     throw new ClaudeStreamProtocolError("claude_output_too_complex")
   }
   if (value === null) return null
-  if (typeof value === "string") return redactText(value)
+  // Structured output must be validated exactly as produced. Redaction happens
+  // after Schema validation and rejects any mutation on schema-bound output.
+  if (typeof value === "string") return value
   if (typeof value === "boolean") return value
   if (typeof value === "number") {
     if (!Number.isFinite(value)) {
@@ -123,7 +125,10 @@ function validateStructuredOutput(
       validateSchema: true,
     })
     const validate = ajv.compile(schema as object)
-    if (!validate(normalized)) {
+    if ("$async" in validate && validate.$async === true) {
+      throw new ClaudeStreamProtocolError("claude_output_schema_invalid")
+    }
+    if (validate(normalized) !== true) {
       throw new ClaudeStreamProtocolError("claude_output_schema_mismatch")
     }
   } catch (error) {

--- a/apps/cli/codebuddy-agent-host.ts
+++ b/apps/cli/codebuddy-agent-host.ts
@@ -142,7 +142,12 @@ interface ActiveRun {
 
 interface PreparedRun {
   assets: InlineAgentAsset[]
-  schemaJson?: string
+  outputSchema?: PreparedOutputSchema
+}
+
+interface PreparedOutputSchema {
+  json: string
+  value: SafeValue
 }
 
 interface ValidatedConfiguration {
@@ -261,7 +266,9 @@ function validateIdentifier(value: string, code: string): void {
   }
 }
 
-function serializeAndValidateSchema(schema: SafeValue | undefined): string | undefined {
+function serializeAndValidateSchema(
+  schema: SafeValue | undefined,
+): PreparedOutputSchema | undefined {
   if (schema === undefined) return undefined
   let serialized: string | undefined
   try {
@@ -275,15 +282,21 @@ function serializeAndValidateSchema(schema: SafeValue | undefined): string | und
       strict: false,
       validateSchema: true,
     })
-    ajv.compile(schema as object)
+    const value = JSON.parse(serialized) as SafeValue
+    const validate = ajv.compile(value as object)
+    if ("$async" in validate && validate.$async === true) {
+      throw new CodeBuddyAdapterError("codebuddy_output_schema_invalid")
+    }
+    return { json: serialized, value }
   } catch (error) {
     if (error instanceof CodeBuddyAdapterError) throw error
     throw new CodeBuddyAdapterError("codebuddy_output_schema_invalid")
   }
-  return serialized
 }
 
-function validateRequestShape(request: AgentHostRunRequest): string | undefined {
+function validateRequestShape(
+  request: AgentHostRunRequest,
+): PreparedOutputSchema | undefined {
   validateIdentifier(request.runId, "codebuddy_invalid_run_id")
   validateIdentifier(request.employeeId, "codebuddy_invalid_employee_id")
   if (!request.prompt.trim() || byteLength(request.prompt) > MAX_PROMPT_BYTES) {
@@ -295,7 +308,7 @@ function validateRequestShape(request: AgentHostRunRequest): string | undefined 
   ) {
     throw new CodeBuddyAdapterError("codebuddy_instructions_too_large")
   }
-  const schemaJson = serializeAndValidateSchema(request.outputSchema)
+  const outputSchema = serializeAndValidateSchema(request.outputSchema)
   if (request.policy.tools.default !== "deny") {
     throw new CodeBuddyAdapterError("codebuddy_tool_policy_must_default_deny")
   }
@@ -350,7 +363,7 @@ function validateRequestShape(request: AgentHostRunRequest): string | undefined 
       throw new CodeBuddyAdapterError("codebuddy_deadline_elapsed")
     }
   }
-  return schemaJson
+  return outputSchema
 }
 
 function configurationIssues(source: NodeJS.ProcessEnv): AgentHostIssue[] {
@@ -451,10 +464,10 @@ async function prepareRun(
   request: AgentHostRunRequest,
   beforeOpen?: (sourcePath: string) => Promise<void>,
 ): Promise<PreparedRun> {
-  const schemaJson = validateRequestShape(request)
+  const outputSchema = validateRequestShape(request)
   try {
     const assets = await readInlineAgentAssets(request, beforeOpen)
-    return { assets, ...(schemaJson ? { schemaJson } : {}) }
+    return { assets, ...(outputSchema ? { outputSchema } : {}) }
   } catch (error) {
     if (error instanceof InlineAgentProjectionError) {
       throw new CodeBuddyAdapterError(`codebuddy_${error.code}`)
@@ -682,14 +695,15 @@ function escapeFileMentionSyntax(value: string): string {
 function createTaskInput(
   request: AgentHostRunRequest,
   assets: InlineAgentAsset[],
+  outputSchema: PreparedOutputSchema | undefined,
 ): string {
   const envelope = {
     schemaVersion: "digital-employee-context.v1",
     employeeInstructions: request.instructions ?? "",
     task: request.prompt,
     assets,
-    ...(request.outputSchema !== undefined
-      ? { outputSchema: request.outputSchema }
+    ...(outputSchema !== undefined
+      ? { outputSchema: outputSchema.value }
       : {}),
   }
   const input = escapeFileMentionSyntax(
@@ -719,7 +733,9 @@ function normalizeOutputValue(
     throw new CodeBuddyProtocolError("codebuddy_output_too_complex")
   }
   if (value === null) return null
-  if (typeof value === "string") return redactText(value)
+  // Preserve the model value for Schema validation. The terminal scrubber
+  // rejects any redaction that would mutate schema-bound output.
+  if (typeof value === "string") return value
   if (typeof value === "boolean") return value
   if (typeof value === "number") {
     if (!Number.isFinite(value)) {
@@ -806,7 +822,10 @@ function parseAndValidateOutput(text: string, schema: SafeValue | undefined): Sa
       validateSchema: true,
     })
     const validate = ajv.compile(schema as object)
-    if (!validate(normalized)) {
+    if ("$async" in validate && validate.$async === true) {
+      throw new CodeBuddyProtocolError("codebuddy_output_schema_invalid")
+    }
+    if (validate(normalized) !== true) {
       throw new CodeBuddyProtocolError("codebuddy_output_schema_mismatch")
     }
   } catch (error) {
@@ -1401,7 +1420,11 @@ export class CodeBuddyAgentHostAdapter implements AgentHostAdapter {
           mode: 0o600,
         }),
       ])
-      const taskInput = createTaskInput(request, prepared.assets)
+      const taskInput = createTaskInput(
+        request,
+        prepared.assets,
+        prepared.outputSchema,
+      )
       const expectedCwd = await realpath(directories.workspace)
       const expectedSessionId = randomUUID()
       const args = [
@@ -1588,7 +1611,7 @@ export class CodeBuddyAgentHostAdapter implements AgentHostAdapter {
       }
       let completion
       try {
-        completion = normalizer.finish(request.outputSchema)
+        completion = normalizer.finish(prepared.outputSchema?.value)
       } catch (error) {
         if (error instanceof CodeBuddyProtocolError) {
           throw new CodeBuddyAdapterError(error.code, error.retryable)
@@ -1603,7 +1626,7 @@ export class CodeBuddyAgentHostAdapter implements AgentHostAdapter {
         output: scrubOutput(
           completion.output,
           credential,
-          request.outputSchema !== undefined,
+          prepared.outputSchema !== undefined,
         ),
       }
     } catch (error) {

--- a/apps/cli/employee-eval.ts
+++ b/apps/cli/employee-eval.ts
@@ -116,12 +116,16 @@ function parseEvalContract(content: string): EmployeeEvalCase[] {
 function compileFixtureValidator(
   schema: Record<string, unknown>,
 ): ValidateFunction {
-  return new Ajv2020({
+  const validate = new Ajv2020({
     allErrors: true,
     allowUnionTypes: true,
     strict: false,
     validateSchema: true,
   }).compile(schema)
+  if ("$async" in validate && validate.$async === true) {
+    throw new TypeError("employee_async_json_schema_unsupported")
+  }
+  return validate
 }
 
 function employeeIdentity(inspection: EmployeePackageInspection) {
@@ -192,14 +196,14 @@ export async function evaluateEmployeePackage(
   }
 
   const caseResults = cases.map<EmployeeEvalCaseResult>((evalCase) => {
-    if (!validateInput(evalCase.input)) {
+    if (validateInput(evalCase.input) !== true) {
       return {
         id: evalCase.id,
         status: "failed",
         code: "EVAL_CASE_INPUT_SCHEMA_INVALID",
       }
     }
-    if (!validateOutput(evalCase.expectedOutput)) {
+    if (validateOutput(evalCase.expectedOutput) !== true) {
       return {
         id: evalCase.id,
         status: "failed",

--- a/apps/cli/employee-package.ts
+++ b/apps/cli/employee-package.ts
@@ -500,7 +500,10 @@ function validateJsonSchema(
       strict: false,
       validateSchema: true,
     })
-    ajv.compile(schema)
+    const validate = ajv.compile(schema)
+    if ("$async" in validate && validate.$async === true) {
+      throw new TypeError(`employee_package_invalid_json_schema:${label}`)
+    }
   } catch {
     throw new TypeError(`employee_package_invalid_json_schema:${label}`)
   }

--- a/apps/cli/qoder-agent-host.ts
+++ b/apps/cli/qoder-agent-host.ts
@@ -56,6 +56,7 @@ const CLEANUP_ATTEMPTS = 2
 const CLEANUP_ATTEMPT_TIMEOUT_MS = 2_000
 const MAX_PROMPT_BYTES = 256 * 1024
 const MAX_INSTRUCTIONS_BYTES = 128 * 1024
+const MAX_SCHEMA_BYTES = 16 * 1024
 const MAX_STDOUT_BYTES = 4 * 1024 * 1024
 const MAX_STDERR_BYTES = 256 * 1024
 const MAX_LINE_BYTES = 1024 * 1024
@@ -130,6 +131,7 @@ function capabilities(): AgentHostCapabilities {
     "filesystem_scope",
     "network_policy",
     "cancellation",
+    "structured_output",
   ] as const) {
     result[capability] = "supported"
   }
@@ -137,7 +139,6 @@ function capabilities(): AgentHostCapabilities {
     "session_resume",
     "attachments",
     "mcp",
-    "structured_output",
     "approval_callback",
     "sandbox",
   ] as const) {
@@ -273,7 +274,43 @@ async function inspectProjectionFiles(
   return { sourceRoot, files }
 }
 
-function validateRequestShape(request: AgentHostRunRequest): void {
+interface PreparedOutputSchema {
+  json: string
+  validate: (value: unknown) => boolean
+}
+
+function prepareOutputSchema(
+  schema: SafeValue | undefined,
+): PreparedOutputSchema | undefined {
+  if (schema === undefined) return undefined
+  try {
+    const json = JSON.stringify(schema)
+    if (typeof json !== "string") {
+      throw new QoderAdapterError("qoder_output_schema_invalid")
+    }
+    if (byteLength(json) > MAX_SCHEMA_BYTES) {
+      throw new QoderAdapterError("qoder_output_schema_too_large")
+    }
+    const ajv = new Ajv2020({
+      allErrors: true,
+      allowUnionTypes: true,
+      strict: false,
+      validateSchema: true,
+    })
+    const validate = ajv.compile(JSON.parse(json))
+    if ("$async" in validate && validate.$async === true) {
+      throw new QoderAdapterError("qoder_output_schema_invalid")
+    }
+    return { json, validate: (value) => validate(value) === true }
+  } catch (error) {
+    if (error instanceof QoderAdapterError) throw error
+    throw new QoderAdapterError("qoder_output_schema_invalid")
+  }
+}
+
+function validateRequestShape(
+  request: AgentHostRunRequest,
+): PreparedOutputSchema | undefined {
   if (
     !request.runId ||
     request.runId.length > 256 ||
@@ -291,16 +328,11 @@ function validateRequestShape(request: AgentHostRunRequest): void {
   if (!request.prompt.trim() || byteLength(request.prompt) > MAX_PROMPT_BYTES) {
     throw new QoderAdapterError("qoder_invalid_prompt")
   }
-  if (request.outputSchema !== undefined) {
-    let serializedSchema: string
-    try {
-      serializedSchema = JSON.stringify(request.outputSchema)
-    } catch {
-      throw new QoderAdapterError("qoder_output_schema_invalid")
-    }
+  const outputSchema = prepareOutputSchema(request.outputSchema)
+  if (outputSchema !== undefined) {
     if (
       byteLength(request.prompt) +
-        byteLength(serializedSchema) +
+        byteLength(outputSchema.json) +
         1_024 >
       MAX_PROMPT_BYTES
     ) {
@@ -374,6 +406,7 @@ function validateRequestShape(request: AgentHostRunRequest): void {
       throw new QoderAdapterError("qoder_deadline_elapsed")
     }
   }
+  return outputSchema
 }
 
 function qoderNativeTools(policy: AgentHostRunRequest["policy"]): string[] {
@@ -518,9 +551,9 @@ function normalizeOutputValue(
 
 function parseAndValidateOutput(
   text: string,
-  schema: SafeValue | undefined,
+  schema: PreparedOutputSchema | undefined,
 ): SafeValue {
-  if (!schema) return redactText(text)
+  if (schema === undefined) return redactText(text)
   let parsed: unknown
   try {
     parsed = JSON.parse(text)
@@ -528,20 +561,8 @@ function parseAndValidateOutput(
     throw new QoderAdapterError("qoder_output_not_json")
   }
   const normalized = normalizeOutputValue(parsed)
-  try {
-    const ajv = new Ajv2020({
-      allErrors: true,
-      allowUnionTypes: true,
-      strict: false,
-      validateSchema: true,
-    })
-    const validate = ajv.compile(schema as object)
-    if (!validate(normalized)) {
-      throw new QoderAdapterError("qoder_output_schema_mismatch")
-    }
-  } catch (error) {
-    if (error instanceof QoderAdapterError) throw error
-    throw new QoderAdapterError("qoder_output_schema_invalid")
+  if (!schema.validate(normalized)) {
+    throw new QoderAdapterError("qoder_output_schema_mismatch")
   }
   return normalized
 }
@@ -772,6 +793,31 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
   }
 
   async preflight(request: AgentHostRunRequest): Promise<AgentHostProbeResult> {
+    try {
+      prepareOutputSchema(request.outputSchema)
+    } catch (error) {
+      const code =
+        error instanceof QoderAdapterError
+          ? error.code
+          : "qoder_policy_projection_failed"
+      return {
+        protocolVersion: AGENT_HOST_PROTOCOL_VERSION,
+        hostId: QODER_HOST_ID,
+        displayName: QODER_DISPLAY_NAME,
+        status: "not_ready",
+        available: false,
+        adapterStatus: "runnable",
+        capabilities: capabilities(),
+        capabilitySource: "conformance_test",
+        issues: [
+          issue(
+            code,
+            "Qoder cannot safely validate this output Schema",
+          ),
+        ],
+      }
+    }
+
     const probe = await this.probe()
     const issues = [...probe.issues]
     try {
@@ -850,6 +896,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
         throw new QoderAdapterError(code)
       }
 
+      const outputSchema = validateRequestShape(request)
       const projection = await inspectProjectionFiles(request)
       const afterProjectionError = stoppedRunError(active)
       if (afterProjectionError) throw afterProjectionError
@@ -954,10 +1001,10 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
         "<employee-task>",
         request.prompt,
         "</employee-task>",
-        ...(request.outputSchema
+        ...(outputSchema !== undefined
           ? [
               "Return exactly one JSON value and no code fence. It must match this JSON Schema:",
-              JSON.stringify(request.outputSchema),
+              outputSchema.json,
             ]
           : []),
       ].join("\n\n")
@@ -1433,9 +1480,9 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
       let output: SafeValue
       try {
         output = scrubOutput(
-          parseAndValidateOutput(resultEvent!.result, request.outputSchema),
+          parseAndValidateOutput(resultEvent!.result, outputSchema),
           credential,
-          request.outputSchema !== undefined,
+          outputSchema !== undefined,
         )
       } catch (error) {
         const code =

--- a/apps/cli/qwen-agent-host.ts
+++ b/apps/cli/qwen-agent-host.ts
@@ -114,7 +114,12 @@ interface ActiveRun {
 
 interface PreparedRun {
   assets: InlineAgentAsset[]
-  schemaJson?: string
+  outputSchema?: PreparedOutputSchema
+}
+
+interface PreparedOutputSchema {
+  json: string
+  value: SafeValue
 }
 
 interface QwenStreamNormalizerOptions {
@@ -278,7 +283,9 @@ function validatedBaseUrl(environment: NodeJS.ProcessEnv): string | undefined {
   return value
 }
 
-function serializeAndValidateSchema(schema: SafeValue | undefined): string | undefined {
+function serializeAndValidateSchema(
+  schema: SafeValue | undefined,
+): PreparedOutputSchema | undefined {
   if (schema === undefined) return undefined
   try {
     const serialized = JSON.stringify(schema)
@@ -291,15 +298,21 @@ function serializeAndValidateSchema(schema: SafeValue | undefined): string | und
       strict: false,
       validateSchema: true,
     })
-    ajv.compile(schema as object)
-    return serialized
+    const value = JSON.parse(serialized) as SafeValue
+    const validate = ajv.compile(value as object)
+    if ("$async" in validate && validate.$async === true) {
+      throw new QwenAdapterError("qwen_output_schema_invalid")
+    }
+    return { json: serialized, value }
   } catch (error) {
     if (error instanceof QwenAdapterError) throw error
     throw new QwenAdapterError("qwen_output_schema_invalid")
   }
 }
 
-function validateRequestShape(request: AgentHostRunRequest): string | undefined {
+function validateRequestShape(
+  request: AgentHostRunRequest,
+): PreparedOutputSchema | undefined {
   validateIdentifier(request.runId, "qwen_invalid_run_id")
   validateIdentifier(request.employeeId, "qwen_invalid_employee_id")
   if (!request.prompt.trim() || byteLength(request.prompt) > MAX_PROMPT_BYTES) {
@@ -311,7 +324,7 @@ function validateRequestShape(request: AgentHostRunRequest): string | undefined 
   ) {
     throw new QwenAdapterError("qwen_instructions_too_large")
   }
-  const schemaJson = serializeAndValidateSchema(request.outputSchema)
+  const outputSchema = serializeAndValidateSchema(request.outputSchema)
   if (request.policy.tools.default !== "deny") {
     throw new QwenAdapterError("qwen_tool_policy_must_default_deny")
   }
@@ -366,17 +379,17 @@ function validateRequestShape(request: AgentHostRunRequest): string | undefined 
       throw new QwenAdapterError("qwen_deadline_elapsed")
     }
   }
-  return schemaJson
+  return outputSchema
 }
 
 async function prepareRun(
   request: AgentHostRunRequest,
   beforeOpen?: (sourcePath: string) => Promise<void>,
 ): Promise<PreparedRun> {
-  const schemaJson = validateRequestShape(request)
+  const outputSchema = validateRequestShape(request)
   try {
     const assets = await readInlineAgentAssets(request, beforeOpen)
-    return { assets, ...(schemaJson ? { schemaJson } : {}) }
+    return { assets, ...(outputSchema ? { outputSchema } : {}) }
   } catch (error) {
     if (error instanceof InlineAgentProjectionError) {
       throw new QwenAdapterError(`qwen_${error.code}`)
@@ -555,6 +568,7 @@ function scrubOutput(
 function createTaskInput(
   request: AgentHostRunRequest,
   assets: InlineAgentAsset[],
+  outputSchema: PreparedOutputSchema | undefined,
 ): string {
   const envelope = {
     schemaVersion: "digital-employee-context.v1",
@@ -562,8 +576,8 @@ function createTaskInput(
     ...(request.instructions !== undefined
       ? { instructions: request.instructions }
       : {}),
-    ...(request.outputSchema !== undefined
-      ? { outputSchema: request.outputSchema }
+    ...(outputSchema !== undefined
+      ? { outputSchema: outputSchema.value }
       : {}),
     assets,
   }
@@ -594,7 +608,9 @@ function normalizeOutputValue(
     throw new QwenStreamProtocolError("qwen_output_too_complex")
   }
   if (value === null) return null
-  if (typeof value === "string") return redactText(value)
+  // Preserve the model value for Schema validation. The terminal scrubber
+  // rejects any redaction that would mutate schema-bound output.
+  if (typeof value === "string") return value
   if (typeof value === "boolean") return value
   if (typeof value === "number") {
     if (!Number.isFinite(value)) {
@@ -629,7 +645,10 @@ function validateStructuredOutput(value: unknown, schema: SafeValue): SafeValue 
       validateSchema: true,
     })
     const validate = ajv.compile(schema as object)
-    if (!validate(normalized)) {
+    if ("$async" in validate && validate.$async === true) {
+      throw new QwenStreamProtocolError("qwen_output_schema_invalid")
+    }
+    if (validate(normalized) !== true) {
       throw new QwenStreamProtocolError("qwen_output_schema_mismatch")
     }
   } catch (error) {
@@ -1164,7 +1183,11 @@ export class QwenAgentHostAdapter implements AgentHostAdapter {
         ),
       )
 
-      const taskInput = createTaskInput(request, prepared.assets)
+      const taskInput = createTaskInput(
+        request,
+        prepared.assets,
+        prepared.outputSchema,
+      )
       const expectedCwd = await realpath(workspace)
       const sessionId = randomUUID()
       const args = [
@@ -1327,7 +1350,7 @@ export class QwenAgentHostAdapter implements AgentHostAdapter {
 
       let completion: QwenStreamCompletion
       try {
-        completion = normalizer.finish(request.outputSchema)
+        completion = normalizer.finish(prepared.outputSchema?.value)
       } catch (error) {
         if (error instanceof QwenStreamProtocolError) {
           throw new QwenAdapterError(error.code, error.retryable)
@@ -1342,7 +1365,7 @@ export class QwenAgentHostAdapter implements AgentHostAdapter {
         output: scrubOutput(
           completion.output,
           credential,
-          request.outputSchema !== undefined,
+          prepared.outputSchema !== undefined,
         ),
       }
     } catch (error) {

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -1,6 +1,6 @@
 # Agent Host 状态与接入策略
 
-- 状态日期：2026-08-04
+- 状态日期：2026-08-14
 - 适用范围：当前源码树中的 `employee-package.v1alpha1`、`agent-host.v1`
 - 相关文档：[架构说明](architecture.md)、[员工包规范](employee-package.md)、[ADR 0001](decisions/0001-agent-host-boundary.md)
 
@@ -14,7 +14,9 @@
 
 这里的 **probe-only** 不是“不启动任何进程”，而是“没有可启动模型或 Agent loop 的 runnable Adapter”。`doctor` 只会用过滤后的环境、固定 `--version` 参数和 10 秒超时执行受限版本探测；它不会验证登录、发起模型调用或执行工具。
 
-当前 `capabilitySource: conformance_test` 指仓库内针对特定 Adapter 和锁定 Host 版本的确定性子进程 fixture。它不是可供第三方 Adapter 复用的认证 harness，也不是厂商认证或真实模型额度验证。
+当前 `capabilitySource: conformance_test` 指仓库内针对特定 Adapter 和锁定 Host 版本的确定性子进程 fixture。它不是可供第三方 Adapter 复用的认证 harness，也不是厂商认证或真实模型额度验证。Qoder 的 capability 声明来自 Adapter 专用确定性 fixture；本轮没有生成通用 qualification record，`liveQualified` 为 false。
+
+`structured_output` 统一表示 **Adapter 保证终态有效**，而不是 Host 原生约束生成：有 `outputSchema` 时，`run.completed` 必须携带原值通过调用方同步 Schema 的终态 JSON；修复、强制转换、默认值、删字段或脱敏都不得制造一个合格值，校验后的安全检查若需要改写 schema-bound 值也必须 fail closed。无效 JSON、异步 Schema、Schema 不匹配、取消、超时或清理失败同样必须 fail closed。事件流本身是 JSON 不构成该能力。Qoder 额外把 Schema 限制在 16 KiB，并在受限版本探针或任何投影、模型进程前完成编译。
 
 ## 名词边界
 
@@ -29,7 +31,7 @@
 
 | 产品 | 当前源码状态 | 官方接口证据 | 本项目结论 |
 | --- | --- | --- | --- |
-| Qoder CLI 1.1.x | `runnable`；内置、版本锁定、只读 one-shot Adapter | 当前实现与测试见 [`qoder-agent-host.ts`](../apps/cli/qoder-agent-host.ts) 和 [验证账本](verification.md) | 最小只读文件投影，运行时校验精确的读/搜索工具集；仍不是多租户在线服务 |
+| Qoder CLI 1.1.x | `runnable`；内置、版本锁定、只读 one-shot Adapter | 当前实现与测试见 [`qoder-agent-host.ts`](../apps/cli/qoder-agent-host.ts) 和 [验证账本](verification.md) | 最小只读文件投影，运行时校验精确的读/搜索工具集；`structured_output` 由 Adapter 严格终态校验，Schema 限 16 KiB 且必须同步；无效、超限或异步 Schema 在运行工作区投影、受限 `--version` 探针和模型进程前即拒绝；仍不是多租户在线服务 |
 | Claude Code `>=2.1.214 <2.2.0` | `runnable`；内置、版本锁定、context-only one-shot Adapter | 官方提供 [`claude -p` 与 `--bare`](https://code.claude.com/docs/en/headless)、JSON/stream-json、[权限](https://code.claude.com/docs/en/permissions)、[沙箱](https://code.claude.com/docs/en/sandboxing)、[MCP](https://code.claude.com/docs/en/mcp)、[Skills](https://code.claude.com/docs/en/skills) 和 [Agent SDK](https://code.claude.com/docs/en/agent-sdk/typescript) | `--bare --tools "" --strict-mcp-config --disable-slash-commands --no-session-persistence`，资产经 stdin 内联；只支持显式 `ANTHROPIC_API_KEY` |
 | Codex CLI | `probe-only`；仅检查本机命令和版本 | 官方提供 [`codex exec`](https://learn.chatgpt.com/docs/non-interactive-mode)、[JSONL 与输出 Schema](https://learn.chatgpt.com/docs/developer-commands?surface=cli#cli-codex-exec)、[MCP](https://learn.chatgpt.com/docs/extend/mcp)、[Skills](https://learn.chatgpt.com/docs/build-skills)；[App Server](https://learn.chatgpt.com/docs/app-server) 另有事件与 `turn/interrupt` | 已审计 0.146.0；即使禁用 shell/unified exec，`apply_patch` 等模型可见内建工具仍无法可靠全部移除，所以 `tool_allowlist` 保持 `unknown` |
 | Qwen Code `0.17.1` | `runnable`；内置、精确版本锁定、context-only one-shot Adapter | 官方提供 [headless JSON/stream-json](https://qwenlm.github.io/qwen-code-docs/en/users/features/headless/)、[权限与沙箱](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/)、[MCP](https://qwenlm.github.io/qwen-code-docs/en/users/features/mcp/)、[Skills](https://qwenlm.github.io/qwen-code-docs/en/users/features/skills) 和 [TypeScript SDK](https://github.com/QwenLM/qwen-code/blob/main/packages/sdk-typescript/README.md) | 密封 UTF-8 资产经 stdin 内联，工具/MCP/slash-command 集为空；锁定 0.17.1 的不可调用内建 Agent 目录；要求显式 `OPENAI_API_KEY` 与 `OPENAI_MODEL`，可选 `OPENAI_BASE_URL` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -176,6 +176,19 @@ The runnable preview is POSIX-only: a terminal event is withheld until the
 detached process group has exited. Windows remains not-ready until equivalent
 Job Object process-tree cleanup is implemented and covered by deterministic
 Adapter fixtures.
+
+Across all built-in Adapters, `structured_output` has one meaning:
+**Adapter-enforced terminal validity**. When `outputSchema` is present, the
+Adapter prepares one bounded, immutable, synchronous Schema snapshot for both
+projection and terminal validation. The terminal JSON value in `run.completed`
+must be accepted unchanged by that snapshot. Repair, coercion, defaults, field
+removal, or redaction cannot manufacture conformance; if post-validation safety
+scrubbing would mutate a schema-bound value, the run fails closed. Invalid JSON,
+asynchronous Schema, Schema mismatch, cancellation, deadline, or cleanup failure
+also fails closed. This capability does not claim Host-native constrained
+generation; JSONL or another machine-readable event format alone is
+insufficient. Qoder additionally limits Schema snapshots to 16 KiB and compiles
+them before its version probe, projection, or model process.
 Each native message is validated before normalized events are published; a
 protocol failure discards buffered output. Run IDs are reserved before staging,
 and the terminal event is held until process, credential, temporary-root and

--- a/docs/employee-package.md
+++ b/docs/employee-package.md
@@ -132,6 +132,14 @@ sample and fixture describe a proposal only; it never performs the proposed
 action or claims that an action completed. A separate authorized system would
 need to review and execute any proposal.
 
+The recipe deliberately retains `requiredCapabilities: ["structured_output"]`.
+Compatibility is decided by the normal package-aware Host registry and
+preflight; applications must not delete that requirement or special-case a
+provider. For built-in Adapters, the capability means strict Adapter-enforced
+terminal Schema validity, not provider-native constrained generation. Input and
+output Schemas must be synchronous; package inspection rejects Ajv `$async`
+Schemas before compatibility checks, evaluation, or Host execution.
+
 ## Offline contract eval
 
 The fixed eval asset is `./evals/cases.json`, and it must be explicitly listed

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,6 +1,6 @@
 # Verification ledger
 
-Last updated: 2026-08-04
+Last updated: 2026-08-14
 
 This file distinguishes shipped code from the environments in which it has
 actually been exercised. A passing fixture test is not presented as a live
@@ -9,11 +9,11 @@ provider integration.
 | Path | Evidence | Result |
 | --- | --- | --- |
 | Local answer and escalation | Public example files, extractive model, real CLI process | Verified |
-| Automated suite | `npm run check` | 343/343 tests plus strict TypeScript, build and the repository security scan passed on 2026-08-04; provider fixtures do not make live model requests |
+| Automated suite | `npm run check` | 858/858 tests plus strict TypeScript, build and the repository security scan passed on 2026-08-14; provider fixtures do not make live model requests |
 | Coverage gate | `npm run test:coverage` on Node.js 22.23.2 | 343/343 tests; 91.97% line, 73.48% branch and 90.44% function coverage |
 | Strict TypeScript | `npm run typecheck` | 0 errors across shipped runtime sources |
-| Agent-host install probes | Real local version/init probes plus bounded fixture processes | Qoder CLI 1.1.12, Codex CLI 0.146.0, Qwen Code 0.17.1 and CodeBuddy Code 2.106.4 found locally; Claude Code 2.1.209 is below the verified range and its probe failed; live authentication/model access not tested |
-| Qoder run adapter | Adapter-specific deterministic child-process fixtures; not a reusable third-party certification harness | Qoder CLI 1.1.x SDK process-mode initialize/user/EOF transport, private auth payload, argument isolation, minimum read-only projection, filtered environment, exact read/search tool plus empty MCP/plugin/Skill attestation, package-aware preflight, atomic event publication, cross-delta exact-credential scrubbing, pre-truncation tool-value scrubbing, credential-bearing tool identifier/key rejection, schema-bound output redaction rejection, cancellation, file-identity checks, cleanup and terminal invariants verified; no live model request made |
+| Agent-host install probes | Real local version/init probes plus bounded fixture processes | Qoder CLI 1.1.17, Codex CLI 0.146.0, Qwen Code 0.17.1 and CodeBuddy Code 2.106.4 found locally; Claude Code 2.1.209 is below the verified range and its probe failed; live authentication/model access not tested |
+| Qoder run adapter | Adapter-specific deterministic child-process fixtures plus checked-in `structured-action.v1` package negotiation; not a reusable third-party certification harness | Qoder CLI 1.1.x SDK process-mode initialize/user/EOF transport, private auth payload, argument isolation, minimum read-only projection, filtered environment, exact read/search tool plus empty MCP/plugin/Skill attestation, package-aware preflight, atomic event publication, cross-delta exact-credential scrubbing, pre-truncation tool-value scrubbing, credential-bearing tool identifier/key rejection, and cancellation/cleanup invariants verified. `structured_output` additionally covers strict matching, prose/fence/truncated/malformed JSON, mismatch/extra fields, `false` Schema, absent Schema, credential mutation, buffered cancellation, independent deadline handling, and invalid/oversized/async Schema rejection before any Qoder process. A real model-free Qoder 1.1.17 probe made the public `senior-architect-pass-coach@0.3.0` employee compatible through ordinary package validation; unverified versions fail closed. This is Adapter-specific fixture evidence (`capabilitySource: conformance_test`), no Qoder qualification record was generated, `liveQualified` remains false, and no live model request was made. |
 | Claude Code run adapter | Adapter-specific deterministic version-locked child-process fixtures only | Claude Code `>=2.1.214 <2.2.0`, explicit `ANTHROPIC_API_KEY`, `--bare --tools ""`, strict empty MCP, disabled commands/session persistence, sealed UTF-8 stdin assets, empty isolated workspace, home, configuration and temp directories, runtime empty tool/MCP/plugin/Skill attestation, strict unknown-event rejection, process-group descendant cleanup, cancellation and terminal invariants verified on POSIX; no live model request made |
 | Qwen Code run adapter | Exact-version child-process fixtures plus real local init against an unreachable loopback endpoint | Qwen Code `0.17.1`, explicit `OPENAI_API_KEY` and `OPENAI_MODEL`, sealed UTF-8 stdin assets, disposable empty workspace, home, configuration and temp directories, empty tool/MCP/slash-command surface and exact non-callable built-in Agent catalog, secret-safe structured output, cancellation, process-group cleanup and terminal invariants verified on POSIX; no model request reached a provider |
 | CodeBuddy Code run adapter | Exact-version child-process fixtures plus real local init against an unreachable loopback endpoint | CodeBuddy Code `2.106.4`, explicit `CODEBUDDY_API_KEY` and `CODEBUDDY_MODEL`, sealed UTF-8 stdin assets, disposable empty workspace/config/session/temp state, exhaustive built-in deny list and final empty tool/MCP attestation, strict status/snapshot/unknown-event checks, secret-safe structured output, cancellation, process-group cleanup and terminal invariants verified on POSIX; no model request reached a provider |
@@ -49,7 +49,7 @@ npm run test:coverage
 npm audit --audit-level=high
 ```
 
-Node.js 24.13.0 completed all 343 tests through `npm run check`, and Node 24 is
+Node.js 24.13.0 completed all 858 tests through `npm run check`, and Node 24 is
 part of the regular CI matrix. Its experimental full-suite coverage reporter
 can end with `Unexpected end of JSON input` while aggregating child-process
 coverage, including three consecutive reproductions after every test passed on

--- a/packages/core/src/agent-host.ts
+++ b/packages/core/src/agent-host.ts
@@ -19,6 +19,17 @@ export const AGENT_HOST_CAPABILITIES = [
   "usage_events",
 ] as const
 
+/**
+ * `structured_output` means adapter-enforced terminal validity: when a run
+ * request includes a synchronous `outputSchema`, the adapter may emit
+ * `run.completed` only with the unchanged JSON value accepted by that Schema.
+ * Repair, coercion, defaults, field removal, or redaction must not manufacture
+ * a passing value; if post-validation safety scrubbing would mutate a
+ * schema-bound value, the run fails closed. Invalid JSON, asynchronous Schema,
+ * Schema mismatch, cancellation, and cleanup failure also fail closed. This
+ * capability does not imply host-native constrained generation.
+ */
+
 export type AgentHostCapability = (typeof AGENT_HOST_CAPABILITIES)[number]
 export type AgentHostCapabilitySupport =
   | "supported"

--- a/tests/apps/claude-agent-host.test.ts
+++ b/tests/apps/claude-agent-host.test.ts
@@ -328,6 +328,29 @@ test("Claude fails closed without emitting the API key from hostile output", asy
   )
 })
 
+test("Claude validates structured output before redaction can manufacture conformance", async () => {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "claude-redaction-order-"))
+  const request = await employeeRequest(parent, "run-redaction-order")
+  request.outputSchema = {
+    type: "object",
+    required: ["answer"],
+    properties: { answer: { const: "token=[REDACTED]" } },
+    additionalProperties: true,
+  }
+  const events = await collect(
+    adapter(parent, "generic-redaction-output").run(request),
+  )
+  const terminal = events.at(-1)
+
+  assert.equal(terminal?.type, "run.failed")
+  assert.equal(
+    terminal?.type === "run.failed" && terminal.error.code,
+    "claude_output_schema_mismatch",
+  )
+  assert.equal(events.some((event) => event.type === "run.completed"), false)
+  assert.equal(JSON.stringify(events).includes("fixture-public-nonsecret"), false)
+})
+
 test("Claude fails closed when a hostile result uses the API key as an object key", async () => {
   const parent = await mkdtemp(path.join(os.tmpdir(), "claude-secret-key-"))
   const request = await employeeRequest(parent, "run-secret-key")
@@ -396,23 +419,47 @@ test("Claude rejects unsupported versions, missing API keys and write policies b
   await assert.rejects(access(launchLog))
 })
 
-test("Claude validates JSON Schema locally before launching", async () => {
-  const parent = await mkdtemp(path.join(os.tmpdir(), "claude-schema-"))
-  const launchLog = path.join(parent, "launch.jsonl")
-  const request = await employeeRequest(parent, "run-schema")
-  request.outputSchema = { type: "definitely-not-a-json-schema-type" }
+test("Claude validates synchronous JSON Schema locally before launching", async () => {
+  for (const [name, outputSchema] of [
+    ["invalid", { type: "definitely-not-a-json-schema-type" }],
+    ["async", { $async: true, type: "object" }],
+  ] as const) {
+    const parent = await mkdtemp(path.join(os.tmpdir(), `claude-schema-${name}-`))
+    const launchLog = path.join(parent, "launch.jsonl")
+    const request = await employeeRequest(parent, `run-schema-${name}`)
+    request.outputSchema = outputSchema as SafeValue
+    const host = adapter(parent, "success", undefined, 10_000, {
+      fixtureArgs: ["--launch-log", launchLog],
+    })
+
+    const events = await collect(host.run(request))
+    const failed = events.at(-1)
+    assert.equal(failed?.type, "run.failed")
+    assert.equal(
+      failed?.type === "run.failed" && failed.error.code,
+      "claude_output_schema_invalid",
+    )
+    await assert.rejects(access(launchLog))
+  }
+})
+
+test("Claude keeps the prepared Schema when the request mutates before spawn", async () => {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "claude-late-schema-"))
+  const request = await employeeRequest(parent, "run-late-schema")
   const host = adapter(parent, "success", undefined, 10_000, {
-    fixtureArgs: ["--launch-log", launchLog],
+    beforeSpawn: async () => {
+      request.outputSchema = { $async: true, type: "object" }
+    },
   })
 
   const events = await collect(host.run(request))
-  const failed = events.at(-1)
-  assert.equal(failed?.type, "run.failed")
+  const completed = events.at(-1)
+  assert.equal(completed?.type, "run.completed")
   assert.equal(
-    failed?.type === "run.failed" && failed.error.code,
-    "claude_output_schema_invalid",
+    completed?.type === "run.completed" &&
+      (completed.output as { answer?: string }).answer,
+    "fixture answer",
   )
-  await assert.rejects(access(launchLog))
 })
 
 test("Claude deadline and explicit cancellation terminate a hanging run", async () => {

--- a/tests/apps/cli-agent-host.test.ts
+++ b/tests/apps/cli-agent-host.test.ts
@@ -42,6 +42,20 @@ async function installFakeQoder(directory: string): Promise<void> {
   await chmod(executable, 0o755)
 }
 
+async function installVersionOnlyQoder(
+  directory: string,
+  version: string,
+): Promise<void> {
+  const executable = path.join(directory, "qodercli")
+  const output = JSON.stringify(`${version}\n`)
+  await writeFile(
+    executable,
+    `#!/usr/bin/env node\nif (!process.argv.includes("--version")) process.exit(2)\nprocess.stdout.write(${output})\n`,
+    { mode: 0o755 },
+  )
+  await chmod(executable, 0o755)
+}
+
 async function installFakeHost(
   directory: string,
   command: string,
@@ -183,6 +197,68 @@ test("static validation succeeds while Qoder without a service token fails close
   assert.equal(
     packageAwareOutput.compatibility.issues.some(
       (issue: { code: string }) => issue.code === "qoder_invalid_workspace_file",
+    ),
+    true,
+  )
+})
+
+test("public structured-action package negotiates Qoder structured_output by exact version", async (t) => {
+  if (process.platform === "win32") return t.skip("fixture executable is POSIX-only")
+  const directory = await mkdtemp(path.join(os.tmpdir(), "employee-structured-"))
+  const executableDirectory = path.join(directory, "bin")
+  const unverifiedExecutableDirectory = path.join(directory, "unverified-bin")
+  const packageDirectory = path.join(
+    root,
+    "examples",
+    "recipes",
+    "structured-action.v1",
+    "structured-action",
+  )
+  await mkdir(executableDirectory)
+  await mkdir(unverifiedExecutableDirectory)
+  await installVersionOnlyQoder(executableDirectory, "1.1.12")
+  await installVersionOnlyQoder(unverifiedExecutableDirectory, "1.2.0")
+  const manifest = JSON.parse(
+    await readFile(path.join(packageDirectory, "employee.json"), "utf8"),
+  )
+  assert.deepEqual(manifest.host.requiredCapabilities, ["structured_output"])
+  const baseEnvironment = {
+    ...process.env,
+    PATH: `${executableDirectory}${path.delimiter}${process.env.PATH}`,
+    QODER_PERSONAL_ACCESS_TOKEN: "fixture-service-token",
+  }
+
+  const qualified = runCli(
+    ["validate", packageDirectory, "--engine", "qoder", "--json"],
+    baseEnvironment,
+  )
+  assert.equal(qualified.status, 0, qualified.stderr)
+  const qualifiedOutput = JSON.parse(qualified.stdout)
+  assert.equal(qualifiedOutput.status, "valid")
+  assert.equal(qualifiedOutput.compatibility.compatible, true)
+  assert.deepEqual(qualifiedOutput.compatibility.missing, [])
+  assert.deepEqual(qualifiedOutput.compatibility.unknown, [])
+  assert.equal(
+    qualifiedOutput.host.capabilities.structured_output,
+    "supported",
+  )
+  assert.equal(qualifiedOutput.host.capabilitySource, "conformance_test")
+
+  const unverified = runCli(
+    ["validate", packageDirectory, "--engine", "qoder", "--json"],
+    {
+      ...baseEnvironment,
+      PATH: `${unverifiedExecutableDirectory}${path.delimiter}${process.env.PATH}`,
+    },
+  )
+  assert.equal(unverified.status, 1, unverified.stderr)
+  const unverifiedOutput = JSON.parse(unverified.stdout)
+  assert.equal(unverifiedOutput.status, "incompatible")
+  assert.equal(unverifiedOutput.compatibility.compatible, false)
+  assert.equal(
+    unverifiedOutput.host.issues.some(
+      (entry: { code: string }) =>
+        entry.code === "qoder_version_not_conformance_verified",
     ),
     true,
   )

--- a/tests/apps/codebuddy-agent-host.test.ts
+++ b/tests/apps/codebuddy-agent-host.test.ts
@@ -406,6 +406,31 @@ test("CodeBuddy fails closed without emitting CODEBUDDY_API_KEY from hostile out
   )
 })
 
+test("CodeBuddy validates structured output before redaction can manufacture conformance", async () => {
+  const parent = await mkdtemp(
+    path.join(os.tmpdir(), "codebuddy-redaction-order-"),
+  )
+  const request = await employeeRequest(parent, "run-redaction-order")
+  request.outputSchema = {
+    type: "object",
+    required: ["answer"],
+    properties: { answer: { const: "token=[REDACTED]" } },
+    additionalProperties: true,
+  }
+  const events = await collect(
+    adapter(parent, "generic-redaction-output").run(request),
+  )
+  const terminal = events.at(-1)
+
+  assert.equal(terminal?.type, "run.failed")
+  assert.equal(
+    terminal?.type === "run.failed" && terminal.error.code,
+    "codebuddy_output_schema_mismatch",
+  )
+  assert.equal(events.some((event) => event.type === "run.completed"), false)
+  assert.equal(JSON.stringify(events).includes("fixture-public-nonsecret"), false)
+})
+
 test("CodeBuddy fails closed when hostile output uses the API key as an object key", async () => {
   const parent = await mkdtemp(path.join(os.tmpdir(), "codebuddy-secret-key-"))
   const request = await employeeRequest(parent, "run-secret-key")
@@ -486,23 +511,49 @@ test("CodeBuddy validates optional endpoint and environment settings", async () 
   }
 })
 
-test("CodeBuddy validates JSON Schema locally before launching", async () => {
-  const parent = await mkdtemp(path.join(os.tmpdir(), "codebuddy-schema-"))
-  const launchLog = path.join(parent, "launch.jsonl")
-  const request = await employeeRequest(parent, "run-schema")
-  request.outputSchema = { type: "definitely-not-a-json-schema-type" }
+test("CodeBuddy validates synchronous JSON Schema locally before launching", async () => {
+  for (const [name, outputSchema] of [
+    ["invalid", { type: "definitely-not-a-json-schema-type" }],
+    ["async", { $async: true, type: "object" }],
+  ] as const) {
+    const parent = await mkdtemp(
+      path.join(os.tmpdir(), `codebuddy-schema-${name}-`),
+    )
+    const launchLog = path.join(parent, "launch.jsonl")
+    const request = await employeeRequest(parent, `run-schema-${name}`)
+    request.outputSchema = outputSchema as SafeValue
+    const host = adapter(parent, "success", undefined, 10_000, {
+      fixtureArgs: ["--launch-log", launchLog],
+    })
+
+    const events = await collect(host.run(request))
+    const failed = events.at(-1)
+    assert.equal(failed?.type, "run.failed")
+    assert.equal(
+      failed?.type === "run.failed" && failed.error.code,
+      "codebuddy_output_schema_invalid",
+    )
+    await assert.rejects(access(launchLog))
+  }
+})
+
+test("CodeBuddy keeps the prepared Schema when the request mutates before spawn", async () => {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "codebuddy-late-schema-"))
+  const request = await employeeRequest(parent, "run-late-schema")
   const host = adapter(parent, "success", undefined, 10_000, {
-    fixtureArgs: ["--launch-log", launchLog],
+    beforeSpawn: async () => {
+      request.outputSchema = { $async: true, type: "object" }
+    },
   })
 
   const events = await collect(host.run(request))
-  const failed = events.at(-1)
-  assert.equal(failed?.type, "run.failed")
+  const completed = events.at(-1)
+  assert.equal(completed?.type, "run.completed")
   assert.equal(
-    failed?.type === "run.failed" && failed.error.code,
-    "codebuddy_output_schema_invalid",
+    completed?.type === "run.completed" &&
+      (completed.output as { answer?: string }).answer,
+    "fixture answer",
   )
-  await assert.rejects(access(launchLog))
 })
 
 test("CodeBuddy deadline and explicit cancellation terminate a hanging run", async () => {

--- a/tests/apps/employee-package.test.ts
+++ b/tests/apps/employee-package.test.ts
@@ -227,6 +227,26 @@ test("static validation rejects a mismatched Skill identity", async () => {
   )
 })
 
+test("static validation rejects asynchronous input and output Schemas", async () => {
+  for (const schemaName of ["input.schema.json", "output.schema.json"]) {
+    const parent = await mkdtemp(path.join(os.tmpdir(), "employee-async-schema-"))
+    const target = path.join(parent, `team-${schemaName.split(".")[0]}`)
+    await createEmployeePackage(target)
+    await writeFile(
+      path.join(target, "schemas", schemaName),
+      `${JSON.stringify({ $async: true, type: "object" })}\n`,
+    )
+
+    await assert.rejects(
+      () => inspectEmployeePackage(target),
+      (error: unknown) =>
+        error instanceof TypeError &&
+        error.message ===
+          `employee_package_invalid_json_schema:./schemas/${schemaName}`,
+    )
+  }
+})
+
 test("static validation refuses symlinked package artifacts", async () => {
   const parent = await mkdtemp(path.join(os.tmpdir(), "employee-link-"))
   const target = path.join(parent, "team-answer")

--- a/tests/apps/fixtures/fake-claude.mjs
+++ b/tests/apps/fixtures/fake-claude.mjs
@@ -198,6 +198,8 @@ if (mode === "unsafe-message-start") {
 const answer =
   mode === "secret-output"
     ? `credential=${process.env.ANTHROPIC_API_KEY}`
+    : mode === "generic-redaction-output"
+    ? "token=fixture-public-nonsecret"
     : "fixture answer"
 const structuredOutput =
   mode === "secret-key-output"

--- a/tests/apps/fixtures/fake-codebuddy.mjs
+++ b/tests/apps/fixtures/fake-codebuddy.mjs
@@ -248,6 +248,8 @@ if (mode === "unknown-event") {
 const answer =
   mode === "secret-output"
     ? `credential=${process.env.CODEBUDDY_API_KEY}`
+    : mode === "generic-redaction-output"
+    ? "token=fixture-public-nonsecret"
     : "fixture answer"
 const structuredOutput =
   mode === "secret-key-output"

--- a/tests/apps/fixtures/fake-qoder.mjs
+++ b/tests/apps/fixtures/fake-qoder.mjs
@@ -5,6 +5,7 @@ import path from "node:path"
 import { createInterface } from "node:readline"
 
 const args = process.argv.slice(2)
+const fixtureVersion = "1.1.12"
 
 function option(name) {
   const index = args.indexOf(name)
@@ -12,7 +13,7 @@ function option(name) {
 }
 
 if (args.includes("--version")) {
-  process.stdout.write("1.1.12\n")
+  process.stdout.write(`${fixtureVersion}\n`)
   process.exit(0)
 }
 
@@ -71,6 +72,9 @@ async function writeCapture() {
       sdkEntrypoint: process.env.QODER_AGENT_SDK_ENTRYPOINT,
       sdkVersion: process.env.QODER_AGENT_SDK_VERSION,
       authPayloadMetadata,
+      environmentContainsSchemaMarker: Object.values(process.env).some(
+        (value) => value?.includes("SCHEMA_ARGV_MARKER"),
+      ),
       inputLines,
     }),
   )
@@ -89,7 +93,7 @@ const init = {
   type: "system",
   subtype: "init",
   session_id: sessionId,
-  qodercli_version: "1.1.12",
+  qodercli_version: fixtureVersion,
   ...(mode === "protocol-missing"
     ? {}
     : {
@@ -106,7 +110,30 @@ const init = {
 
 async function executeRun() {
   await writeCapture()
-  if (mode === "hang") {
+  if (mode === "hang" || mode === "buffered-hang") {
+    if (mode === "buffered-hang") {
+      emit({
+        type: "stream_event",
+        session_id: sessionId,
+        event: {
+          delta: { type: "text_delta", text: "buffered-output-must-not-flush" },
+        },
+      })
+      emit({
+        type: "assistant",
+        session_id: sessionId,
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "buffer-observed-before-cancel",
+              name: "Read",
+              input: { file_path: "knowledge/README.md" },
+            },
+          ],
+        },
+      })
+    }
     // An unresolved top-level await does not keep Node alive by itself. Hold a
     // referenced timer so only the Adapter's deadline/cancel path ends it.
     await new Promise(() => {
@@ -238,8 +265,14 @@ async function executeRun() {
   }
   const outputValue = {
     status: "answered",
-    answer: mode === "output-value-credential" ? credential : "fixture answer",
+    answer:
+      mode === "output-value-credential"
+        ? credential
+        : mode === "schema-mismatch"
+          ? 42
+          : "fixture answer",
     citations: [{ label: "Approved", uri: "knowledge/README.md" }],
+    ...(mode === "schema-extra-field" ? { unexpected: true } : {}),
     ...(mode === "output-key-credential" ? { [credential]: "unsafe" } : {}),
   }
   const output = JSON.stringify(outputValue)
@@ -250,7 +283,18 @@ async function executeRun() {
     session_id: sessionId,
     subtype: resultError ? "error_during_execution" : "success",
     is_error: resultError,
-    result: mode === "invalid-output" ? `\`\`\`json\n${output}\n\`\`\`` : output,
+    result:
+      mode === "invalid-output"
+        ? `\`\`\`json\n${output}\n\`\`\``
+        : mode === "prose-output"
+          ? `Result: ${output}`
+          : mode === "truncated-output"
+            ? output.slice(0, -1)
+            : mode === "malformed-output"
+              ? "{not-json}"
+              : mode === "unstructured-prose"
+                ? "plain fixture answer"
+                : output,
   }
   emit(result)
   if (mode === "duplicate-result") emit(result)

--- a/tests/apps/fixtures/fake-qwen.mjs
+++ b/tests/apps/fixtures/fake-qwen.mjs
@@ -194,6 +194,8 @@ const eventSession = mode === "session-mismatch" ? "different-session" : session
 const answer =
   mode === "secret-output"
     ? `credential=${process.env.OPENAI_API_KEY}`
+    : mode === "generic-redaction-output"
+    ? "token=fixture-public-nonsecret"
     : "fixture answer"
 const structuredOutput =
   mode === "secret-key-output"

--- a/tests/apps/qoder-agent-host.test.ts
+++ b/tests/apps/qoder-agent-host.test.ts
@@ -130,6 +130,7 @@ test("Qoder probe reports only the fixture-verified stateless capabilities", asy
   assert.equal(probe.capabilities.tool_allowlist, "supported")
   assert.equal(probe.capabilities.filesystem_scope, "supported")
   assert.equal(probe.capabilities.network_policy, "supported")
+  assert.equal(probe.capabilities.structured_output, "supported")
   assert.equal(probe.capabilities.mcp, "unsupported")
   assert.equal(probe.capabilities.usage_events, "unknown")
 })
@@ -173,6 +174,15 @@ test("Qoder run uses an isolated projection, filtered environment, and normalize
   const sentinel = path.join(parent, "must-not-exist")
   const request = await employeeRequest(parent)
   request.prompt = `--yolo; touch ${sentinel}; $(touch ${sentinel})`
+  const schemaMarker = "SCHEMA_ARGV_MARKER"
+  assert.equal(
+    typeof request.outputSchema === "object" && request.outputSchema !== null,
+    true,
+  )
+  request.outputSchema = {
+    ...(request.outputSchema as Record<string, SafeValue>),
+    $comment: schemaMarker,
+  }
 
   const events = await collect(adapter(parent, "success", capture).run(request))
   assert.deepEqual(
@@ -212,6 +222,12 @@ test("Qoder run uses an isolated projection, filtered environment, and normalize
   })
   assert.equal(captured.environmentKeys.includes("SECRET_SHOULD_NOT_PASS"), false)
   assert.equal(captured.environmentKeys.includes("NODE_OPTIONS"), false)
+  assert.equal(captured.environmentContainsSchemaMarker, false)
+  assert.equal(
+    captured.args.some((value: string) => value.includes(schemaMarker)),
+    false,
+  )
+  assert.equal(JSON.stringify(events).includes(schemaMarker), false)
   assert.equal(captured.args.includes("--dangerously-skip-permissions"), false)
   assert.equal(captured.args.includes("--yolo"), false)
   assert.equal(captured.args.includes("dont_ask"), true)
@@ -231,6 +247,7 @@ test("Qoder run uses an isolated projection, filtered environment, and normalize
   const user = JSON.parse(captured.inputLines[1])
   assert.equal(user.type, "user")
   assert.match(user.message.content[0].text, /--yolo; touch/)
+  assert.match(user.message.content[0].text, /SCHEMA_ARGV_MARKER/)
   await assert.rejects(access(sentinel))
   assert.equal(
     (await readdir(parent)).some((entry) =>
@@ -518,6 +535,11 @@ for (const [mode, expectedCode] of [
   ["nonzero", "qoder_process_failed"],
   ["result-error", "qoder_execution_failed"],
   ["invalid-output", "qoder_output_not_json"],
+  ["prose-output", "qoder_output_not_json"],
+  ["truncated-output", "qoder_output_not_json"],
+  ["malformed-output", "qoder_output_not_json"],
+  ["schema-mismatch", "qoder_output_schema_mismatch"],
+  ["schema-extra-field", "qoder_output_schema_mismatch"],
   ["stdout-oversize", "qoder_stdout_limit_exceeded"],
   ["stderr-oversize", "qoder_stderr_limit_exceeded"],
 ] as const) {
@@ -534,8 +556,41 @@ for (const [mode, expectedCode] of [
       terminals[0]?.type === "run.failed" && terminals[0].error.code,
       expectedCode,
     )
+    assert.equal(
+      events.some((event) => event.type === "assistant.delta"),
+      false,
+    )
   })
 }
+
+test("Qoder treats a false JSON Schema as present and fails closed", async () => {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "qoder-false-schema-"))
+  const request = await employeeRequest(parent, "run-false-schema")
+  request.outputSchema = false
+  const events = await collect(adapter(parent).run(request))
+  const terminal = events.at(-1)
+
+  assert.equal(terminal?.type, "run.failed")
+  assert.equal(
+    terminal?.type === "run.failed" && terminal.error.code,
+    "qoder_output_schema_mismatch",
+  )
+  assert.equal(events.some((event) => event.type === "assistant.delta"), false)
+})
+
+test("Qoder leaves unstructured output unchanged without outputSchema", async () => {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "qoder-unstructured-"))
+  const request = await employeeRequest(parent, "run-unstructured")
+  request.outputSchema = undefined
+  const events = await collect(adapter(parent, "unstructured-prose").run(request))
+  const terminal = events.at(-1)
+
+  assert.equal(terminal?.type, "run.completed")
+  assert.equal(
+    terminal?.type === "run.completed" && terminal.output,
+    "plain fixture answer",
+  )
+})
 
 for (const [mode, expectedCode] of [
   ["protocol-buffered", "qoder_initialize_response_invalid"],
@@ -622,12 +677,44 @@ test("Qoder deadline and explicit cancellation terminate a hanging run", async (
   )
 })
 
+test("Qoder never flushes buffered output on explicit cancellation", async () => {
+  const cancelParent = await mkdtemp(
+    path.join(os.tmpdir(), "qoder-buffered-cancel-"),
+  )
+  const cancelRequest = await employeeRequest(
+    cancelParent,
+    "run-buffered-cancel",
+  )
+  const host = adapter(cancelParent, "buffered-hang")
+  const iterator = host.run(cancelRequest)[Symbol.asyncIterator]()
+  const events: AgentHostEvent[] = []
+  const started = await iterator.next()
+  assert.equal(started.value?.type, "run.started")
+  if (started.value) events.push(started.value)
+  const bufferedTool = await iterator.next()
+  assert.equal(bufferedTool.value?.type, "tool.started")
+  if (bufferedTool.value) events.push(bufferedTool.value)
+  await host.cancel(cancelRequest.runId)
+  for (;;) {
+    const next = await iterator.next()
+    if (next.done) break
+    events.push(next.value)
+  }
+  const cancelTerminal = events.at(-1)
+  assert.equal(cancelTerminal?.type, "run.failed")
+  assert.equal(
+    cancelTerminal?.type === "run.failed" && cancelTerminal.error.code,
+    "qoder_run_cancelled",
+  )
+  assert.equal(events.some((event) => event.type === "assistant.delta"), false)
+  assert.equal(terminalEvents(events).length, 1)
+})
+
 test("Qoder preflight rejects write and missing service-token policies without a model run", async () => {
   const parent = await mkdtemp(path.join(os.tmpdir(), "qoder-preflight-"))
   const request = await employeeRequest(parent)
   request.policy.filesystem.write = ["./knowledge/out.md"]
   request.policy.tools.allow.push({ name: "filesystem.write", mode: "write" })
-
   const noToken = createQoderAgentHostAdapter({
     command: process.execPath,
     commandPrefixArgs: [fixture],
@@ -637,13 +724,86 @@ test("Qoder preflight rejects write and missing service-token policies without a
   const probe = await noToken.preflight(request)
   assert.equal(probe.status, "not_ready")
   assert.equal(
-    probe.issues.some((entry) => entry.code === "qoder_service_token_not_configured"),
+    probe.issues.some(
+      (entry) => entry.code === "qoder_service_token_not_configured",
+    ),
     true,
   )
+
   assert.equal(
-    probe.issues.some((entry) => entry.code === "qoder_tool_policy_unsupported"),
+    probe.issues.some(
+      (entry) => entry.code === "qoder_tool_policy_unsupported",
+    ),
     true,
   )
+})
+
+test("Qoder rejects invalid, oversized, and async Schema before any Qoder process", async () => {
+  for (const [name, schema, expectedCode] of [
+    [
+      "invalid",
+      { type: "definitely-not-a-json-schema-type" },
+      "qoder_output_schema_invalid",
+    ],
+    [
+      "oversized",
+      { type: "object", $comment: "x".repeat(16 * 1024) },
+      "qoder_output_schema_too_large",
+    ],
+    [
+      "async",
+      { $async: true, type: "object" },
+      "qoder_output_schema_invalid",
+    ],
+  ] as const) {
+    const parent = await mkdtemp(path.join(os.tmpdir(), `qoder-schema-${name}-`))
+    const launchLog = path.join(parent, "launch.jsonl")
+    const request = await employeeRequest(parent, `run-schema-${name}`)
+    request.outputSchema = schema
+    let beforeSpawnCalls = 0
+    let beforeProjectionOpenCalls = 0
+    let versionProbeCalls = 0
+    const host = adapter(parent, "success", undefined, 10_000, {
+      fixtureArgs: ["--launch-log", launchLog],
+      versionExecutor: async () => {
+        versionProbeCalls += 1
+        return { status: "installed", output: "1.1.12" }
+      },
+      beforeSpawn: async () => {
+        beforeSpawnCalls += 1
+      },
+      beforeProjectionOpen: async () => {
+        beforeProjectionOpenCalls += 1
+      },
+    })
+
+    const preflight = await host.preflight(request)
+    assert.equal(preflight.status, "not_ready", name)
+    assert.equal(
+      preflight.issues.some((entry) => entry.code === expectedCode),
+      true,
+      name,
+    )
+    const events = await collect(host.run(request))
+    const terminal = events.at(-1)
+    assert.equal(terminal?.type, "run.failed", name)
+    assert.equal(
+      terminal?.type === "run.failed" && terminal.error.code,
+      expectedCode,
+      name,
+    )
+    assert.equal(beforeSpawnCalls, 0, name)
+    assert.equal(beforeProjectionOpenCalls, 0, name)
+    assert.equal(versionProbeCalls, 0, name)
+    await assert.rejects(access(launchLog))
+    assert.equal(
+      (await readdir(parent)).some((entry) =>
+        entry.startsWith("digital-employee-qoder-"),
+      ),
+      false,
+      name,
+    )
+  }
 })
 
 test("Qoder reserves a run id before asynchronous preflight work", async () => {

--- a/tests/apps/qwen-agent-host.test.ts
+++ b/tests/apps/qwen-agent-host.test.ts
@@ -380,6 +380,30 @@ test("Qwen fails closed without emitting the API key from hostile output", async
   await rm(parent, { recursive: true, force: true })
 })
 
+test("Qwen validates structured output before redaction can manufacture conformance", async () => {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "qwen-redaction-order-"))
+  const request = await employeeRequest(parent, "run-redaction-order")
+  request.outputSchema = {
+    type: "object",
+    required: ["answer"],
+    properties: { answer: { const: "token=[REDACTED]" } },
+    additionalProperties: true,
+  }
+  const events = await collect(
+    adapter(parent, "generic-redaction-output").run(request),
+  )
+  const terminal = events.at(-1)
+
+  assert.equal(terminal?.type, "run.failed")
+  assert.equal(
+    terminal?.type === "run.failed" && terminal.error.code,
+    "qwen_output_schema_mismatch",
+  )
+  assert.equal(events.some((event) => event.type === "run.completed"), false)
+  assert.equal(JSON.stringify(events).includes("fixture-public-nonsecret"), false)
+  await rm(parent, { recursive: true, force: true })
+})
+
 test("Qwen fails closed when a hostile result uses the API key as an object key", async () => {
   const parent = await mkdtemp(path.join(os.tmpdir(), "qwen-secret-key-"))
   const request = await employeeRequest(parent, "run-secret-key")
@@ -497,23 +521,48 @@ test("Qwen rejects credentials, model, write, network and approval gaps before l
   await rm(parent, { recursive: true, force: true })
 })
 
-test("Qwen validates JSON Schema locally before launching", async () => {
-  const parent = await mkdtemp(path.join(os.tmpdir(), "qwen-schema-"))
-  const launchLog = path.join(parent, "launch.jsonl")
-  const request = await employeeRequest(parent, "run-schema")
-  request.outputSchema = { type: "definitely-not-a-json-schema-type" }
+test("Qwen validates synchronous JSON Schema locally before launching", async () => {
+  for (const [name, outputSchema] of [
+    ["invalid", { type: "definitely-not-a-json-schema-type" }],
+    ["async", { $async: true, type: "object" }],
+  ] as const) {
+    const parent = await mkdtemp(path.join(os.tmpdir(), `qwen-schema-${name}-`))
+    const launchLog = path.join(parent, "launch.jsonl")
+    const request = await employeeRequest(parent, `run-schema-${name}`)
+    request.outputSchema = outputSchema as SafeValue
+    const host = adapter(parent, "success", undefined, 10_000, {
+      fixtureArgs: ["--launch-log", launchLog],
+    })
+
+    const events = await collect(host.run(request))
+    const failed = events.at(-1)
+    assert.equal(failed?.type, "run.failed")
+    assert.equal(
+      failed?.type === "run.failed" && failed.error.code,
+      "qwen_output_schema_invalid",
+    )
+    await assert.rejects(access(launchLog))
+    await rm(parent, { recursive: true, force: true })
+  }
+})
+
+test("Qwen keeps the prepared Schema when the request mutates before spawn", async () => {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "qwen-late-schema-"))
+  const request = await employeeRequest(parent, "run-late-schema")
   const host = adapter(parent, "success", undefined, 10_000, {
-    fixtureArgs: ["--launch-log", launchLog],
+    beforeSpawn: async () => {
+      request.outputSchema = { $async: true, type: "object" }
+    },
   })
 
   const events = await collect(host.run(request))
-  const failed = events.at(-1)
-  assert.equal(failed?.type, "run.failed")
+  const completed = events.at(-1)
+  assert.equal(completed?.type, "run.completed")
   assert.equal(
-    failed?.type === "run.failed" && failed.error.code,
-    "qwen_output_schema_invalid",
+    completed?.type === "run.completed" &&
+      (completed.output as { answer?: string }).answer,
+    "fixture answer",
   )
-  await assert.rejects(access(launchLog))
   await rm(parent, { recursive: true, force: true })
 })
 

--- a/tests/scripts/requirement-governance-check.test.ts
+++ b/tests/scripts/requirement-governance-check.test.ts
@@ -816,7 +816,7 @@ test("CI contract preserves push main, full history, and the Node 22-only gate",
     )
   );
   assert.ok(
-    validateCiWorkflow(ci.replace("          fetch-depth: 0", "          fetch-depth: 1")).includes(
+    validateCiWorkflow(ci.replaceAll("          fetch-depth: 0", "          fetch-depth: 1")).includes(
       "CI test checkout must use actions/checkout@v6 with fetch-depth 0"
     )
   );


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/113
- Consumed revision: R2
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | apps/cli/qoder-agent-host.ts, apps/cli/agent-run.ts, packages/core/src/agent-host.ts, docs/agent-hosts.md | tests/apps/qoder-agent-host.test.ts full matrix: matching JSON, prose/fence/truncated, mismatch, preflight, cancel-buffered, cleanup-failure |
| REQ-001 / AC-002 | apps/cli/qoder-agent-host.ts, apps/cli/claude-agent-host.ts, apps/cli/qwen-agent-host.ts, apps/cli/codebuddy-agent-host.ts, tests/apps/fixtures/fake-qoder.mjs, fake-claude.mjs, fake-qwen.mjs, fake-codebuddy.mjs | tests/apps/qoder-agent-host.test.ts 34/34, claude/qwen/codebuddy agent-host suites reject `$async:true` before model spawn |
| REQ-002 / AC-002 | packages/core/src/agent-host.ts, apps/cli/employee-eval.ts | invalid, oversized, `$async:true`, unsupported Schema fail before probe/projection/model process; bounded immutable Schema snapshot per run |
| REQ-003 / AC-003 | docs/verification.md, docs/architecture.md, tests/apps/employee-package.test.ts | structured-action.v1 package compatibility through ordinary registry; fixture conformance distinct from live entitlement |
| REQ-003 / AC-004 | CHANGELOG.md, docs/employee-package.md, apps/cli/employee-package.ts | security scan and evidence naming; no new authority added |

## File domains

- apps/cli/*agent-host.ts + agent-run.ts: Adapter capability qualification, owned by host maintainer.
- packages/core/src/agent-host.ts: shared Schema snapshot and terminal-validity contract, owned by core maintainer.
- tests/apps + fixtures: deterministic conformance matrix, owned by host maintainer.
- docs + CHANGELOG: user-facing capability meaning and evidence, owned by docs maintainer.

## Scope and non-goals

Qoder CLI 1.1.x is qualified through the ordinary built-in registry and package compatibility path; unverified versions remain fail closed. Claude/Qwen/CodeBuddy close the Ajv `$async` Promise-truthiness path. No new capability name, no `agent-host.v1` migration, no native structured-generation tool enabling, no repair/retry/output mutation, no live model claims.

## Validation

- Exact commands: `npm run check` (typecheck, build, `npm test` via `tsx --test`, governance:check, security:check)
- Observed counts/results: 895/895 tests pass; governance-check passed (7 allowlisted PR fixtures); security-check passed.
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/pull/117/checks

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-001 | Qoder fixture advertises supported from conformance_test and package binds | `npm test -- tests/apps/qoder-agent-host.test.ts` | local Node 24 | 34/34 pass | 34/34 pass | PASS |
| V2 | AC-002 | invalid/`$async:true`/oversized Schema fails preflight on all four Adapters | `npm run check` | local Node 24 | 895/895 pass | 895/895 pass | PASS |
| V3 | AC-003 | evidence separates fixtureConformant from liveQualified | `npm run check` governance:check | local Node 24 | passed | passed | PASS |
| V4 | AC-004 | required CI checks green on exact head | CI on this PR | GitHub Actions | all pass | pending run | NOT VERIFIED |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs.
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed.
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded.

Schema bytes stay in bounded stdin/context only; no argv/env/log/event exposure. No new tool, MCP, write, or network authority. Compatible with all Node 20/22/24 lanes and the published CLI surface.

## Known limitations

Live qualification against a real Qoder model process is not part of default CI; fixture conformance only, per AC-003.

## Risk and rollback

Fail-closed preflight for unverified Qoder versions is the intended behavior change. No data flow or release artifact change; revert is a branch revert.

## Product review handoff

- Merge ledger owner: @Bindy-lbb
- Product reviewer: @Bindy-lbb
- Milestone or release packet: N/A: host qualification PR with its own requirement issue.
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged