### PR TITLE
feat(host): harden qualification evidence lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
+- Adapter qualification kit 1.1.0 now gives every case one awaited, bounded
+  finalizer; teardown that cannot settle aborts the suite without emitting a
+  record. Typed filesystem/network/MCP denial codes replace generic failure evidence,
+  sentinel scans fail closed on accessors, Proxies, descriptor errors, and
+  budget exhaustion, and process cleanup is bound to the exact Adapter,
+  config/probe/version fingerprint, and verified child-to-grandchild lineage.
+  The v1 record validator retains the original 1.0.0 nine-case contract while
+  deriving all domain counts and axes exactly for both supported kit versions.
 - Qoder assistant text is now buffered until successful process and cleanup
   completion, then scrubbed as one value with the exact service credential.
   This prevents secrets split across native stream chunks from escaping in

--- a/apps/cli/reference-stdio-host.ts
+++ b/apps/cli/reference-stdio-host.ts
@@ -14,6 +14,16 @@ import {
 import type { AgentHostStdioRequest } from "../../packages/core/src/agent-host-stdio.js"
 import { CoreError } from "../../packages/core/src/contracts.js"
 import {
+  ADAPTER_QUALIFICATION_DRIVER_SCHEMA_ID,
+  QUALIFICATION_FILESYSTEM_DENIAL_CODE,
+  QUALIFICATION_MCP_DENIAL_CODE,
+  QUALIFICATION_NETWORK_DENIAL_CODE,
+} from "../../packages/core/src/adapter-qualification.js"
+import type {
+  QualificationDriverOperation,
+  QualificationProcessTreeScenario,
+} from "../../packages/core/src/adapter-qualification.js"
+import {
   MCP_CONFORMANCE_CODES,
   SYNTHETIC_DOC_SERVER,
   SYNTHETIC_MEM_SERVER,
@@ -117,6 +127,80 @@ interface SyntheticRunPayload {
   metadata?: Record<string, unknown>
   policy?: { tools?: { allow?: Array<{ name: string; mode: string }> } }
   workingDirectory?: string
+}
+
+function qualificationOperation(
+  payload: { metadata?: Record<string, unknown> },
+): QualificationDriverOperation | undefined {
+  if (!envFlag("REFERENCE_STDIO_QUALIFICATION_MODE")) return undefined
+  const driver = payload.metadata?.adapterQualification
+  if (!driver || typeof driver !== "object" || Array.isArray(driver)) {
+    return undefined
+  }
+  const driverRecord = driver as Record<string, unknown>
+  if (
+    Object.keys(driverRecord).some(
+      (key) => key !== "schema" && key !== "operation",
+    ) ||
+    driverRecord.schema !== ADAPTER_QUALIFICATION_DRIVER_SCHEMA_ID ||
+    !driverRecord.operation ||
+    typeof driverRecord.operation !== "object" ||
+    Array.isArray(driverRecord.operation)
+  ) {
+    return undefined
+  }
+  const operation = driverRecord.operation as Record<string, unknown>
+  if (
+    operation.kind === "filesystem.write" &&
+    operation.path === "../qualification-denied/outside-scope" &&
+    Object.keys(operation).length === 2
+  ) {
+    return {
+      kind: "filesystem.write",
+      path: "../qualification-denied/outside-scope",
+    }
+  }
+  if (
+    operation.kind === "network.connect" &&
+    operation.url === "https://qualification.invalid/" &&
+    Object.keys(operation).length === 2
+  ) {
+    return {
+      kind: "network.connect",
+      url: "https://qualification.invalid/",
+    }
+  }
+  if (
+    operation.kind === "mcp.invoke" &&
+    operation.server === "qualification-denied" &&
+    operation.tool === "qualification.noop" &&
+    Object.keys(operation).length === 3
+  ) {
+    return {
+      kind: "mcp.invoke",
+      server: "qualification-denied",
+      tool: "qualification.noop",
+    }
+  }
+  if (
+    operation.kind === "lifecycle.wait_for_cancel" &&
+    Object.keys(operation).length === 1
+  ) {
+    return { kind: "lifecycle.wait_for_cancel" }
+  }
+  if (
+    operation.kind === "process_tree" &&
+    (operation.scenario === "normal" ||
+      operation.scenario === "timeout" ||
+      operation.scenario === "cancel") &&
+    Object.keys(operation).length === 2
+  ) {
+    return {
+      kind: "process_tree",
+      scenario: operation.scenario,
+    }
+  }
+  return undefined
 }
 
 function loadJsonFile(path: string | undefined): unknown {
@@ -227,20 +311,79 @@ export function serveReferenceStdioHost(): void {
   const lineReader = readline.createInterface({ input: process.stdin })
   let cancelledRunId: string | null = null
   let activeRun: { id: string; runId: string } | null = null
+  let descendantsReady: Promise<void> | undefined
+  const qualificationTrees = new Set<ReturnType<typeof spawn>>()
 
-  if (envFlag("REFERENCE_STDIO_SPAWN_CHILD")) {
-    // Same process group, unref'd and detached from stdio: it survives the
-    // host's own exit, so only a real process-tree cleanup can stop it.
-    const leaked = spawn(
+  const spawnQualificationTree = (
+    scenario: QualificationProcessTreeScenario,
+  ): void => {
+    const child = spawn(
       process.execPath,
-      ["-e", "setInterval(() => {}, 1000)"],
-      { stdio: "ignore" },
+      [
+        "-e",
+        [
+          'const { spawn } = require("node:child_process")',
+          'const grandchild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" })',
+          'process.stdout.write(String(grandchild.pid) + "\\n")',
+          "setInterval(() => {}, 1000)",
+        ].join(";"),
+      ],
+      { stdio: ["ignore", "pipe", "ignore"] },
     )
-    leaked.unref()
-    diagnostics(`spawned child pid ${leaked.pid ?? 0}`)
+    qualificationTrees.add(child)
+    child.once("exit", () => qualificationTrees.delete(child))
+    child.once("error", () => {
+      diagnostics(
+        `qualification process_tree ${scenario} child pid ${child.pid ?? 0} grandchild pid 0`,
+      )
+    })
+    child.stdout?.once("data", (chunk: Buffer) => {
+      diagnostics(
+        `qualification process_tree ${scenario} child pid ${child.pid ?? 0} grandchild pid ${Number(chunk.toString("utf8").trim())}`,
+      )
+    })
+    child.unref()
   }
 
-  lineReader.on("line", (line) => {
+  if (envFlag("REFERENCE_STDIO_SPAWN_CHILD")) {
+    // The child creates its own grandchild. Both inherit the reference host's
+    // process group and survive a leader-only exit, so qualification can prove
+    // that cleanup reaches two descendant generations.
+    const leaked = spawn(
+      process.execPath,
+      [
+        "-e",
+        [
+          'const { spawn } = require("node:child_process")',
+          'const grandchild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" })',
+          'process.stdout.write(String(grandchild.pid) + "\\n")',
+          "setInterval(() => {}, 1000)",
+        ].join(";"),
+      ],
+      { stdio: ["ignore", "pipe", "ignore"] },
+    )
+    descendantsReady = new Promise<void>((resolve) => {
+      if (!leaked.stdout) {
+        diagnostics(`spawned child pid ${leaked.pid ?? 0} grandchild pid 0`)
+        resolve()
+        return
+      }
+      leaked.stdout.once("data", (chunk: Buffer) => {
+        const grandchildPid = Number(chunk.toString("utf8").trim())
+        diagnostics(
+          `spawned child pid ${leaked.pid ?? 0} grandchild pid ${grandchildPid}`,
+        )
+        resolve()
+      })
+      leaked.once("error", () => {
+        diagnostics(`spawned child pid ${leaked.pid ?? 0} grandchild pid 0`)
+        resolve()
+      })
+    })
+    leaked.unref()
+  }
+
+  const handleLine = (line: string): void => {
     let request: AgentHostStdioRequest
     try {
       request = parseAgentHostStdioRequest(line)
@@ -277,10 +420,29 @@ export function serveReferenceStdioHost(): void {
         return
       }
       case "preflight": {
-        const payload = request.payload as { policy?: { filesystem?: { write?: string[] } } }
+        const payload = request.payload as {
+          runId?: string
+          policy?: { filesystem?: { write?: string[] } }
+          metadata?: Record<string, unknown>
+        }
+        const operation = qualificationOperation(payload)
+        if (operation?.kind === "filesystem.write") {
+          if (!envFlag("REFERENCE_STDIO_HOSTILE_WRITE_OK")) {
+            errorResponse(request.id, QUALIFICATION_FILESYSTEM_DENIAL_CODE)
+            return
+          }
+        }
         const writes = payload.policy?.filesystem?.write ?? []
         if (writes.length > 0 && !envFlag("REFERENCE_STDIO_HOSTILE_WRITE_OK")) {
           errorResponse(request.id, "agent_host_preflight_invalid")
+          return
+        }
+        if (operation?.kind === "network.connect") {
+          errorResponse(request.id, QUALIFICATION_NETWORK_DENIAL_CODE)
+          return
+        }
+        if (operation?.kind === "mcp.invoke") {
+          errorResponse(request.id, QUALIFICATION_MCP_DENIAL_CODE)
           return
         }
         successResponse(request.id, referenceStdioProbe())
@@ -310,10 +472,15 @@ export function serveReferenceStdioHost(): void {
         const payload = request.payload as {
           runId: string
           outputSchema?: unknown
+          metadata?: Record<string, unknown>
         }
+        const operation = qualificationOperation(payload)
         activeRun = { id: request.id, runId: payload.runId }
         diagnostics(`run started for ${payload.runId}`)
         event(request.id, payload.runId, { type: "run.started" })
+        if (operation?.kind === "process_tree") {
+          spawnQualificationTree(operation.scenario)
+        }
         if (envFlag("REFERENCE_STDIO_DISALLOWED_TOOL")) {
           event(request.id, payload.runId, {
             type: "tool.started",
@@ -321,7 +488,12 @@ export function serveReferenceStdioHost(): void {
             toolName: "shell",
           })
         }
-        if (envFlag("REFERENCE_STDIO_HANG")) {
+        if (
+          envFlag("REFERENCE_STDIO_HANG") ||
+          operation?.kind === "lifecycle.wait_for_cancel" ||
+          (operation?.kind === "process_tree" &&
+            operation.scenario !== "normal")
+        ) {
           return
         }
         if (cancelledRunId === payload.runId) {
@@ -385,6 +557,15 @@ export function serveReferenceStdioHost(): void {
       default:
         errorResponse(request.id, "agent_host_stdio_unknown_message")
     }
+  }
+  lineReader.on("line", (line) => {
+    if (!descendantsReady) {
+      handleLine(line)
+      return
+    }
+    // When the deterministic process-tree fixture is enabled, do not answer
+    // its probe until both descendant PIDs have been captured as evidence.
+    void descendantsReady.then(() => handleLine(line))
   })
   lineReader.on("close", () => {
     process.exit(0)

--- a/apps/cli/stdio-agent-host.ts
+++ b/apps/cli/stdio-agent-host.ts
@@ -70,6 +70,7 @@ export class ExternalStdioAgentHostAdapter implements AgentHostAdapter {
   readonly hostId: string
 
   private readonly config: StdioAdapterConfig
+  private readonly qualificationConfigurationDigest: string
   private child: ChildProcess | null = null
   private stdoutCarry = ""
   private stderrTail = ""
@@ -84,6 +85,25 @@ export class ExternalStdioAgentHostAdapter implements AgentHostAdapter {
   constructor(config: StdioAdapterConfig) {
     this.config = config
     this.hostId = config.hostId
+    this.qualificationConfigurationDigest = createHash("sha256")
+      .update(
+        JSON.stringify({
+          schema: config.schema,
+          hostId: config.hostId,
+          displayName: config.displayName,
+          executable: config.executable,
+          args: [...config.args],
+          digest: {
+            algorithm: config.digest.algorithm,
+            hex: config.digest.hex,
+          },
+          envAllowlist: [...config.envAllowlist],
+          workingDirectoryPolicy: config.workingDirectoryPolicy,
+          timeoutMs: config.timeoutMs,
+          maxStderrBytes: config.maxStderrBytes,
+        }),
+      )
+      .digest("hex")
   }
 
   /** Bounded stderr diagnostics tail; raw stderr is never surfaced unbounded. */
@@ -100,6 +120,23 @@ export class ExternalStdioAgentHostAdapter implements AgentHostAdapter {
     const payload = validateAgentHostRunRequestWire(this.wirePayload(request))
     const message = await this.exchange("preflight", payload)
     return probeResultFromStdioResponse(message, this.hostId)
+  }
+
+  async qualificationIdentity(): Promise<{
+    configurationDigest: string
+    ownerPid: number
+  }> {
+    const child = await this.ensureChild()
+    if (child.pid === undefined) {
+      throw stdioError(
+        STDIO_CODES.spawnFailed,
+        "stdio adapter process has no qualification owner pid",
+      )
+    }
+    return {
+      configurationDigest: this.qualificationConfigurationDigest,
+      ownerPid: child.pid,
+    }
   }
 
   async *run(request: AgentHostRunRequest): AsyncGenerator<AgentHostEvent> {

--- a/docs/adapter-qualification.md
+++ b/docs/adapter-qualification.md
@@ -1,0 +1,100 @@
+# Adapter qualification
+
+`runQualificationSuite` produces an `adapter-qualification-record.v1` record
+from repository-owned, offline evidence. Kit version `1.1.0` hardens every
+case with a wall-clock bound and requires direct evidence for cancellation,
+default-deny policy enforcement, secret handling, and process-tree cleanup.
+
+Qualification does not discover, install, or trust an Adapter. The caller
+registers the Adapter and supplies a working directory plus a deterministic
+process fixture:
+
+```ts
+const record = await runQualificationSuite(adapter, {
+  workingDirectory,
+  generatedAt: new Date().toISOString(),
+  caseTimeoutMs: 30_000,
+  processTreeFixture,
+})
+```
+
+`caseTimeoutMs` defaults to 30 seconds and must be an integer from 1,000 to
+600,000 milliseconds. The bound is applied independently to each case. Every
+value, error, overflow, and timeout goes through one awaited finalizer: abort
+the case, await cancellation on the exact Adapter that owns each run, then
+await iterator return and fixture disposal. A hung body that responds to abort
+records `qualification_case_timeout` and the next case may run only after
+teardown settles. If teardown itself does not settle within its separate
+bounded grace, the entire suite fails with `QUALIFICATION_CLEANUP_TIMEOUT` and
+does not emit a record.
+
+## Evidence matrix
+
+The record contains 13 cases across the existing nine domains:
+
+| Domain | Case | Required evidence |
+| --- | --- | --- |
+| `capability_negotiation` | `probe_contract` | A complete `agent-host.v1` probe for the registered host. `capabilitySource` is exactly `adapter_declaration` or `conformance_test`; `version` is non-empty and at most 256 characters. |
+| `native_event_validation` | `events_well_formed` | Every native event validates and the bounded stream closes. |
+| `single_terminal_outcome` | `exactly_one_terminal` | Exactly one terminal event is last. |
+| `deadline_cancel` | `cancel_stops_active_run` | The kit observes `run.started`, then calls `cancel`, then observes exactly one final `run.failed` and no later event. |
+| `process_tree_cleanup` | `descendants_disposed_normal` | A real child and its real grandchild are alive during a normally completing run and absent after fixture disposal. |
+| `process_tree_cleanup` | `descendants_disposed_timeout` | The same two-generation evidence is collected for a run that stays active until its deadline and is cancelled. |
+| `process_tree_cleanup` | `descendants_disposed_cancel` | The same two-generation evidence is collected for an explicitly cancelled active run. |
+| `credential_boundaries` | `no_metadata_echo` | A sentinel placed in request metadata is absent from events, partial streams, malformed values, rejected promises, thrown errors, and the final record. |
+| `filesystem_network_enforcement` | `hostile_write_refused` | The typed `filesystem.write` qualification operation is rejected with `qualification_filesystem_policy_denied` during preflight or after `run.started` in one final `run.failed`. |
+| `filesystem_network_enforcement` | `network_deny_refused` | The typed `network.connect` qualification operation is rejected with `qualification_network_policy_denied` during preflight or after `run.started` in one final `run.failed`. |
+| `tool_mcp_enforcement` | `tool_allowlist_respected` | No event reports a tool outside the frozen allowlist. |
+| `tool_mcp_enforcement` | `mcp_deny_refused` | The typed `mcp.invoke` qualification operation is rejected with `qualification_mcp_policy_denied` during preflight or after `run.started` in one final `run.failed`. |
+| `output_schema` | `terminal_output_matches_schema` | The terminal output matches the requested closed schema. |
+
+The sentinel scanner is bounded and cycle-safe. It inspects string and symbol
+data properties without invoking getters or custom serializers. Accessors,
+Proxies, descriptor failures, and budget exhaustion produce an `incomplete`
+scan and fail closed; a sentinel produces `detected`. Teardown errors are
+awaited and scanned before another case or a record is allowed. The same scan
+is applied before externally supplied records are read. Evidence records
+contain only the frozen machine-readable fields; diagnostics, raw exceptions,
+paths, credentials, and process IDs are never copied into the record.
+
+## Process-tree fixture contract
+
+`processTreeFixture.create(scenario)` must return the exact process-backed
+Adapter instance being qualified. The Adapter exposes an opaque configuration
+digest and real owner PID through `qualificationIdentity()`; the kit rechecks
+that identity plus the original probe fingerprint and Host version for every
+scenario. `descendants()` returns the PID of a real child and that child's real
+grandchild. The kit independently verifies their parent relationship, process
+group, start identities, and liveness. Both PIDs must be absent after the
+fixture's idempotent, awaited `dispose()` finishes.
+
+The kit invokes the fixture separately for `normal`, `timeout`, and `cancel`.
+If the fixture is missing, malformed, substitutes another Adapter, drifts its
+probe/configuration/version, supplies unrelated PIDs, or leaves either
+descendant alive, all affected cleanup evidence fails closed. Synthetic PID
+claims and leader-only cleanup cannot earn `fixtureConformant`.
+
+The reference implementation is exercised in
+`tests/apps/stdio-agent-host.test.ts`; the in-memory protocol fixture is
+exercised in `tests/core/adapter-qualification.test.ts`.
+
+## Evidence axes
+
+- `implemented` requires the exact probe contract and canonical capability
+  source.
+- `fixtureConformant` requires `implemented` and every deterministic case to
+  pass.
+- `liveQualified` is false unless the caller explicitly supplies validated,
+  digest-addressed `liveEvidence`.
+
+The kit never calls a live model or provider itself. Fixture conformance is
+not vendor certification, entitlement validation, or a commercial deployment
+gate.
+
+## Record compatibility
+
+New runs always emit kit `1.1.0` with the 13-case contract above. The v1 record
+validator also accepts kit `1.0.0` under its original nine-case contract
+(`cancel_stops_run` and `stream_terminates`). For either version it rejects
+missing, extra, duplicated, or cross-domain cases and recomputes every domain
+count and evidence axis from the cases and optional live evidence.

--- a/docs/agent-host-stdio.md
+++ b/docs/agent-host-stdio.md
@@ -71,8 +71,11 @@ fail-closed paths are reproducible in CI.
 ## Qualification
 
 An Adapter cannot be reported as supported on fixture evidence alone: run the
-Issue #30 qualification kit against it to produce an
+Issue #52 qualification kit against it to produce an
 `adapter-qualification-record.v1` record
-(`tests/apps/stdio-agent-host.test.ts` shows the integration).
+(`tests/apps/stdio-agent-host.test.ts` shows the integration). The complete
+case matrix, timeout bounds, direct deny evidence, and real two-generation
+cleanup fixture contract are documented in
+[`adapter-qualification.md`](adapter-qualification.md).
 
 Stdio isolation is a process boundary, not a multi-tenant sandbox.

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -33,6 +33,7 @@ export type {
   AgentHostPolicy,
   AgentHostProbeResult,
   AgentHostProbeStatus,
+  AgentHostQualificationIdentity,
   AgentHostRequirements,
   AgentHostRunRequest,
 } from "./src/agent-host.js"
@@ -97,19 +98,35 @@ export type {
 } from "./src/runner-protocol-vectors.js"
 export {
   ADAPTER_QUALIFICATION_KIT_VERSION,
+  ADAPTER_QUALIFICATION_DRIVER_SCHEMA_ID,
   ADAPTER_QUALIFICATION_SCHEMA_ID,
+  DEFAULT_QUALIFICATION_CASE_TIMEOUT_MS,
+  LEGACY_ADAPTER_QUALIFICATION_KIT_VERSION,
+  MAX_QUALIFICATION_CASE_TIMEOUT_MS,
+  MIN_QUALIFICATION_CASE_TIMEOUT_MS,
+  QUALIFICATION_CAPABILITY_SOURCES,
   QUALIFICATION_DOMAINS,
+  QUALIFICATION_FILESYSTEM_DENIAL_CODE,
+  QUALIFICATION_MCP_DENIAL_CODE,
+  QUALIFICATION_NETWORK_DENIAL_CODE,
   canonicalPolicyDigest,
   runQualificationSuite,
   validateAdapterQualificationRecord,
 } from "./src/adapter-qualification.js"
 export type {
   AdapterQualificationRecord,
+  AdapterQualificationKitVersion,
   QualificationAxes,
   QualificationCaseResult,
   QualificationDomain,
+  QualificationDriverMetadata,
+  QualificationDriverOperation,
   QualificationLiveEvidence,
   QualificationOptions,
+  QualificationProcessTreeDescendants,
+  QualificationProcessTreeFixture,
+  QualificationProcessTreeFixtureInstance,
+  QualificationProcessTreeScenario,
 } from "./src/adapter-qualification.js"
 export {
   AGENT_HOST_STDIO_CONFIG_SCHEMA_VERSION,

--- a/packages/core/src/adapter-qualification.ts
+++ b/packages/core/src/adapter-qualification.ts
@@ -1,4 +1,6 @@
+import { execFile } from "node:child_process"
 import { createHash } from "node:crypto"
+import { promisify, types as utilTypes } from "node:util"
 
 import {
   AGENT_HOST_CAPABILITIES,
@@ -9,15 +11,34 @@ import type {
   AgentHostEvent,
   AgentHostPolicy,
   AgentHostProbeResult,
+  AgentHostQualificationIdentity,
   AgentHostRunRequest,
 } from "./agent-host.js"
 import { CoreError } from "./contracts.js"
-import type { SafeValue } from "./contracts.js"
 
 export const ADAPTER_QUALIFICATION_SCHEMA_ID =
   "adapter-qualification-record.v1" as const
 
-export const ADAPTER_QUALIFICATION_KIT_VERSION = "1.0.0" as const
+export const ADAPTER_QUALIFICATION_KIT_VERSION = "1.1.0" as const
+export const LEGACY_ADAPTER_QUALIFICATION_KIT_VERSION = "1.0.0" as const
+
+export const ADAPTER_QUALIFICATION_DRIVER_SCHEMA_ID =
+  "adapter-qualification-driver.v1" as const
+export const QUALIFICATION_FILESYSTEM_DENIAL_CODE =
+  "qualification_filesystem_policy_denied" as const
+export const QUALIFICATION_NETWORK_DENIAL_CODE =
+  "qualification_network_policy_denied" as const
+export const QUALIFICATION_MCP_DENIAL_CODE =
+  "qualification_mcp_policy_denied" as const
+
+export const DEFAULT_QUALIFICATION_CASE_TIMEOUT_MS = 30_000
+export const MIN_QUALIFICATION_CASE_TIMEOUT_MS = 1_000
+export const MAX_QUALIFICATION_CASE_TIMEOUT_MS = 600_000
+
+export const QUALIFICATION_CAPABILITY_SOURCES = [
+  "adapter_declaration",
+  "conformance_test",
+] as const
 
 export const QUALIFICATION_DOMAINS = [
   "capability_negotiation",
@@ -32,6 +53,63 @@ export const QUALIFICATION_DOMAINS = [
 ] as const
 
 export type QualificationDomain = (typeof QUALIFICATION_DOMAINS)[number]
+
+const LEGACY_QUALIFICATION_CASE_CONTRACT = [
+  ["capability_negotiation", "probe_contract"],
+  ["native_event_validation", "events_well_formed"],
+  ["single_terminal_outcome", "exactly_one_terminal"],
+  ["deadline_cancel", "cancel_stops_run"],
+  ["process_tree_cleanup", "stream_terminates"],
+  ["credential_boundaries", "no_metadata_echo"],
+  ["filesystem_network_enforcement", "hostile_write_refused"],
+  ["tool_mcp_enforcement", "tool_allowlist_respected"],
+  ["output_schema", "terminal_output_matches_schema"],
+] as const satisfies readonly (readonly [QualificationDomain, string])[]
+
+const CURRENT_QUALIFICATION_CASE_CONTRACT = [
+  ["capability_negotiation", "probe_contract"],
+  ["native_event_validation", "events_well_formed"],
+  ["single_terminal_outcome", "exactly_one_terminal"],
+  ["deadline_cancel", "cancel_stops_active_run"],
+  ["process_tree_cleanup", "descendants_disposed_normal"],
+  ["process_tree_cleanup", "descendants_disposed_timeout"],
+  ["process_tree_cleanup", "descendants_disposed_cancel"],
+  ["credential_boundaries", "no_metadata_echo"],
+  ["filesystem_network_enforcement", "hostile_write_refused"],
+  ["filesystem_network_enforcement", "network_deny_refused"],
+  ["tool_mcp_enforcement", "tool_allowlist_respected"],
+  ["tool_mcp_enforcement", "mcp_deny_refused"],
+  ["output_schema", "terminal_output_matches_schema"],
+] as const satisfies readonly (readonly [QualificationDomain, string])[]
+
+export type AdapterQualificationKitVersion =
+  | typeof LEGACY_ADAPTER_QUALIFICATION_KIT_VERSION
+  | typeof ADAPTER_QUALIFICATION_KIT_VERSION
+
+export type QualificationDriverOperation =
+  | {
+      kind: "filesystem.write"
+      path: "../qualification-denied/outside-scope"
+    }
+  | {
+      kind: "network.connect"
+      url: "https://qualification.invalid/"
+    }
+  | {
+      kind: "mcp.invoke"
+      server: "qualification-denied"
+      tool: "qualification.noop"
+    }
+  | { kind: "lifecycle.wait_for_cancel" }
+  | {
+      kind: "process_tree"
+      scenario: QualificationProcessTreeScenario
+    }
+
+export interface QualificationDriverMetadata {
+  schema: typeof ADAPTER_QUALIFICATION_DRIVER_SCHEMA_ID
+  operation: QualificationDriverOperation
+}
 
 export interface QualificationCaseResult {
   domain: QualificationDomain
@@ -52,12 +130,39 @@ export interface QualificationLiveEvidence {
   evidenceDigest: string
 }
 
+export type QualificationProcessTreeScenario =
+  | "normal"
+  | "timeout"
+  | "cancel"
+
+export interface QualificationProcessTreeDescendants {
+  childPid: number
+  grandchildPid: number
+}
+
+/**
+ * One deterministic, disposable process-backed fixture. It must return the
+ * exact Adapter instance being qualified; only its descendants are disposed.
+ * PIDs are inspected in memory only and never enter the qualification record.
+ */
+export interface QualificationProcessTreeFixtureInstance {
+  adapter: AgentHostAdapter
+  descendants(): Promise<QualificationProcessTreeDescendants>
+  dispose(): Promise<void>
+}
+
+export interface QualificationProcessTreeFixture {
+  create(
+    scenario: QualificationProcessTreeScenario,
+  ): Promise<QualificationProcessTreeFixtureInstance>
+}
+
 export interface AdapterQualificationRecord {
   schema: typeof ADAPTER_QUALIFICATION_SCHEMA_ID
   hostId: string
   hostVersion: string
   policyDigest: string
-  kitVersion: typeof ADAPTER_QUALIFICATION_KIT_VERSION
+  kitVersion: AdapterQualificationKitVersion
   generatedAt: string
   axes: QualificationAxes
   domains: Record<QualificationDomain, { passed: number; failed: number }>
@@ -69,6 +174,13 @@ export interface QualificationOptions {
   workingDirectory: string
   generatedAt: string
   requiredCapabilities?: readonly string[]
+  /** Per-case wall clock bound. Defaults to 30 seconds. */
+  caseTimeoutMs?: number
+  /**
+   * Required for truthful process_tree_cleanup evidence. Without a real
+   * process-backed fixture, all cleanup scenarios fail closed.
+   */
+  processTreeFixture?: QualificationProcessTreeFixture
   /**
    * Explicit opt-in live evidence. Without it the live axis stays false and
    * no provider call is ever made by the kit.
@@ -79,8 +191,18 @@ export interface QualificationOptions {
 const HOST_ID_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$/
 const HEX_64_PATTERN = /^[0-9a-f]{64}$/
 const CASE_ID_PATTERN = /^[a-z0-9]+(?:_[a-z0-9]+)*$/
+const CASE_CODE_PATTERN = /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/
 const ENVIRONMENT_ID_PATTERN = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/
 const ISO_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/
+const CAPABILITY_SOURCE_SET = new Set<string>(
+  QUALIFICATION_CAPABILITY_SOURCES,
+)
+const CAPABILITY_SUPPORT_SET = new Set([
+  "supported",
+  "documented",
+  "unsupported",
+  "unknown",
+])
 
 function qualificationError(
   code: string,
@@ -123,37 +245,394 @@ function defaultQualificationPolicy(): AgentHostPolicy {
   }
 }
 
+const QUALIFICATION_SENTINEL = "qualification-sentinel-do-not-leak"
+
+const QUALIFICATION_SCAN_BUDGET = 4_096
+const MAX_QUALIFICATION_CLEANUP_GRACE_MS = 5_000
+const execFileAsync = promisify(execFile)
+
+const NATIVE_ERROR_STACK_ACCESSOR_DESCRIPTORS = [
+  new Error("qualification native stack probe"),
+  new EvalError("qualification native stack probe"),
+  new RangeError("qualification native stack probe"),
+  new ReferenceError("qualification native stack probe"),
+  new SyntaxError("qualification native stack probe"),
+  new TypeError("qualification native stack probe"),
+  new URIError("qualification native stack probe"),
+  new AggregateError([], "qualification native stack probe"),
+]
+  .map((error) => Object.getOwnPropertyDescriptor(error, "stack"))
+  .filter(
+    (descriptor): descriptor is PropertyDescriptor =>
+      descriptor !== undefined &&
+      (typeof descriptor.get === "function" ||
+        typeof descriptor.set === "function"),
+  )
+
+function isNativeErrorStackAccessor(
+  key: PropertyKey,
+  descriptor: PropertyDescriptor,
+): boolean {
+  if (key !== "stack" || descriptor.enumerable !== false) return false
+  return NATIVE_ERROR_STACK_ACCESSOR_DESCRIPTORS.some(
+    (nativeDescriptor) =>
+      descriptor.get === nativeDescriptor.get &&
+      descriptor.set === nativeDescriptor.set &&
+      descriptor.enumerable === nativeDescriptor.enumerable &&
+      descriptor.configurable === nativeDescriptor.configurable,
+  )
+}
+
+type QualificationScanState = "clean" | "detected" | "incomplete"
+
+class QualificationSentinelScanner {
+  state: QualificationScanState = "clean"
+
+  get detected(): boolean {
+    return this.state === "detected"
+  }
+
+  get incomplete(): boolean {
+    return this.state === "incomplete"
+  }
+
+  private markIncomplete(_reason: string): void {
+    if (this.state !== "clean") return
+    this.state = "incomplete"
+  }
+
+  observe(value: unknown): void {
+    if (this.detected) return
+    const seen = new Set<object>()
+    const pending: unknown[] = [value]
+    let inspected = 0
+    while (pending.length > 0) {
+      if (inspected >= QUALIFICATION_SCAN_BUDGET) {
+        this.markIncomplete("budget")
+        return
+      }
+      inspected += 1
+      const entry = pending.pop()
+      if (typeof entry === "string") {
+        if (entry.includes(QUALIFICATION_SENTINEL)) {
+          this.state = "detected"
+          return
+        }
+        continue
+      }
+      if (
+        entry === null ||
+        (typeof entry !== "object" && typeof entry !== "function")
+      ) {
+        continue
+      }
+      const object = entry as object
+      if (seen.has(object)) continue
+      seen.add(object)
+      if (utilTypes.isProxy(object)) {
+        this.markIncomplete("proxy")
+        continue
+      }
+      try {
+        const keys = Reflect.ownKeys(object)
+        for (const key of keys) {
+          const descriptor = Object.getOwnPropertyDescriptor(object, key)
+          if (descriptor === undefined) {
+            this.markIncomplete("missing descriptor")
+            continue
+          }
+          if ("get" in descriptor || "set" in descriptor) {
+            // Supported V8 releases install one shared lazy stack accessor.
+            // Match the accessor functions captured from native Errors in this
+            // realm; merely being an Error is not enough because callers can
+            // replace `stack` with an arbitrary getter. Never invoke either.
+            if (isNativeErrorStackAccessor(key, descriptor)) {
+              continue
+            }
+            this.markIncomplete(`accessor ${String(key)}`)
+            continue
+          }
+          if (typeof key === "string" && key.includes(QUALIFICATION_SENTINEL)) {
+            this.state = "detected"
+            return
+          }
+          if (
+            typeof key === "symbol" &&
+            (key.description ?? "").includes(QUALIFICATION_SENTINEL)
+          ) {
+            this.state = "detected"
+            return
+          }
+          pending.push(descriptor.value)
+        }
+      } catch {
+        // Never invoke accessors or custom serializers. Opaque values cannot
+        // be proven clean and therefore fail closed.
+        this.markIncomplete("descriptor inspection threw")
+      }
+    }
+  }
+}
+
+interface TrackedQualificationRun {
+  ownerAdapter: AgentHostAdapter
+  runId: string
+  cancelAttempted: boolean
+}
+
+interface QualificationCaseContext {
+  readonly signal: AbortSignal
+  readonly deadline: string
+  readonly scanner: QualificationSentinelScanner
+  remainingMs(): number
+  abort(): void
+  trackRun(ownerAdapter: AgentHostAdapter, runId: string): void
+  cancelRun(ownerAdapter: AgentHostAdapter, runId: string): Promise<void>
+  registerCleanup(cleanup: () => Promise<void> | void): void
+}
+
+type BoundedOutcome<T> =
+  | { kind: "value"; value: T }
+  | { kind: "error"; error: unknown }
+  | { kind: "timeout" }
+
+type QualificationExecutionOutcome<T> = Exclude<
+  BoundedOutcome<T>,
+  { kind: "timeout" }
+>
+
+async function runBoundedCase<T>(
+  caseTimeoutMs: number,
+  scanner: QualificationSentinelScanner,
+  fallback: (code: string) => T,
+  body: (context: QualificationCaseContext) => Promise<T>,
+): Promise<T> {
+  const startedAt = Date.now()
+  const deadlineAt = startedAt + caseTimeoutMs
+  const controller = new AbortController()
+  const trackedRuns: TrackedQualificationRun[] = []
+  const cleanups: Array<() => Promise<void> | void> = []
+  const findRun = (ownerAdapter: AgentHostAdapter, runId: string) =>
+    trackedRuns.find(
+      (entry) => entry.ownerAdapter === ownerAdapter && entry.runId === runId,
+    )
+  const context: QualificationCaseContext = {
+    signal: controller.signal,
+    deadline: new Date(deadlineAt).toISOString(),
+    scanner,
+    remainingMs: () => Math.max(0, deadlineAt - Date.now()),
+    abort: () => controller.abort(),
+    trackRun: (ownerAdapter, runId) => {
+      if (!findRun(ownerAdapter, runId)) {
+        trackedRuns.push({ ownerAdapter, runId, cancelAttempted: false })
+      }
+    },
+    cancelRun: async (ownerAdapter, runId) => {
+      let tracked = findRun(ownerAdapter, runId)
+      if (!tracked) {
+        tracked = { ownerAdapter, runId, cancelAttempted: false }
+        trackedRuns.push(tracked)
+      }
+      if (tracked.cancelAttempted) return
+      tracked.cancelAttempted = true
+      await ownerAdapter.cancel?.(runId)
+    },
+    registerCleanup: (cleanup) => cleanups.push(cleanup),
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<BoundedOutcome<T>>((resolve) => {
+    timer = setTimeout(() => resolve({ kind: "timeout" }), caseTimeoutMs)
+  })
+  const execution = Promise.resolve()
+    .then(() => body(context))
+    .then<QualificationExecutionOutcome<T>, QualificationExecutionOutcome<T>>(
+      (value) => ({ kind: "value", value }),
+      (error: unknown) => {
+        scanner.observe(error)
+        return { kind: "error", error }
+      },
+    )
+  const outcome = await Promise.race([execution, timeout])
+  if (timer !== undefined) clearTimeout(timer)
+  const cleanupErrors: unknown[] = []
+  const cleanupPromises = new Map<
+    () => Promise<void> | void,
+    Promise<void>
+  >()
+  const invokeCleanup = (
+    cleanup: () => Promise<void> | void,
+  ): Promise<void> => {
+    let promise = cleanupPromises.get(cleanup)
+    if (!promise) {
+      try {
+        promise = Promise.resolve(cleanup()).catch((error: unknown) => {
+          cleanupErrors.push(error)
+          scanner.observe(error)
+        })
+      } catch (error) {
+        cleanupErrors.push(error)
+        scanner.observe(error)
+        promise = Promise.resolve()
+      }
+      cleanupPromises.set(cleanup, promise)
+    }
+    return promise
+  }
+  let settledExecution = outcome.kind === "timeout" ? undefined : outcome
+  const finalizer = async (): Promise<void> => {
+    controller.abort()
+    const processedRuns = new Set<TrackedQualificationRun>()
+    const processedCleanups = new Set<() => Promise<void> | void>()
+    while (true) {
+      const pendingRuns = trackedRuns.filter(
+        (entry) => !processedRuns.has(entry),
+      )
+      for (const tracked of pendingRuns) {
+        processedRuns.add(tracked)
+        if (tracked.cancelAttempted || !tracked.ownerAdapter.cancel) continue
+        tracked.cancelAttempted = true
+        try {
+          await tracked.ownerAdapter.cancel(tracked.runId)
+        } catch (error) {
+          cleanupErrors.push(error)
+          scanner.observe(error)
+        }
+      }
+
+      const pendingCleanups = cleanups
+        .filter((cleanup) => !processedCleanups.has(cleanup))
+        .reverse()
+      for (const cleanup of pendingCleanups) {
+        processedCleanups.add(cleanup)
+        await invokeCleanup(cleanup)
+      }
+
+      if (settledExecution === undefined) {
+        settledExecution = await execution
+        continue
+      }
+      if (
+        trackedRuns.every((entry) => processedRuns.has(entry)) &&
+        cleanups.every((cleanup) => processedCleanups.has(cleanup))
+      ) {
+        return
+      }
+    }
+  }
+  const cleanupGraceMs = Math.min(
+    caseTimeoutMs,
+    MAX_QUALIFICATION_CLEANUP_GRACE_MS,
+  )
+  let cleanupTimer: ReturnType<typeof setTimeout> | undefined
+  const cleanupTimeout = new Promise<"timeout">((resolve) => {
+    cleanupTimer = setTimeout(() => resolve("timeout"), cleanupGraceMs)
+    cleanupTimer.unref?.()
+  })
+  const cleanupOutcome = await Promise.race([
+    finalizer().then(() => "settled" as const),
+    cleanupTimeout,
+  ])
+  if (cleanupTimer !== undefined) clearTimeout(cleanupTimer)
+  if (cleanupOutcome === "timeout") {
+    // A stuck cancel/return must not prevent process isolation. Invoke every
+    // registered cleanup exactly once and give that emergency recovery its
+    // own bounded grace before failing the entire suite.
+    let isolationTimer: ReturnType<typeof setTimeout> | undefined
+    const isolationTimeout = new Promise<void>((resolve) => {
+      isolationTimer = setTimeout(resolve, cleanupGraceMs)
+      isolationTimer.unref?.()
+    })
+    await Promise.race([
+      Promise.all(cleanups.slice().reverse().map(invokeCleanup)).then(
+        () => undefined,
+      ),
+      isolationTimeout,
+    ])
+    if (isolationTimer !== undefined) clearTimeout(isolationTimer)
+    throw qualificationError(
+      "QUALIFICATION_CLEANUP_TIMEOUT",
+      "qualification case cleanup did not settle within the bounded grace period",
+    )
+  }
+  if (settledExecution?.kind === "error") {
+    scanner.observe(settledExecution.error)
+  }
+  for (const error of cleanupErrors) scanner.observe(error)
+  if (cleanupErrors.length > 0) {
+    return fallback("qualification_cleanup_failed")
+  }
+  if (outcome.kind === "error") {
+    return fallback("qualification_case_unavailable")
+  }
+  if (outcome.kind === "timeout") {
+    return fallback("qualification_case_timeout")
+  }
+  return outcome.value
+}
+
 function qualificationRequest(
+  ownerAdapter: AgentHostAdapter,
   caseId: string,
   workingDirectory: string,
   policy: AgentHostPolicy,
-  outputSchema?: SafeValue,
+  context: QualificationCaseContext,
+  overrides: Partial<AgentHostRunRequest> = {},
 ): AgentHostRunRequest {
+  const runId = `qualification-${caseId}`
+  context.trackRun(ownerAdapter, runId)
   return {
-    runId: `qualification-${caseId}`,
+    runId,
     employeeId: "qualification-employee",
     workingDirectory,
     prompt: `qualification case ${caseId}`,
     policy,
-    ...(outputSchema ? { outputSchema } : {}),
+    deadline: context.deadline,
+    signal: context.signal,
+    ...overrides,
+  }
+}
+
+interface CollectedEvents {
+  events: AgentHostEvent[]
+  failed: boolean
+  overflow: boolean
+}
+
+async function collectFromIterator(
+  iterator: AsyncIterator<AgentHostEvent>,
+  context: QualificationCaseContext,
+  initial: AgentHostEvent[] = [],
+): Promise<CollectedEvents> {
+  const events = [...initial]
+  try {
+    while (true) {
+      const next = await iterator.next()
+      if (next.done) return { events, failed: false, overflow: false }
+      context.scanner.observe(next.value)
+      if (context.scanner.incomplete) {
+        return { events, failed: true, overflow: false }
+      }
+      events.push(next.value)
+      if (events.length > 256) {
+        return { events, failed: true, overflow: true }
+      }
+    }
+  } catch (error) {
+    context.scanner.observe(error)
+    return { events, failed: true, overflow: false }
   }
 }
 
 async function collectEvents(
   adapter: AgentHostAdapter,
   request: AgentHostRunRequest,
-): Promise<AgentHostEvent[]> {
-  const events: AgentHostEvent[] = []
-  for await (const event of adapter.run(request)) {
-    events.push(event)
-    if (events.length > 256) {
-      throw qualificationError(
-        "qualification_event_overflow",
-        "adapter emitted more than 256 events for one qualification case",
-      )
-    }
-  }
-  return events
+  context: QualificationCaseContext,
+): Promise<CollectedEvents> {
+  const iterator = adapter.run(request)[Symbol.asyncIterator]()
+  context.registerCleanup(async () => {
+    await iterator.return?.()
+  })
+  return await collectFromIterator(iterator, context)
 }
 
 const KNOWN_EVENT_TYPES = new Set([
@@ -167,8 +646,19 @@ const KNOWN_EVENT_TYPES = new Set([
   "run.failed",
 ])
 
-function isTerminal(event: AgentHostEvent): boolean {
-  return event.type === "run.completed" || event.type === "run.failed"
+function eventRecord(event: unknown): Record<string, unknown> | undefined {
+  return event && typeof event === "object" && !Array.isArray(event)
+    ? (event as Record<string, unknown>)
+    : undefined
+}
+
+function eventType(event: unknown): unknown {
+  return eventRecord(event)?.type
+}
+
+function isTerminal(event: unknown): event is AgentHostEvent {
+  const type = eventType(event)
+  return type === "run.completed" || type === "run.failed"
 }
 
 function caseResult(
@@ -180,96 +670,157 @@ function caseResult(
   return { domain, id, passed, code }
 }
 
+function validHostVersion(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= 256
+}
+
+function probeContractValid(
+  probe: unknown,
+  expectedHostId: string,
+): probe is AgentHostProbeResult {
+  const record = eventRecord(probe)
+  if (!record) return false
+  const capabilities = eventRecord(record.capabilities)
+  return (
+    record.protocolVersion === AGENT_HOST_PROTOCOL_VERSION &&
+    record.hostId === expectedHostId &&
+    record.status === "ready" &&
+    record.available === true &&
+    record.adapterStatus === "runnable" &&
+    validHostVersion(record.version) &&
+    typeof record.capabilitySource === "string" &&
+    CAPABILITY_SOURCE_SET.has(record.capabilitySource) &&
+    capabilities !== undefined &&
+    AGENT_HOST_CAPABILITIES.every((capability) =>
+      CAPABILITY_SUPPORT_SET.has(capabilities[capability] as string),
+    )
+  )
+}
+
+interface CapabilityCaseOutcome {
+  result: QualificationCaseResult
+  probe?: AgentHostProbeResult
+  probeFingerprint?: string
+  hostVersion?: string
+  identity?: AgentHostQualificationIdentity
+}
+
 async function runCapabilityCase(
   adapter: AgentHostAdapter,
-): Promise<QualificationCaseResult> {
+  context: QualificationCaseContext,
+): Promise<CapabilityCaseOutcome> {
   let probe: AgentHostProbeResult
   try {
     probe = await adapter.probe()
-  } catch {
-    return caseResult(
+    context.scanner.observe(probe)
+    if (context.scanner.incomplete) {
+      return {
+        result: caseResult(
+          "capability_negotiation",
+          "probe_contract",
+          false,
+          "qualification_evidence_scan_incomplete",
+        ),
+      }
+    }
+  } catch (error) {
+    context.scanner.observe(error)
+    return {
+      result: caseResult(
+        "capability_negotiation",
+        "probe_contract",
+        false,
+        "probe_unavailable",
+      ),
+    }
+  }
+  const passed = probeContractValid(probe, adapter.hostId)
+  let identity: AgentHostQualificationIdentity | undefined
+  if (typeof adapter.qualificationIdentity === "function") {
+    try {
+      const candidate = await adapter.qualificationIdentity()
+      context.scanner.observe(candidate)
+      if (
+        !context.scanner.incomplete &&
+        typeof candidate.configurationDigest === "string" &&
+        HEX_64_PATTERN.test(candidate.configurationDigest) &&
+        Number.isSafeInteger(candidate.ownerPid) &&
+        candidate.ownerPid > 0
+      ) {
+        identity = {
+          configurationDigest: candidate.configurationDigest,
+          ownerPid: candidate.ownerPid,
+        }
+      }
+    } catch (error) {
+      context.scanner.observe(error)
+    }
+  }
+  return {
+    result: caseResult(
       "capability_negotiation",
       "probe_contract",
-      false,
-      "probe_unavailable",
-    )
+      passed,
+      passed ? "probe_contract_ok" : "probe_contract_violation",
+    ),
+    probe,
+    probeFingerprint: qualificationProbeFingerprint(probe),
+    hostVersion: probe.version,
+    identity,
   }
-  const complete = AGENT_HOST_CAPABILITIES.every(
-    (capability) => probe.capabilities[capability] !== undefined,
-  )
-  const passed =
-    probe.protocolVersion === AGENT_HOST_PROTOCOL_VERSION &&
-    probe.status === "ready" &&
-    probe.available &&
-    probe.adapterStatus === "runnable" &&
-    (probe.capabilitySource === "conformance_test" ||
-      probe.capabilitySource === "adapter_declaration") &&
-    complete
-  return caseResult(
-    "capability_negotiation",
-    "probe_contract",
-    passed,
-    passed ? "probe_contract_ok" : "probe_contract_violation",
-  )
 }
 
 async function runEventCases(
   adapter: AgentHostAdapter,
   workingDirectory: string,
   policy: AgentHostPolicy,
+  context: QualificationCaseContext,
 ): Promise<QualificationCaseResult[]> {
-  const results: QualificationCaseResult[] = []
   const request = qualificationRequest(
+    adapter,
     "event_stream",
     workingDirectory,
     policy,
+    context,
   )
-  let events: AgentHostEvent[]
-  try {
-    events = await collectEvents(adapter, request)
-  } catch {
+  const collected = await collectEvents(adapter, request, context)
+  if (collected.failed) {
+    const code = collected.overflow
+      ? "qualification_event_overflow"
+      : "event_stream_unavailable"
     return [
-      caseResult(
-        "native_event_validation",
-        "events_well_formed",
-        false,
-        "event_stream_unavailable",
-      ),
-      caseResult(
-        "single_terminal_outcome",
-        "exactly_one_terminal",
-        false,
-        "event_stream_unavailable",
-      ),
+      caseResult("native_event_validation", "events_well_formed", false, code),
+      caseResult("single_terminal_outcome", "exactly_one_terminal", false, code),
     ]
   }
 
-  const wellFormed = events.every(
-    (event) =>
-      event.runId === request.runId &&
-      typeof event.timestamp === "string" &&
-      ISO_PATTERN.test(event.timestamp) &&
-      KNOWN_EVENT_TYPES.has(event.type),
-  )
-  results.push(
+  const wellFormed = collected.events.every((event) => {
+    const record = eventRecord(event)
+    return (
+      record !== undefined &&
+      record.runId === request.runId &&
+      typeof record.timestamp === "string" &&
+      ISO_PATTERN.test(record.timestamp) &&
+      typeof record.type === "string" &&
+      KNOWN_EVENT_TYPES.has(record.type)
+    )
+  })
+  const terminals = collected.events.filter(isTerminal)
+  const terminalLast =
+    terminals.length > 0 && isTerminal(collected.events.at(-1))
+  const terminalPassed = terminals.length === 1 && terminalLast
+  return [
     caseResult(
       "native_event_validation",
       "events_well_formed",
       wellFormed,
       wellFormed ? "events_well_formed_ok" : "malformed_native_event",
     ),
-  )
-
-  const terminals = events.filter(isTerminal)
-  const terminalLast =
-    terminals.length > 0 && isTerminal(events[events.length - 1])
-  const passed = terminals.length === 1 && terminalLast
-  results.push(
     caseResult(
       "single_terminal_outcome",
       "exactly_one_terminal",
-      passed,
-      passed
+      terminalPassed,
+      terminalPassed
         ? "single_terminal_ok"
         : terminals.length === 0
           ? "missing_terminal_event"
@@ -277,178 +828,662 @@ async function runEventCases(
             ? "duplicate_terminal_event"
             : "event_after_terminal",
     ),
-  )
-  return results
+  ]
 }
 
 async function runCancelCase(
   adapter: AgentHostAdapter,
   workingDirectory: string,
   policy: AgentHostPolicy,
+  context: QualificationCaseContext,
 ): Promise<QualificationCaseResult> {
-  const request = qualificationRequest("cancel", workingDirectory, policy)
-  let events: AgentHostEvent[]
-  try {
-    if (typeof adapter.cancel === "function") {
-      void Promise.resolve(adapter.cancel(request.runId)).catch(() => {})
-    }
-    events = await collectEvents(adapter, request)
-  } catch {
+  const request = qualificationRequest(
+    adapter,
+    "cancel",
+    workingDirectory,
+    policy,
+    context,
+    {
+      metadata: {
+        adapterQualification: {
+          schema: ADAPTER_QUALIFICATION_DRIVER_SCHEMA_ID,
+          operation: { kind: "lifecycle.wait_for_cancel" },
+        } satisfies QualificationDriverMetadata,
+      },
+    },
+  )
+  if (typeof adapter.cancel !== "function") {
     return caseResult(
       "deadline_cancel",
-      "cancel_stops_run",
+      "cancel_stops_active_run",
+      false,
+      "cancel_not_supported",
+    )
+  }
+  const iterator = adapter.run(request)[Symbol.asyncIterator]()
+  context.registerCleanup(async () => {
+    await iterator.return?.()
+  })
+  let first: IteratorResult<AgentHostEvent>
+  try {
+    first = await iterator.next()
+    if (!first.done) context.scanner.observe(first.value)
+  } catch (error) {
+    context.scanner.observe(error)
+    return caseResult(
+      "deadline_cancel",
+      "cancel_stops_active_run",
       false,
       "cancel_path_unavailable",
     )
   }
-  const terminals = events.filter(isTerminal)
-  const passed =
-    terminals.length === 1 && isTerminal(events[events.length - 1])
-  return caseResult(
-    "deadline_cancel",
-    "cancel_stops_run",
-    passed,
-    passed ? "cancel_stops_run_ok" : "cancel_leaves_stream_open",
-  )
-}
-
-async function runCleanupCase(
-  adapter: AgentHostAdapter,
-  workingDirectory: string,
-  policy: AgentHostPolicy,
-): Promise<QualificationCaseResult> {
-  const request = qualificationRequest("cleanup", workingDirectory, policy)
-  try {
-    const events = await collectEvents(adapter, request)
-    if (events.length === 0 || !isTerminal(events[events.length - 1])) {
-      return caseResult(
-        "process_tree_cleanup",
-        "stream_terminates",
-        false,
-        "stream_not_terminated",
-      )
-    }
-    if (typeof adapter.cancel === "function") {
-      await adapter.cancel(request.runId)
-      await adapter.cancel(request.runId)
-    }
+  if (first.done || eventType(first.value) !== "run.started") {
     return caseResult(
-      "process_tree_cleanup",
-      "stream_terminates",
-      true,
-      "stream_terminates_ok",
-    )
-  } catch {
-    return caseResult(
-      "process_tree_cleanup",
-      "stream_terminates",
+      "deadline_cancel",
+      "cancel_stops_active_run",
       false,
-      "cleanup_path_threw",
+      "cancel_never_started",
     )
   }
+  try {
+    await context.cancelRun(adapter, request.runId)
+  } catch (error) {
+    context.scanner.observe(error)
+    return caseResult(
+      "deadline_cancel",
+      "cancel_stops_active_run",
+      false,
+      "cancel_path_unavailable",
+    )
+  }
+  const collected = await collectFromIterator(iterator, context, [first.value])
+  if (collected.failed) {
+    return caseResult(
+      "deadline_cancel",
+      "cancel_stops_active_run",
+      false,
+      collected.overflow
+        ? "qualification_event_overflow"
+        : "cancel_path_unavailable",
+    )
+  }
+  const terminals = collected.events.filter(isTerminal)
+  const terminal = terminals[0]
+  const passed =
+    terminals.length === 1 &&
+    eventType(terminal) === "run.failed" &&
+    collected.events.at(-1) === terminal
+  let code = "cancel_stops_active_run_ok"
+  if (!passed) {
+    code =
+      terminals.length === 0
+        ? "cancel_leaves_stream_open"
+        : terminals.length > 1
+          ? "cancel_terminal_contract_violation"
+          : eventType(terminal) === "run.completed"
+            ? "cancel_completed_terminal"
+            : "cancel_event_after_terminal"
+  }
+  return caseResult(
+    "deadline_cancel",
+    "cancel_stops_active_run",
+    passed,
+    code,
+  )
 }
-
-const QUALIFICATION_SENTINEL = "qualification-sentinel-do-not-leak"
 
 async function runCredentialCase(
   adapter: AgentHostAdapter,
   workingDirectory: string,
   policy: AgentHostPolicy,
+  context: QualificationCaseContext,
 ): Promise<QualificationCaseResult> {
-  const request: AgentHostRunRequest = {
-    ...qualificationRequest("credential", workingDirectory, policy),
-    metadata: { qualificationSentinel: QUALIFICATION_SENTINEL },
-  }
-  try {
-    const events = await collectEvents(adapter, request)
-    const leaked = events.some((event) =>
-      JSON.stringify(event).includes(QUALIFICATION_SENTINEL),
-    )
-    return caseResult(
-      "credential_boundaries",
-      "no_metadata_echo",
-      !leaked,
-      leaked ? "metadata_secret_echoed" : "no_metadata_echo_ok",
-    )
-  } catch {
+  const request = qualificationRequest(
+    adapter,
+    "credential",
+    workingDirectory,
+    policy,
+    context,
+    { metadata: { qualificationSentinel: QUALIFICATION_SENTINEL } },
+  )
+  const collected = await collectEvents(adapter, request, context)
+  if (context.scanner.detected) {
     return caseResult(
       "credential_boundaries",
       "no_metadata_echo",
       false,
-      "credential_case_unavailable",
+      "metadata_secret_echoed",
     )
   }
+  if (context.scanner.incomplete) {
+    return caseResult(
+      "credential_boundaries",
+      "no_metadata_echo",
+      false,
+      "metadata_secret_scan_incomplete",
+    )
+  }
+  if (collected.failed) {
+    return caseResult(
+      "credential_boundaries",
+      "no_metadata_echo",
+      false,
+      collected.overflow
+        ? "qualification_event_overflow"
+        : "credential_case_unavailable",
+    )
+  }
+  return caseResult(
+    "credential_boundaries",
+    "no_metadata_echo",
+    true,
+    "no_metadata_echo_ok",
+  )
 }
 
-async function runEnforcementCases(
+function qualificationPolicyDenialMatches(
+  error: unknown,
+  expectedCode: string,
+): boolean {
+  if (!(error instanceof CoreError) || error.retryable !== false) return false
+  if (error.code === expectedCode) return true
+  if (error.code !== "agent_host_stdio_host_error") return false
+  const details = eventRecord(error.details)
+  return details?.code === expectedCode && details.retryable === false
+}
+
+async function runDirectDenyCase(
+  kind: "filesystem" | "network" | "mcp",
   adapter: AgentHostAdapter,
   workingDirectory: string,
   policy: AgentHostPolicy,
-): Promise<QualificationCaseResult[]> {
-  const results: QualificationCaseResult[] = []
-
-  const hostileFsRequest = qualificationRequest(
-    "filesystem_enforcement",
+  context: QualificationCaseContext,
+): Promise<QualificationCaseResult> {
+  const domain =
+    kind === "mcp"
+      ? "tool_mcp_enforcement"
+      : "filesystem_network_enforcement"
+  const id = kind === "filesystem" ? "hostile_write_refused" : `${kind}_deny_refused`
+  const expectedCode =
+    kind === "filesystem"
+      ? QUALIFICATION_FILESYSTEM_DENIAL_CODE
+      : kind === "network"
+        ? QUALIFICATION_NETWORK_DENIAL_CODE
+        : QUALIFICATION_MCP_DENIAL_CODE
+  const operation: QualificationDriverOperation =
+    kind === "filesystem"
+      ? {
+          kind: "filesystem.write",
+          path: "../qualification-denied/outside-scope",
+        }
+      : kind === "network"
+        ? {
+            kind: "network.connect",
+            url: "https://qualification.invalid/",
+          }
+        : {
+            kind: "mcp.invoke",
+            server: "qualification-denied",
+            tool: "qualification.noop",
+          }
+  const request = qualificationRequest(
+    adapter,
+    `${kind}_deny`,
     workingDirectory,
+    policy,
+    context,
     {
-      ...policy,
-      filesystem: { read: ["."], write: ["/etc"] },
-      network: { mode: "deny" },
+      prompt:
+        kind === "filesystem"
+          ? "attempt one write outside the qualified filesystem scope; filesystem policy must deny it"
+          : kind === "network"
+            ? "attempt one HTTPS request to qualification.invalid; network policy must deny it"
+            : "attempt the undeclared qualification-denied MCP server; it must be denied",
+      metadata: {
+        adapterQualification: {
+          schema: ADAPTER_QUALIFICATION_DRIVER_SCHEMA_ID,
+          operation,
+        } satisfies QualificationDriverMetadata,
+      },
     },
   )
-  let fsRefused = false
   try {
-    await adapter.preflight(hostileFsRequest)
-  } catch {
-    fsRefused = true
+    await adapter.preflight(request)
+  } catch (error) {
+    context.scanner.observe(error)
+    const refused =
+      !context.scanner.incomplete &&
+      qualificationPolicyDenialMatches(error, expectedCode)
+    return caseResult(
+      domain,
+      id,
+      refused,
+      refused
+        ? `${kind}_deny_refused_ok`
+        : `${kind}_deny_policy_evidence_invalid`,
+    )
   }
-  results.push(
-    caseResult(
-      "filesystem_network_enforcement",
-      "hostile_write_refused",
-      fsRefused,
-      fsRefused ? "hostile_write_refused_ok" : "hostile_write_accepted",
-    ),
+  const collected = await collectEvents(adapter, request, context)
+  if (collected.failed) {
+    return caseResult(
+      domain,
+      id,
+      false,
+      collected.overflow
+        ? "qualification_event_overflow"
+        : `${kind}_deny_case_unavailable`,
+    )
+  }
+  const terminals = collected.events.filter(isTerminal)
+  const terminal = terminals[0]
+  const terminalRecord = terminal ? eventRecord(terminal) : undefined
+  const terminalError = eventRecord(terminalRecord?.error)
+  const refused =
+    collected.events.length >= 2 &&
+    eventType(collected.events[0]) === "run.started" &&
+    terminals.length === 1 &&
+    eventType(terminal) === "run.failed" &&
+    collected.events.at(-1) === terminal &&
+    terminalError?.code === expectedCode &&
+    terminalError.retryable === false
+  return caseResult(
+    domain,
+    id,
+    refused,
+    refused
+      ? `${kind}_deny_refused_ok`
+      : terminal && eventType(terminal) === "run.completed"
+        ? `${kind}_deny_accepted`
+        : `${kind}_deny_policy_evidence_invalid`,
   )
+}
 
-  const toolRequest = qualificationRequest(
+async function runToolCase(
+  adapter: AgentHostAdapter,
+  workingDirectory: string,
+  policy: AgentHostPolicy,
+  context: QualificationCaseContext,
+): Promise<QualificationCaseResult> {
+  const request = qualificationRequest(
+    adapter,
     "tool_enforcement",
     workingDirectory,
     policy,
+    context,
   )
-  try {
-    const events = await collectEvents(adapter, toolRequest)
-    const allowed = new Set(policy.tools.allow.map((entry) => entry.name))
-    const violation = events.some(
-      (event) =>
-        (event.type === "tool.started" || event.type === "tool.completed") &&
-        !allowed.has(event.toolName),
-    )
-    results.push(
-      caseResult(
-        "tool_mcp_enforcement",
-        "tool_allowlist_respected",
-        !violation,
-        violation ? "disallowed_tool_event" : "tool_allowlist_respected_ok",
-      ),
-    )
-  } catch {
-    results.push(
-      caseResult(
-        "tool_mcp_enforcement",
-        "tool_allowlist_respected",
-        false,
-        "tool_case_unavailable",
-      ),
+  const collected = await collectEvents(adapter, request, context)
+  if (collected.failed) {
+    return caseResult(
+      "tool_mcp_enforcement",
+      "tool_allowlist_respected",
+      false,
+      collected.overflow ? "qualification_event_overflow" : "tool_case_unavailable",
     )
   }
-  return results
+  const allowed = new Set(policy.tools.allow.map((entry) => entry.name))
+  const violation = collected.events.some((event) => {
+    const record = eventRecord(event)
+    return (
+      (record?.type === "tool.started" || record?.type === "tool.completed") &&
+      !allowed.has(String(record.toolName))
+    )
+  })
+  return caseResult(
+    "tool_mcp_enforcement",
+    "tool_allowlist_respected",
+    !violation,
+    violation ? "disallowed_tool_event" : "tool_allowlist_respected_ok",
+  )
+}
+
+function processAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0 || pid === process.pid) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH"
+  }
+}
+
+interface QualificationProcessIdentity {
+  pid: number
+  parentPid: number
+  processGroupId: number
+  startIdentity: string
+}
+
+async function inspectProcessIdentities(
+  pids: readonly number[],
+): Promise<Map<number, QualificationProcessIdentity> | undefined> {
+  if (process.platform === "win32") return undefined
+  try {
+    const { stdout } = await execFileAsync(
+      "/bin/ps",
+      [
+        "-o",
+        "pid=,ppid=,pgid=,lstart=",
+        "-p",
+        [...new Set(pids)].join(","),
+      ],
+      { encoding: "utf8", maxBuffer: 64 * 1024 },
+    )
+    const identities = new Map<number, QualificationProcessIdentity>()
+    for (const line of String(stdout).split("\n")) {
+      const match = line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(.+?)\s*$/)
+      if (!match) continue
+      const identity = {
+        pid: Number(match[1]),
+        parentPid: Number(match[2]),
+        processGroupId: Number(match[3]),
+        startIdentity: match[4] ?? "",
+      }
+      identities.set(identity.pid, identity)
+    }
+    return identities
+  } catch {
+    return undefined
+  }
+}
+
+async function descendantsGone(
+  descendants: QualificationProcessTreeDescendants,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, timeoutMs)
+  while (
+    processAlive(descendants.childPid) ||
+    processAlive(descendants.grandchildPid)
+  ) {
+    if (Date.now() >= deadline) return false
+    await new Promise<void>((resolve) => setTimeout(resolve, 20))
+  }
+  return true
+}
+
+function validDescendants(
+  value: QualificationProcessTreeDescendants,
+): boolean {
+  return (
+    Number.isSafeInteger(value.childPid) &&
+    value.childPid > 0 &&
+    Number.isSafeInteger(value.grandchildPid) &&
+    value.grandchildPid > 0 &&
+    value.childPid !== value.grandchildPid &&
+    value.childPid !== process.pid &&
+    value.grandchildPid !== process.pid
+  )
+}
+
+function qualificationProbeFingerprint(probe: AgentHostProbeResult): string {
+  return createHash("sha256").update(canonicalJson(probe)).digest("hex")
+}
+
+async function processTreeLineageValid(
+  ownerPid: number,
+  descendants: QualificationProcessTreeDescendants,
+): Promise<boolean> {
+  const identities = await inspectProcessIdentities([
+    ownerPid,
+    descendants.childPid,
+    descendants.grandchildPid,
+  ])
+  const owner = identities?.get(ownerPid)
+  const child = identities?.get(descendants.childPid)
+  const grandchild = identities?.get(descendants.grandchildPid)
+  const valid = Boolean(
+    owner &&
+      child &&
+      grandchild &&
+      child.parentPid === owner.pid &&
+      grandchild.parentPid === child.pid &&
+      owner.processGroupId > 0 &&
+      child.processGroupId === owner.processGroupId &&
+      grandchild.processGroupId === owner.processGroupId &&
+      owner.startIdentity.length > 0 &&
+      child.startIdentity.length > 0 &&
+      grandchild.startIdentity.length > 0,
+  )
+  return valid
+}
+
+function cancelledLifecycle(events: AgentHostEvent[]): boolean {
+  const terminals = events.filter(isTerminal)
+  return (
+    terminals.length === 1 &&
+    eventType(terminals[0]) === "run.failed" &&
+    events.at(-1) === terminals[0]
+  )
+}
+
+async function runProcessTreeCase(
+  scenario: QualificationProcessTreeScenario,
+  expectedAdapter: AgentHostAdapter,
+  expectedProbeFingerprint: string | undefined,
+  expectedHostVersion: string | undefined,
+  expectedIdentity: AgentHostQualificationIdentity | undefined,
+  workingDirectory: string,
+  policy: AgentHostPolicy,
+  fixture: QualificationProcessTreeFixture | undefined,
+  context: QualificationCaseContext,
+): Promise<() => QualificationCaseResult> {
+  const id = `descendants_disposed_${scenario}`
+  const result = (
+    passed: boolean,
+    code: string,
+  ): (() => QualificationCaseResult) =>
+    () => caseResult("process_tree_cleanup", id, passed, code)
+  if (!fixture) {
+    return result(false, "process_tree_fixture_unavailable")
+  }
+  let instance: QualificationProcessTreeFixtureInstance | undefined
+  let disposePromise: Promise<void> | undefined
+  const disposeOnce = async (): Promise<void> => {
+    if (!instance) return
+    disposePromise ??= Promise.resolve(instance.dispose())
+    await disposePromise
+  }
+  let descendants: QualificationProcessTreeDescendants | undefined
+  let lifecyclePassed = false
+  let lineagePassed = false
+  let descendantsDisposed = false
+  let failureCode = "process_tree_fixture_create_failed"
+  try {
+    instance = await fixture.create(scenario)
+    context.registerCleanup(async () => {
+      await disposeOnce()
+      if (descendants) {
+        descendantsDisposed = await descendantsGone(descendants, 1_000)
+      }
+    })
+    failureCode = "process_tree_case_unavailable"
+    if (instance.adapter !== expectedAdapter) {
+      failureCode = "process_tree_adapter_mismatch"
+    } else if (
+      !expectedProbeFingerprint ||
+      !expectedHostVersion ||
+      !expectedIdentity
+    ) {
+      failureCode = "process_tree_binding_unavailable"
+    } else {
+      const currentProbe = await instance.adapter.probe()
+      context.scanner.observe(currentProbe)
+      const currentIdentity = await instance.adapter.qualificationIdentity?.()
+      context.scanner.observe(currentIdentity)
+      if (
+        context.scanner.incomplete ||
+        !currentIdentity ||
+        currentProbe.version !== expectedHostVersion ||
+        qualificationProbeFingerprint(currentProbe) !==
+          expectedProbeFingerprint ||
+        currentIdentity.configurationDigest !==
+          expectedIdentity.configurationDigest ||
+        currentIdentity.ownerPid !== expectedIdentity.ownerPid
+      ) {
+        failureCode = "process_tree_binding_mismatch"
+        return () => caseResult("process_tree_cleanup", id, false, failureCode)
+      }
+      const timeoutDelayMs = Math.max(
+        25,
+        Math.min(250, Math.floor(context.remainingMs() / 4)),
+      )
+      const request = qualificationRequest(
+        instance.adapter,
+        `process_tree_${scenario}`,
+        workingDirectory,
+        policy,
+        context,
+        {
+          ...(scenario === "timeout"
+            ? { deadline: new Date(Date.now() + timeoutDelayMs).toISOString() }
+            : {}),
+          metadata: {
+            adapterQualification: {
+              schema: ADAPTER_QUALIFICATION_DRIVER_SCHEMA_ID,
+              operation: { kind: "process_tree", scenario },
+            } satisfies QualificationDriverMetadata,
+          },
+        },
+      )
+      const iterator = instance.adapter.run(request)[Symbol.asyncIterator]()
+      context.registerCleanup(async () => {
+        await iterator.return?.()
+      })
+      failureCode = "process_tree_run_unavailable"
+      const first = await iterator.next()
+      if (first.done) {
+        failureCode = "process_tree_run_not_started"
+      } else {
+        context.scanner.observe(first.value)
+        if (eventType(first.value) !== "run.started") {
+          failureCode = "process_tree_run_not_started"
+        } else {
+          failureCode = "process_tree_descendants_unavailable"
+          descendants = await instance.descendants()
+          context.scanner.observe(descendants)
+          if (!validDescendants(descendants)) {
+            failureCode = "process_tree_descendants_invalid"
+          } else if (
+            !processAlive(descendants.childPid) ||
+            !processAlive(descendants.grandchildPid)
+          ) {
+            failureCode = "process_tree_descendants_not_running"
+          } else if (
+            !(await processTreeLineageValid(
+              expectedIdentity.ownerPid,
+              descendants,
+            ))
+          ) {
+            failureCode = "process_tree_lineage_unverified"
+          } else if (scenario === "normal") {
+            lineagePassed = true
+            const collected = await collectFromIterator(iterator, context, [
+              first.value,
+            ])
+            const terminals = collected.events.filter(isTerminal)
+            lifecyclePassed =
+              !collected.failed &&
+              terminals.length === 1 &&
+              eventType(terminals[0]) === "run.completed" &&
+              collected.events.at(-1) === terminals[0]
+            failureCode = lifecyclePassed
+              ? failureCode
+              : "process_tree_lifecycle_violation"
+          } else if (typeof instance.adapter.cancel !== "function") {
+            failureCode = "process_tree_cancel_not_supported"
+          } else if (scenario === "cancel") {
+            lineagePassed = true
+            await context.cancelRun(instance.adapter, request.runId)
+            const collected = await collectFromIterator(iterator, context, [
+              first.value,
+            ])
+            lifecyclePassed =
+              !collected.failed && cancelledLifecycle(collected.events)
+            failureCode = lifecyclePassed
+              ? failureCode
+              : "process_tree_lifecycle_violation"
+          } else {
+            lineagePassed = true
+            let timeoutTimer: ReturnType<typeof setTimeout> | undefined
+            const pending = iterator.next().then<
+              | { kind: "next"; result: IteratorResult<AgentHostEvent> }
+              | { kind: "error"; error: unknown }
+              ,
+              | { kind: "next"; result: IteratorResult<AgentHostEvent> }
+              | { kind: "error"; error: unknown }
+            >(
+              (result) => ({ kind: "next", result }),
+              (error: unknown) => ({ kind: "error", error }),
+            )
+            const timeout = new Promise<{ kind: "timeout" }>((resolve) => {
+              timeoutTimer = setTimeout(
+                () => resolve({ kind: "timeout" }),
+                timeoutDelayMs,
+              )
+            })
+            const firstAfterStart = await Promise.race([pending, timeout])
+            if (timeoutTimer !== undefined) clearTimeout(timeoutTimer)
+            const events = [first.value]
+            let timedOut = false
+            if (firstAfterStart.kind === "timeout") {
+              timedOut = true
+              context.abort()
+              await context.cancelRun(instance.adapter, request.runId)
+              const afterCancel = await pending
+              if (afterCancel.kind === "error") {
+                context.scanner.observe(afterCancel.error)
+              } else if (!afterCancel.result.done) {
+                context.scanner.observe(afterCancel.result.value)
+                events.push(afterCancel.result.value)
+              }
+            } else if (firstAfterStart.kind === "error") {
+              context.scanner.observe(firstAfterStart.error)
+            } else if (!firstAfterStart.result.done) {
+              context.scanner.observe(firstAfterStart.result.value)
+              events.push(firstAfterStart.result.value)
+              const record = eventRecord(firstAfterStart.result.value)
+              timedOut =
+                record?.type === "run.failed" &&
+                typeof eventRecord(record.error)?.code === "string" &&
+                /(?:deadline|timeout)/.test(
+                  String(eventRecord(record.error)?.code),
+                )
+            }
+            const collected = await collectFromIterator(iterator, context, events)
+            lifecyclePassed =
+              timedOut &&
+              !collected.failed &&
+              cancelledLifecycle(collected.events)
+            failureCode = lifecyclePassed
+              ? failureCode
+              : "process_tree_timeout_not_observed"
+          }
+        }
+      }
+    }
+  } catch (error) {
+    context.scanner.observe(error)
+  }
+  return () => {
+    if (!descendants || !lineagePassed || !lifecyclePassed) {
+      return caseResult("process_tree_cleanup", id, false, failureCode)
+    }
+    return caseResult(
+      "process_tree_cleanup",
+      id,
+      descendantsDisposed,
+      descendantsDisposed
+        ? `descendants_disposed_${scenario}_ok`
+        : "process_tree_descendants_survived",
+    )
+  }
 }
 
 async function runOutputSchemaCase(
   adapter: AgentHostAdapter,
   workingDirectory: string,
   policy: AgentHostPolicy,
+  context: QualificationCaseContext,
 ): Promise<QualificationCaseResult> {
   const schema = {
     type: "object",
@@ -457,45 +1492,53 @@ async function runOutputSchemaCase(
     additionalProperties: false,
   }
   const request = qualificationRequest(
+    adapter,
     "output_schema",
     workingDirectory,
     policy,
-    schema,
+    context,
+    { outputSchema: schema },
   )
-  try {
-    const events = await collectEvents(adapter, request)
-    const terminal = events.filter(isTerminal)
-    if (terminal.length !== 1 || terminal[0].type !== "run.completed") {
-      return caseResult(
-        "output_schema",
-        "terminal_output_matches_schema",
-        false,
-        "no_completed_terminal",
-      )
-    }
-    const output = terminal[0].output as Record<string, unknown>
-    const keys =
-      output && typeof output === "object" && !Array.isArray(output)
-        ? Object.keys(output)
-        : []
-    const matches =
-      keys.length === 1 &&
-      keys[0] === "answer" &&
-      typeof output.answer === "string"
-    return caseResult(
-      "output_schema",
-      "terminal_output_matches_schema",
-      matches,
-      matches ? "output_schema_ok" : "output_schema_violation",
-    )
-  } catch {
+  const collected = await collectEvents(adapter, request, context)
+  if (collected.failed) {
     return caseResult(
       "output_schema",
       "terminal_output_matches_schema",
       false,
-      "output_schema_case_unavailable",
+      collected.overflow
+        ? "qualification_event_overflow"
+        : "output_schema_case_unavailable",
     )
   }
+  const terminal = collected.events.filter(isTerminal)
+  if (terminal.length !== 1 || eventType(terminal[0]) !== "run.completed") {
+    return caseResult(
+      "output_schema",
+      "terminal_output_matches_schema",
+      false,
+      "no_completed_terminal",
+    )
+  }
+  const output = eventRecord(terminal[0])?.output
+  const outputRecord = eventRecord(output)
+  const keys = outputRecord ? Object.keys(outputRecord) : []
+  const matches =
+    keys.length === 1 &&
+    keys[0] === "answer" &&
+    typeof outputRecord?.answer === "string"
+  return caseResult(
+    "output_schema",
+    "terminal_output_matches_schema",
+    matches,
+    matches ? "output_schema_ok" : "output_schema_violation",
+  )
+}
+
+function caseTimeoutResult(
+  domain: QualificationDomain,
+  id: string,
+): (code: string) => QualificationCaseResult {
+  return (code) => caseResult(domain, id, false, code)
 }
 
 export async function runQualificationSuite(
@@ -514,49 +1557,186 @@ export async function runQualificationSuite(
       "generatedAt must be an ISO-8601 UTC timestamp",
     )
   }
+  const caseTimeoutMs =
+    options.caseTimeoutMs ?? DEFAULT_QUALIFICATION_CASE_TIMEOUT_MS
+  if (
+    !Number.isInteger(caseTimeoutMs) ||
+    caseTimeoutMs < MIN_QUALIFICATION_CASE_TIMEOUT_MS ||
+    caseTimeoutMs > MAX_QUALIFICATION_CASE_TIMEOUT_MS
+  ) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_CASE_TIMEOUT",
+      `caseTimeoutMs must be an integer from ${MIN_QUALIFICATION_CASE_TIMEOUT_MS} to ${MAX_QUALIFICATION_CASE_TIMEOUT_MS}`,
+    )
+  }
 
+  const scanner = new QualificationSentinelScanner()
   const policy = defaultQualificationPolicy()
   const cases: QualificationCaseResult[] = []
-  cases.push(await runCapabilityCase(adapter))
-  cases.push(
-    ...(await runEventCases(adapter, options.workingDirectory, policy)),
+  const capability = await runBoundedCase(
+    caseTimeoutMs,
+    scanner,
+    (code): CapabilityCaseOutcome => ({
+      result: caseResult(
+        "capability_negotiation",
+        "probe_contract",
+        false,
+        code,
+      ),
+    }),
+    (context) => runCapabilityCase(adapter, context),
   )
+  cases.push(capability.result)
   cases.push(
-    await runCancelCase(adapter, options.workingDirectory, policy),
-  )
-  cases.push(
-    await runCleanupCase(adapter, options.workingDirectory, policy),
-  )
-  cases.push(
-    await runCredentialCase(adapter, options.workingDirectory, policy),
-  )
-  cases.push(
-    ...(await runEnforcementCases(
-      adapter,
-      options.workingDirectory,
-      policy,
+    ...(await runBoundedCase(
+      caseTimeoutMs,
+      scanner,
+      (code) => [
+        caseResult("native_event_validation", "events_well_formed", false, code),
+        caseResult("single_terminal_outcome", "exactly_one_terminal", false, code),
+      ],
+      (context) =>
+        runEventCases(adapter, options.workingDirectory, policy, context),
     )),
   )
   cases.push(
-    await runOutputSchemaCase(adapter, options.workingDirectory, policy),
+    await runBoundedCase(
+      caseTimeoutMs,
+      scanner,
+      caseTimeoutResult("deadline_cancel", "cancel_stops_active_run"),
+      (context) =>
+        runCancelCase(adapter, options.workingDirectory, policy, context),
+    ),
+  )
+  for (const scenario of ["normal", "timeout", "cancel"] as const) {
+    const processResult = await runBoundedCase(
+        caseTimeoutMs,
+        scanner,
+        (code) => () =>
+          caseResult(
+            "process_tree_cleanup",
+            `descendants_disposed_${scenario}`,
+            false,
+            code,
+          ),
+        (context) =>
+          runProcessTreeCase(
+            scenario,
+            adapter,
+            capability.probeFingerprint,
+            capability.hostVersion,
+            capability.identity,
+            options.workingDirectory,
+            policy,
+            options.processTreeFixture,
+            context,
+          ),
+      )
+    cases.push(processResult())
+  }
+  cases.push(
+    await runBoundedCase(
+      caseTimeoutMs,
+      scanner,
+      caseTimeoutResult("credential_boundaries", "no_metadata_echo"),
+      (context) =>
+        runCredentialCase(adapter, options.workingDirectory, policy, context),
+    ),
+  )
+  cases.push(
+    await runBoundedCase(
+      caseTimeoutMs,
+      scanner,
+      caseTimeoutResult(
+        "filesystem_network_enforcement",
+        "hostile_write_refused",
+      ),
+      (context) =>
+        runDirectDenyCase(
+          "filesystem",
+          adapter,
+          options.workingDirectory,
+          policy,
+          context,
+        ),
+    ),
+  )
+  cases.push(
+    await runBoundedCase(
+      caseTimeoutMs,
+      scanner,
+      caseTimeoutResult(
+        "filesystem_network_enforcement",
+        "network_deny_refused",
+      ),
+      (context) =>
+        runDirectDenyCase(
+          "network",
+          adapter,
+          options.workingDirectory,
+          policy,
+          context,
+        ),
+    ),
+  )
+  cases.push(
+    await runBoundedCase(
+      caseTimeoutMs,
+      scanner,
+      caseTimeoutResult("tool_mcp_enforcement", "tool_allowlist_respected"),
+      (context) =>
+        runToolCase(adapter, options.workingDirectory, policy, context),
+    ),
+  )
+  cases.push(
+    await runBoundedCase(
+      caseTimeoutMs,
+      scanner,
+      caseTimeoutResult("tool_mcp_enforcement", "mcp_deny_refused"),
+      (context) =>
+        runDirectDenyCase(
+          "mcp",
+          adapter,
+          options.workingDirectory,
+          policy,
+          context,
+        ),
+    ),
+  )
+  cases.push(
+    await runBoundedCase(
+      caseTimeoutMs,
+      scanner,
+      caseTimeoutResult("output_schema", "terminal_output_matches_schema"),
+      (context) =>
+        runOutputSchemaCase(adapter, options.workingDirectory, policy, context),
+    ),
   )
 
-  let probe: AgentHostProbeResult | undefined
-  try {
-    probe = await adapter.probe()
-  } catch {
-    probe = undefined
-  }
-  const implemented =
-    probe !== undefined &&
-    probe.protocolVersion === AGENT_HOST_PROTOCOL_VERSION &&
-    probe.status === "ready" &&
-    probe.available &&
-    probe.adapterStatus === "runnable" &&
-    AGENT_HOST_CAPABILITIES.every(
-      (capability) => probe!.capabilities[capability] !== undefined,
+  if (scanner.detected || scanner.incomplete) {
+    const credentialIndex = cases.findIndex(
+      (entry) => entry.domain === "credential_boundaries",
     )
+    if (credentialIndex !== -1) {
+      cases[credentialIndex] = caseResult(
+        "credential_boundaries",
+        "no_metadata_echo",
+        false,
+        scanner.detected
+          ? "metadata_secret_echoed"
+          : "metadata_secret_scan_incomplete",
+      )
+    }
+  }
 
+  const probe = capability.probe
+  if (probe !== undefined && !validHostVersion(probe.version)) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_HOST_VERSION",
+      "a responding qualification host must report a non-empty version of at most 256 characters",
+    )
+  }
+  const implemented = probeContractValid(probe, adapter.hostId)
   const fixtureConformant =
     implemented && cases.every((result) => result.passed)
   // Project to the frozen two-field shape so callers cannot smuggle extra
@@ -605,6 +1785,20 @@ export async function runQualificationSuite(
     cases,
     ...(liveEvidence !== undefined ? { liveEvidence } : {}),
   }
+  const recordScanner = new QualificationSentinelScanner()
+  recordScanner.observe(record)
+  if (recordScanner.detected) {
+    throw qualificationError(
+      "QUALIFICATION_EVIDENCE_SECRET_DETECTED",
+      "qualification evidence contained the credential sentinel",
+    )
+  }
+  if (recordScanner.incomplete) {
+    throw qualificationError(
+      "QUALIFICATION_EVIDENCE_SCAN_INCOMPLETE",
+      "qualification evidence could not be scanned completely",
+    )
+  }
   validateAdapterQualificationRecord(record)
   return record
 }
@@ -612,6 +1806,20 @@ export async function runQualificationSuite(
 export function validateAdapterQualificationRecord(
   value: unknown,
 ): AdapterQualificationRecord {
+  const evidenceScanner = new QualificationSentinelScanner()
+  evidenceScanner.observe(value)
+  if (evidenceScanner.detected) {
+    throw qualificationError(
+      "QUALIFICATION_EVIDENCE_SECRET_DETECTED",
+      "qualification evidence contained the credential sentinel",
+    )
+  }
+  if (evidenceScanner.incomplete) {
+    throw qualificationError(
+      "QUALIFICATION_EVIDENCE_SCAN_INCOMPLETE",
+      "qualification evidence could not be scanned completely",
+    )
+  }
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw qualificationError(
       "INVALID_QUALIFICATION_RECORD",
@@ -673,10 +1881,13 @@ export function validateAdapterQualificationRecord(
       "policyDigest must be a sha256 hex digest",
     )
   }
-  if (record.kitVersion !== ADAPTER_QUALIFICATION_KIT_VERSION) {
+  if (
+    record.kitVersion !== ADAPTER_QUALIFICATION_KIT_VERSION &&
+    record.kitVersion !== LEGACY_ADAPTER_QUALIFICATION_KIT_VERSION
+  ) {
     throw qualificationError(
       "INVALID_QUALIFICATION_RECORD",
-      `kitVersion must be ${ADAPTER_QUALIFICATION_KIT_VERSION}`,
+      `kitVersion must be ${LEGACY_ADAPTER_QUALIFICATION_KIT_VERSION} or ${ADAPTER_QUALIFICATION_KIT_VERSION}`,
     )
   }
   if (
@@ -786,7 +1997,21 @@ export function validateAdapterQualificationRecord(
       "cases must be a non-empty array",
     )
   }
+  const expectedContract =
+    record.kitVersion === LEGACY_ADAPTER_QUALIFICATION_KIT_VERSION
+      ? LEGACY_QUALIFICATION_CASE_CONTRACT
+      : CURRENT_QUALIFICATION_CASE_CONTRACT
+  if (record.cases.length !== expectedContract.length) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      `kit ${record.kitVersion} requires exactly ${expectedContract.length} cases`,
+    )
+  }
+  const expectedCases = new Map<string, QualificationDomain>(
+    expectedContract.map(([domain, id]) => [id, domain]),
+  )
   const seenDomains = new Set<string>()
+  const seenCases = new Set<string>()
   for (const entry of record.cases as Array<Record<string, unknown>>) {
     if (
       !entry ||
@@ -823,19 +2048,33 @@ export function validateAdapterQualificationRecord(
         "case ids must be lowercase snake_case",
       )
     }
+    if (
+      seenCases.has(entry.id) ||
+      expectedCases.get(entry.id) !== entry.domain
+    ) {
+      throw qualificationError(
+        "INVALID_QUALIFICATION_RECORD",
+        `case ${entry.id} is duplicated or outside the ${record.kitVersion} contract`,
+      )
+    }
     if (typeof entry.passed !== "boolean") {
       throw qualificationError(
         "INVALID_QUALIFICATION_RECORD",
         "every case must report a boolean result",
       )
     }
-    if (typeof entry.code !== "string" || entry.code === "") {
+    if (
+      typeof entry.code !== "string" ||
+      entry.code.length > 128 ||
+      !CASE_CODE_PATTERN.test(entry.code)
+    ) {
       throw qualificationError(
         "INVALID_QUALIFICATION_RECORD",
-        "every case must report a machine code",
+        "every case must report a bounded lowercase ASCII machine code",
       )
     }
     seenDomains.add(entry.domain)
+    seenCases.add(entry.id)
   }
   for (const domain of QUALIFICATION_DOMAINS) {
     if (!seenDomains.has(domain)) {
@@ -844,6 +2083,37 @@ export function validateAdapterQualificationRecord(
         `cases must cover domain ${domain}`,
       )
     }
+  }
+  const typedCases = record.cases as QualificationCaseResult[]
+  for (const domain of QUALIFICATION_DOMAINS) {
+    const domainCases = typedCases.filter((entry) => entry.domain === domain)
+    const expectedPassed = domainCases.filter((entry) => entry.passed).length
+    const expectedFailed = domainCases.length - expectedPassed
+    const summary = domains[domain] as { passed: number; failed: number }
+    if (
+      summary.passed !== expectedPassed ||
+      summary.failed !== expectedFailed
+    ) {
+      throw qualificationError(
+        "INVALID_QUALIFICATION_RECORD",
+        `domain ${domain} summary does not match its cases`,
+      )
+    }
+  }
+  const probeCase = typedCases.find((entry) => entry.id === "probe_contract")
+  const expectedImplemented = probeCase?.passed === true
+  const expectedFixtureConformant =
+    expectedImplemented && typedCases.every((entry) => entry.passed)
+  const expectedLiveQualified = record.liveEvidence !== undefined
+  if (
+    axes.implemented !== expectedImplemented ||
+    axes.fixtureConformant !== expectedFixtureConformant ||
+    axes.liveQualified !== expectedLiveQualified
+  ) {
+    throw qualificationError(
+      "INVALID_QUALIFICATION_RECORD",
+      "qualification axes do not match the derived case and evidence state",
+    )
   }
   return value as AdapterQualificationRecord
 }

--- a/packages/core/src/adapter-qualification.ts
+++ b/packages/core/src/adapter-qualification.ts
@@ -378,6 +378,7 @@ interface TrackedQualificationRun {
   ownerAdapter: AgentHostAdapter
   runId: string
   cancelAttempted: boolean
+  cancelPromise?: Promise<void>
 }
 
 interface QualificationCaseContext {
@@ -412,53 +413,62 @@ async function runBoundedCase<T>(
   const controller = new AbortController()
   const trackedRuns: TrackedQualificationRun[] = []
   const cleanups: Array<() => Promise<void> | void> = []
-  const findRun = (ownerAdapter: AgentHostAdapter, runId: string) =>
-    trackedRuns.find(
-      (entry) => entry.ownerAdapter === ownerAdapter && entry.runId === runId,
-    )
-  const context: QualificationCaseContext = {
-    signal: controller.signal,
-    deadline: new Date(deadlineAt).toISOString(),
-    scanner,
-    remainingMs: () => Math.max(0, deadlineAt - Date.now()),
-    abort: () => controller.abort(),
-    trackRun: (ownerAdapter, runId) => {
-      if (!findRun(ownerAdapter, runId)) {
-        trackedRuns.push({ ownerAdapter, runId, cancelAttempted: false })
-      }
-    },
-    cancelRun: async (ownerAdapter, runId) => {
-      let tracked = findRun(ownerAdapter, runId)
-      if (!tracked) {
-        tracked = { ownerAdapter, runId, cancelAttempted: false }
-        trackedRuns.push(tracked)
-      }
-      if (tracked.cancelAttempted) return
-      tracked.cancelAttempted = true
-      await ownerAdapter.cancel?.(runId)
-    },
-    registerCleanup: (cleanup) => cleanups.push(cleanup),
-  }
-  let timer: ReturnType<typeof setTimeout> | undefined
-  const timeout = new Promise<BoundedOutcome<T>>((resolve) => {
-    timer = setTimeout(() => resolve({ kind: "timeout" }), caseTimeoutMs)
-  })
-  const execution = Promise.resolve()
-    .then(() => body(context))
-    .then<QualificationExecutionOutcome<T>, QualificationExecutionOutcome<T>>(
-      (value) => ({ kind: "value", value }),
-      (error: unknown) => {
-        scanner.observe(error)
-        return { kind: "error", error }
-      },
-    )
-  const outcome = await Promise.race([execution, timeout])
-  if (timer !== undefined) clearTimeout(timer)
   const cleanupErrors: unknown[] = []
   const cleanupPromises = new Map<
     () => Promise<void> | void,
     Promise<void>
   >()
+  let finalizing = false
+  let resourceGeneration = 0
+  const resourceWaiters = new Set<() => void>()
+  const signalResourceChange = (): void => {
+    resourceGeneration += 1
+    const waiters = [...resourceWaiters]
+    resourceWaiters.clear()
+    for (const resolve of waiters) resolve()
+  }
+  const waitForResourceChange = (
+    observedGeneration: number,
+  ): { promise: Promise<void>; cancel: () => void } => {
+    let resolveWait: (() => void) | undefined
+    const promise = new Promise<void>((resolve) => {
+      if (resourceGeneration !== observedGeneration) {
+        resolve()
+        return
+      }
+      resolveWait = resolve
+      resourceWaiters.add(resolve)
+    })
+    return {
+      promise,
+      cancel: () => {
+        if (resolveWait) resourceWaiters.delete(resolveWait)
+      },
+    }
+  }
+  const findRun = (ownerAdapter: AgentHostAdapter, runId: string) =>
+    trackedRuns.find(
+      (entry) => entry.ownerAdapter === ownerAdapter && entry.runId === runId,
+    )
+  const startCancel = (tracked: TrackedQualificationRun): Promise<void> => {
+    if (!tracked.cancelAttempted) {
+      tracked.cancelAttempted = true
+      tracked.cancelPromise = Promise.resolve().then(async () => {
+        await tracked.ownerAdapter.cancel?.(tracked.runId)
+      })
+    }
+    return tracked.cancelPromise ?? Promise.resolve()
+  }
+  const settleCancel = async (
+    tracked: TrackedQualificationRun,
+  ): Promise<void> => {
+    try {
+      await startCancel(tracked)
+    } catch (error) {
+      cleanupErrors.push(error)
+      scanner.observe(error)
+    }
+  }
   const invokeCleanup = (
     cleanup: () => Promise<void> | void,
   ): Promise<void> => {
@@ -478,8 +488,54 @@ async function runBoundedCase<T>(
     }
     return promise
   }
+  const context: QualificationCaseContext = {
+    signal: controller.signal,
+    deadline: new Date(deadlineAt).toISOString(),
+    scanner,
+    remainingMs: () => Math.max(0, deadlineAt - Date.now()),
+    abort: () => controller.abort(),
+    trackRun: (ownerAdapter, runId) => {
+      if (!findRun(ownerAdapter, runId)) {
+        const tracked = { ownerAdapter, runId, cancelAttempted: false }
+        trackedRuns.push(tracked)
+        signalResourceChange()
+        if (finalizing) void settleCancel(tracked)
+      }
+    },
+    cancelRun: async (ownerAdapter, runId) => {
+      let tracked = findRun(ownerAdapter, runId)
+      if (!tracked) {
+        tracked = { ownerAdapter, runId, cancelAttempted: false }
+        trackedRuns.push(tracked)
+        signalResourceChange()
+        if (finalizing) void settleCancel(tracked)
+      }
+      await startCancel(tracked)
+    },
+    registerCleanup: (cleanup) => {
+      cleanups.push(cleanup)
+      signalResourceChange()
+      if (finalizing) void invokeCleanup(cleanup)
+    },
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<BoundedOutcome<T>>((resolve) => {
+    timer = setTimeout(() => resolve({ kind: "timeout" }), caseTimeoutMs)
+  })
+  const execution = Promise.resolve()
+    .then(() => body(context))
+    .then<QualificationExecutionOutcome<T>, QualificationExecutionOutcome<T>>(
+      (value) => ({ kind: "value", value }),
+      (error: unknown) => {
+        scanner.observe(error)
+        return { kind: "error", error }
+      },
+    )
+  const outcome = await Promise.race([execution, timeout])
+  if (timer !== undefined) clearTimeout(timer)
   let settledExecution = outcome.kind === "timeout" ? undefined : outcome
   const finalizer = async (): Promise<void> => {
+    finalizing = true
     controller.abort()
     const processedRuns = new Set<TrackedQualificationRun>()
     const processedCleanups = new Set<() => Promise<void> | void>()
@@ -489,14 +545,7 @@ async function runBoundedCase<T>(
       )
       for (const tracked of pendingRuns) {
         processedRuns.add(tracked)
-        if (tracked.cancelAttempted || !tracked.ownerAdapter.cancel) continue
-        tracked.cancelAttempted = true
-        try {
-          await tracked.ownerAdapter.cancel(tracked.runId)
-        } catch (error) {
-          cleanupErrors.push(error)
-          scanner.observe(error)
-        }
+        await settleCancel(tracked)
       }
 
       const pendingCleanups = cleanups
@@ -508,7 +557,14 @@ async function runBoundedCase<T>(
       }
 
       if (settledExecution === undefined) {
-        settledExecution = await execution
+        const observedGeneration = resourceGeneration
+        const resourceChange = waitForResourceChange(observedGeneration)
+        const next = await Promise.race([
+          execution.then((value) => ({ kind: "execution" as const, value })),
+          resourceChange.promise.then(() => ({ kind: "resource" as const })),
+        ])
+        resourceChange.cancel()
+        if (next.kind === "execution") settledExecution = next.value
         continue
       }
       if (
@@ -526,7 +582,6 @@ async function runBoundedCase<T>(
   let cleanupTimer: ReturnType<typeof setTimeout> | undefined
   const cleanupTimeout = new Promise<"timeout">((resolve) => {
     cleanupTimer = setTimeout(() => resolve("timeout"), cleanupGraceMs)
-    cleanupTimer.unref?.()
   })
   const cleanupOutcome = await Promise.race([
     finalizer().then(() => "settled" as const),
@@ -540,12 +595,12 @@ async function runBoundedCase<T>(
     let isolationTimer: ReturnType<typeof setTimeout> | undefined
     const isolationTimeout = new Promise<void>((resolve) => {
       isolationTimer = setTimeout(resolve, cleanupGraceMs)
-      isolationTimer.unref?.()
     })
     await Promise.race([
-      Promise.all(cleanups.slice().reverse().map(invokeCleanup)).then(
-        () => undefined,
-      ),
+      Promise.all([
+        ...trackedRuns.map(settleCancel),
+        ...cleanups.slice().reverse().map(invokeCleanup),
+      ]).then(() => undefined),
       isolationTimeout,
     ])
     if (isolationTimer !== undefined) clearTimeout(isolationTimer)

--- a/packages/core/src/agent-host.ts
+++ b/packages/core/src/agent-host.ts
@@ -215,6 +215,17 @@ export interface AgentHostAdapter {
     decision: "allow" | "deny",
   ): Promise<void>
   cancel?(runId: string): Promise<void>
+  /**
+   * Optional qualification-only binding for deterministic process fixtures.
+   * Implementations expose an opaque configuration digest and the PID that
+   * actually owns their runs; neither value is published in evidence.
+   */
+  qualificationIdentity?(): Promise<AgentHostQualificationIdentity>
+}
+
+export interface AgentHostQualificationIdentity {
+  configurationDigest: string
+  ownerPid: number
 }
 
 export function createUnknownAgentHostCapabilities(): AgentHostCapabilities {

--- a/tests/apps/stdio-agent-host.test.ts
+++ b/tests/apps/stdio-agent-host.test.ts
@@ -15,6 +15,10 @@ import {
 } from "../../apps/cli/stdio-agent-host.js"
 import type { AgentHostRunRequest } from "../../packages/core/src/agent-host.js"
 import { runQualificationSuite } from "../../packages/core/src/adapter-qualification.js"
+import type {
+  QualificationProcessTreeFixture,
+  QualificationProcessTreeScenario,
+} from "../../packages/core/src/adapter-qualification.js"
 import {
   AGENT_HOST_STDIO_CONFIG_SCHEMA_VERSION,
   validateStdioAdapterConfig,
@@ -25,7 +29,6 @@ const packageRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
 )
-const tsxBinary = path.join(packageRoot, "node_modules", ".bin", "tsx")
 const referenceHostScript = path.join(
   packageRoot,
   "apps",
@@ -45,6 +48,7 @@ const ENV_FLAGS = [
   "REFERENCE_STDIO_HOSTILE_WRITE_OK",
   "REFERENCE_STDIO_PROBE_ONLY",
   "REFERENCE_STDIO_NOT_READY",
+  "REFERENCE_STDIO_QUALIFICATION_MODE",
 ]
 
 function referenceConfig(overrides: {
@@ -53,17 +57,20 @@ function referenceConfig(overrides: {
 } = {}): StdioAdapterConfig {
   const digest =
     overrides.digest ??
-    createHash("sha256").update(readFileSync(tsxBinary)).digest("hex")
+    createHash("sha256").update(readFileSync(process.execPath)).digest("hex")
   return validateStdioAdapterConfig({
     schema: AGENT_HOST_STDIO_CONFIG_SCHEMA_VERSION,
     hostId: REFERENCE_STDIO_HOST_ID,
     displayName: "Reference Stdio Host",
-    executable: tsxBinary,
-    args: [referenceHostScript],
+    // Running through the tsx CLI adds a launcher between the pinned Adapter
+    // owner and the test host. Load tsx in the pinned Node process so process
+    // lineage evidence names the actual owner that directly spawns the child.
+    executable: process.execPath,
+    args: ["--import", "tsx", referenceHostScript],
     digest: { algorithm: "sha256", hex: digest },
     envAllowlist: ["PATH", ...ENV_FLAGS],
     workingDirectoryPolicy: "request",
-    timeoutMs: overrides.timeoutMs ?? 10_000,
+    timeoutMs: overrides.timeoutMs ?? 30_000,
     maxStderrBytes: 16_384,
   })
 }
@@ -102,6 +109,79 @@ async function withFlags(
   }
 }
 
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH"
+  }
+}
+
+function referenceProcessTreeFixture(
+  adapter: ExternalStdioAgentHostAdapter,
+  observed: Array<{ childPid: number; grandchildPid: number }>,
+): QualificationProcessTreeFixture {
+  return {
+    async create(scenario: QualificationProcessTreeScenario) {
+      let reported: { childPid: number; grandchildPid: number } | undefined
+      const readReported = () => {
+        const matches = [
+          ...adapter.diagnosticsTail().matchAll(
+            new RegExp(
+              `qualification process_tree ${scenario} child pid (\\d+) grandchild pid (\\d+)`,
+              "g",
+            ),
+          ),
+        ]
+        const match = matches.at(-1)
+        return match
+          ? { childPid: Number(match[1]), grandchildPid: Number(match[2]) }
+          : undefined
+      }
+      return {
+        adapter,
+        async descendants() {
+          const deadline = Date.now() + 5_000
+          while (Date.now() < deadline) {
+            reported = readReported()
+            if (reported) {
+              observed.push(reported)
+              return reported
+            }
+            await new Promise<void>((resolve) => setTimeout(resolve, 20))
+          }
+          throw new Error("reference process-tree fixture did not report descendants")
+        },
+        async dispose() {
+          reported ??= readReported()
+          if (!reported) return
+          for (const signal of ["SIGTERM", "SIGKILL"] as const) {
+            for (const pid of [reported.grandchildPid, reported.childPid]) {
+              if (!processExists(pid)) continue
+              try {
+                process.kill(pid, signal)
+              } catch (error) {
+                if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error
+              }
+            }
+            const deadline = Date.now() + 1_000
+            while (
+              [reported.childPid, reported.grandchildPid].some(processExists) &&
+              Date.now() < deadline
+            ) {
+              await new Promise<void>((resolve) => setTimeout(resolve, 20))
+            }
+            if (![reported.childPid, reported.grandchildPid].some(processExists)) {
+              return
+            }
+          }
+        },
+      }
+    },
+  }
+}
+
 test("an explicit external adapter completes the full lifecycle through the registry", async () => {
   await withFlags([], async () => {
     const registration = createExternalStdioHostRegistration(referenceConfig())
@@ -118,6 +198,10 @@ test("an explicit external adapter completes the full lifecycle through the regi
     try {
       const preflight = await adapter.preflight(readOnlyRequest("preflight-1"))
       assert.equal(preflight.hostId, REFERENCE_STDIO_HOST_ID)
+      const formerlyMagicPreflight = await adapter.preflight(
+        readOnlyRequest("qualification-network_deny"),
+      )
+      assert.equal(formerlyMagicPreflight.hostId, REFERENCE_STDIO_HOST_ID)
 
       await assert.rejects(
         () =>
@@ -137,6 +221,17 @@ test("an explicit external adapter completes the full lifecycle through the regi
       }
       assert.deepEqual(
         events.map((event) => event.type),
+        ["run.started", "run.completed"],
+      )
+
+      const formerlyMagicRun = []
+      for await (const event of adapter.run(
+        readOnlyRequest("qualification-cancel"),
+      )) {
+        formerlyMagicRun.push(event)
+      }
+      assert.deepEqual(
+        formerlyMagicRun.map((event) => event.type),
         ["run.started", "run.completed"],
       )
 
@@ -231,45 +326,75 @@ test("violation fixtures fail closed with stable error codes", async () => {
   })
 })
 
-test("dispose cleans the detached process tree completely", async () => {
+test("dispose cleans a real detached child and grandchild completely", async () => {
   await withFlags(["REFERENCE_STDIO_SPAWN_CHILD"], async () => {
     const adapter = new ExternalStdioAgentHostAdapter(referenceConfig())
+    let descendants: { childPid: number; grandchildPid: number } | undefined
     try {
       await adapter.probe()
+      const deadline = Date.now() + 5_000
+      while (!descendants && Date.now() < deadline) {
+        const match = adapter
+          .diagnosticsTail()
+          .match(/spawned child pid (\d+) grandchild pid (\d+)/)
+        if (match) {
+          descendants = {
+            childPid: Number(match[1]),
+            grandchildPid: Number(match[2]),
+          }
+          break
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 20))
+      }
+      assert.ok(descendants, "expected the fixture to report both descendant pids")
+      assert.deepEqual(
+        [descendants.childPid, descendants.grandchildPid].map(processExists),
+        [true, true],
+      )
     } finally {
       await adapter.dispose()
     }
-    const match = adapter
-      .diagnosticsTail()
-      .match(/spawned child pid (\d+)/)
-    assert.ok(match, "expected the fixture to report its leaked child pid")
-    const pid = Number(match[1])
-    assert.throws(
-      () => process.kill(pid, 0),
-      (error: unknown) =>
-        error instanceof Error &&
-        (error as NodeJS.ErrnoException).code === "ESRCH",
+    assert.ok(descendants)
+    assert.deepEqual(
+      [descendants.childPid, descendants.grandchildPid].map(processExists),
+      [false, false],
     )
   })
 })
 
 test("the qualification kit issues a fixture-conformant record for the reference adapter", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "stdio-qualification-"))
-  await withFlags([], async () => {
+  await withFlags(["REFERENCE_STDIO_QUALIFICATION_MODE"], async () => {
     const adapter = new ExternalStdioAgentHostAdapter(referenceConfig())
+    const observed: Array<{ childPid: number; grandchildPid: number }> = []
     try {
       const record = await runQualificationSuite(adapter, {
         workingDirectory: directory,
         generatedAt: "2026-08-06T04:00:00Z",
+        caseTimeoutMs: 10_000,
+        processTreeFixture: referenceProcessTreeFixture(adapter, observed),
       })
       assert.equal(record.schema, "adapter-qualification-record.v1")
       assert.equal(record.hostId, REFERENCE_STDIO_HOST_ID)
+      assert.deepEqual(
+        record.cases.filter((entry) => !entry.passed),
+        [],
+      )
       assert.deepEqual(record.axes, {
         implemented: true,
         fixtureConformant: true,
         liveQualified: false,
       })
       assert.equal(record.liveEvidence, undefined)
+      assert.equal(record.cases.length, 13)
+      assert.ok(record.cases.every((entry) => entry.passed))
+      assert.equal(observed.length, 3)
+      assert.ok(
+        observed.every(
+          ({ childPid, grandchildPid }) =>
+            !processExists(childPid) && !processExists(grandchildPid),
+        ),
+      )
     } finally {
       await adapter.dispose()
     }

--- a/tests/core/adapter-qualification.test.ts
+++ b/tests/core/adapter-qualification.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import type { ChildProcess } from "node:child_process"
 import { createHash } from "node:crypto"
 import { mkdtemp } from "node:fs/promises"
 import os from "node:os"
@@ -17,6 +19,7 @@ import type {
   AgentHostProbeResult,
   AgentHostRunRequest,
 } from "../../packages/core/src/agent-host.js"
+import { CoreError } from "../../packages/core/src/contracts.js"
 import {
   AGENT_HOST_STDIO_PROTOCOL_VERSION,
   encodeAgentHostStdioLine,
@@ -27,12 +30,19 @@ import {
 import {
   ADAPTER_QUALIFICATION_KIT_VERSION,
   ADAPTER_QUALIFICATION_SCHEMA_ID,
+  DEFAULT_QUALIFICATION_CASE_TIMEOUT_MS,
+  MAX_QUALIFICATION_CASE_TIMEOUT_MS,
+  MIN_QUALIFICATION_CASE_TIMEOUT_MS,
   QUALIFICATION_DOMAINS,
+  QUALIFICATION_FILESYSTEM_DENIAL_CODE,
+  QUALIFICATION_MCP_DENIAL_CODE,
+  QUALIFICATION_NETWORK_DENIAL_CODE,
   canonicalPolicyDigest,
   runQualificationSuite,
   validateAdapterQualificationRecord,
 } from "../../packages/core/src/adapter-qualification.js"
 import type { AdapterQualificationRecord } from "../../packages/core/src/adapter-qualification.js"
+import type { QualificationProcessTreeFixture } from "../../packages/core/src/adapter-qualification.js"
 
 const GENERATED_AT = "2026-08-06T03:00:00Z"
 const SENTINEL = "qualification-sentinel-do-not-leak"
@@ -66,11 +76,39 @@ interface FixtureBehavior {
   missingCapability?: boolean
   probeOnly?: boolean
   acceptHostileWrite?: boolean
+  acceptNetworkDeny?: boolean
+  acceptMcpDeny?: boolean
+  failNetworkDenyAtRun?: boolean
+  failMcpDenyAtRun?: boolean
+  genericNetworkDeny?: boolean
+  genericMcpDeny?: boolean
+  wrongNetworkDenyAtRun?: boolean
+  wrongMcpDenyAtRun?: boolean
+  omitNetworkDenyAttempt?: boolean
+  omitMcpDenyAttempt?: boolean
+  cancelCompletes?: boolean
+  eventAfterCancel?: boolean
+  hangEventStream?: boolean
+  capabilitySource?: unknown
+  hostVersion?: string
+  lifecycle?: string[]
+}
+
+function qualificationOperation(request: AgentHostRunRequest): string {
+  const driver = request.metadata?.adapterQualification
+  if (!driver || typeof driver !== "object" || Array.isArray(driver)) return ""
+  const operation = (driver as Record<string, unknown>).operation
+  if (!operation || typeof operation !== "object" || Array.isArray(operation)) {
+    return ""
+  }
+  return String((operation as Record<string, unknown>).kind ?? "")
 }
 
 function qualificationAdapter(
   behavior: FixtureBehavior = {},
 ): AgentHostAdapter {
+  const cancelled = new Set<string>()
+  const cancelWaiters = new Map<string, () => void>()
   return {
     hostId: "fixture-host",
     async probe() {
@@ -85,15 +123,64 @@ function qualificationAdapter(
       if (behavior.probeOnly) {
         probe.adapterStatus = "probe_only"
       }
+      if (behavior.capabilitySource !== undefined) {
+        ;(probe as unknown as Record<string, unknown>).capabilitySource =
+          behavior.capabilitySource
+      }
+      if (behavior.hostVersion !== undefined) probe.version = behavior.hostVersion
       return probe
     },
     async preflight(request: AgentHostRunRequest) {
+      const operation = qualificationOperation(request)
+      if (operation === "filesystem.write" && !behavior.acceptHostileWrite) {
+        throw new CoreError(
+          QUALIFICATION_FILESYSTEM_DENIAL_CODE,
+          "filesystem operation denied by policy",
+          { status: 403, retryable: false },
+        )
+      }
       if (!behavior.acceptHostileWrite && request.policy.filesystem.write.length > 0) {
         throw new Error("write outside filesystem scope")
+      }
+      if (
+        operation === "network.connect" &&
+        !behavior.acceptNetworkDeny &&
+        !behavior.failNetworkDenyAtRun &&
+        !behavior.wrongNetworkDenyAtRun &&
+        !behavior.omitNetworkDenyAttempt
+      ) {
+        if (behavior.genericNetworkDeny) throw new Error("network denied")
+        throw new CoreError(
+          QUALIFICATION_NETWORK_DENIAL_CODE,
+          "network operation denied by policy",
+          { status: 403, retryable: false },
+        )
+      }
+      if (
+        operation === "mcp.invoke" &&
+        !behavior.acceptMcpDeny &&
+        !behavior.failMcpDenyAtRun &&
+        !behavior.wrongMcpDenyAtRun &&
+        !behavior.omitMcpDenyAttempt
+      ) {
+        if (behavior.genericMcpDeny) throw new Error("undeclared MCP denied")
+        throw new CoreError(
+          QUALIFICATION_MCP_DENIAL_CODE,
+          "MCP operation denied by policy",
+          { status: 403, retryable: false },
+        )
       }
       return verifiedProbe()
     },
     async *run(request) {
+      behavior.lifecycle?.push(`run:${request.runId}`)
+      const operation = qualificationOperation(request)
+      if (
+        (operation === "network.connect" && behavior.omitNetworkDenyAttempt) ||
+        (operation === "mcp.invoke" && behavior.omitMcpDenyAttempt)
+      ) {
+        return
+      }
       const at = "2026-08-06T03:00:00.000Z"
       const started: AgentHostEvent = {
         type: "run.started",
@@ -101,6 +188,78 @@ function qualificationAdapter(
         timestamp: at,
       }
       yield started
+      if (
+        (operation === "network.connect" &&
+          (behavior.failNetworkDenyAtRun ||
+            behavior.wrongNetworkDenyAtRun)) ||
+        (operation === "mcp.invoke" &&
+          (behavior.failMcpDenyAtRun || behavior.wrongMcpDenyAtRun))
+      ) {
+        yield {
+          type: "run.failed",
+          runId: request.runId,
+          timestamp: at,
+          error: {
+            code:
+              behavior.wrongNetworkDenyAtRun || behavior.wrongMcpDenyAtRun
+                ? "unrelated_failure"
+                : operation === "network.connect"
+                ? QUALIFICATION_NETWORK_DENIAL_CODE
+                : QUALIFICATION_MCP_DENIAL_CODE,
+            message: "direct qualification attempt denied",
+            retryable: false,
+          },
+        }
+        return
+      }
+      if (
+        behavior.hangEventStream &&
+        request.runId === "qualification-event_stream"
+      ) {
+        await new Promise<void>((resolve) => {
+          cancelWaiters.set(request.runId, resolve)
+          if (cancelled.has(request.runId)) resolve()
+        })
+        return
+      }
+      if (
+        operation === "lifecycle.wait_for_cancel" ||
+        (operation === "process_tree" &&
+          request.runId !== "qualification-process_tree_normal")
+      ) {
+        if (behavior.cancelCompletes) {
+          yield {
+            type: "run.completed",
+            runId: request.runId,
+            timestamp: at,
+            output: { status: "completed-before-cancel" },
+          }
+          return
+        }
+        await new Promise<void>((resolve) => {
+          cancelWaiters.set(request.runId, resolve)
+          if (cancelled.has(request.runId)) resolve()
+        })
+        yield {
+          type: "run.failed",
+          runId: request.runId,
+          timestamp: at,
+          error: {
+            code: "agent_host_cancelled",
+            message: "run cancelled",
+            retryable: false,
+          },
+        }
+        if (behavior.eventAfterCancel) {
+          yield {
+            type: "usage",
+            runId: request.runId,
+            timestamp: at,
+            totalTokens: 1,
+          }
+        }
+        return
+      }
       if (behavior.echoMetadata) {
         yield {
           type: "assistant.delta",
@@ -146,7 +305,19 @@ function qualificationAdapter(
         }
       }
     },
-    async cancel() {},
+    async cancel(runId) {
+      behavior.lifecycle?.push(`cancel:${runId}`)
+      cancelled.add(runId)
+      cancelWaiters.get(runId)?.()
+    },
+    async qualificationIdentity() {
+      return {
+        configurationDigest: createHash("sha256")
+          .update("fixture-host/default-config")
+          .digest("hex"),
+        ownerPid: process.pid,
+      }
+    },
   }
 }
 
@@ -154,11 +325,288 @@ async function workingDirectory(): Promise<string> {
   return await mkdtemp(path.join(os.tmpdir(), "adapter-qualification-"))
 }
 
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH"
+  }
+}
+
+async function waitForPidsGone(
+  pids: readonly number[],
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (pids.some(pidAlive) && Date.now() < deadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+async function terminateFixtureTree(
+  child: ChildProcess,
+  grandchildPid?: number,
+): Promise<void> {
+  const pids = [child.pid, grandchildPid].filter(
+    (pid): pid is number => pid !== undefined,
+  )
+  const signal = (name: NodeJS.Signals): void => {
+    if (process.platform !== "win32" && child.pid !== undefined) {
+      try {
+        process.kill(-child.pid, name)
+        return
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error
+      }
+    }
+    for (const pid of pids) {
+      if (!pidAlive(pid)) continue
+      try {
+        process.kill(pid, name)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error
+      }
+    }
+  }
+  signal("SIGTERM")
+  await waitForPidsGone(pids)
+  if (pids.some(pidAlive)) {
+    signal("SIGKILL")
+    await waitForPidsGone(pids)
+  }
+  child.stdout?.destroy()
+  child.unref()
+}
+
+function realProcessTreeFixture(
+  adapter: AgentHostAdapter,
+  observed: Array<{ childPid: number; grandchildPid: number }> = [],
+): QualificationProcessTreeFixture {
+  return {
+    async create() {
+      // These helpers are intentionally terminated, so they must not leave a
+      // half-written V8 coverage artifact in the parent test run.
+      const {
+        NODE_V8_COVERAGE: _testRunnerCoverageDirectory,
+        ...fixtureEnvironment
+      } = process.env
+      const child = spawn(
+        process.execPath,
+        [
+          "-e",
+          [
+            'const { spawn } = require("node:child_process")',
+            'const grandchild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" })',
+            'process.stdout.write(String(grandchild.pid) + "\\n")',
+            "setInterval(() => {}, 1000)",
+          ].join(";"),
+        ],
+        {
+          detached: false,
+          env: fixtureEnvironment,
+          stdio: ["ignore", "pipe", "ignore"],
+        },
+      )
+      assert.ok(child.pid)
+      let handshakeTimer: ReturnType<typeof setTimeout> | undefined
+      let grandchildPid: number
+      try {
+        grandchildPid = await new Promise<number>((resolve, reject) => {
+          let carry = ""
+          handshakeTimer = setTimeout(
+            () => reject(new Error("grandchild pid fixture timed out")),
+            5_000,
+          )
+          child.stdout?.on("data", (chunk: Buffer) => {
+            carry += chunk.toString("utf8")
+            const newline = carry.indexOf("\n")
+            if (newline === -1) return
+            resolve(Number(carry.slice(0, newline)))
+          })
+          child.once("error", reject)
+        })
+      } catch (error) {
+        await terminateFixtureTree(child)
+        throw error
+      } finally {
+        if (handshakeTimer !== undefined) clearTimeout(handshakeTimer)
+      }
+      child.stdout?.destroy()
+      child.unref()
+      const descendants = { childPid: child.pid, grandchildPid }
+      observed.push(descendants)
+      let disposePromise: Promise<void> | undefined
+      return {
+        adapter,
+        async descendants() {
+          return descendants
+        },
+        dispose() {
+          disposePromise ??= terminateFixtureTree(child, grandchildPid)
+          return disposePromise
+        },
+      }
+    },
+  }
+}
+
+function unrelatedProcessFixture(
+  adapter: AgentHostAdapter,
+  observed: Array<{ childPid: number; grandchildPid: number }> = [],
+): QualificationProcessTreeFixture {
+  return {
+    async create() {
+      const { NODE_V8_COVERAGE: _coverageDirectory, ...fixtureEnvironment } =
+        process.env
+      const child = spawn(
+        process.execPath,
+        ["-e", "setInterval(() => {}, 1000)"],
+        { detached: false, env: fixtureEnvironment, stdio: "ignore" },
+      )
+      const unrelated = spawn(
+        process.execPath,
+        ["-e", "setInterval(() => {}, 1000)"],
+        { detached: false, env: fixtureEnvironment, stdio: "ignore" },
+      )
+      assert.ok(child.pid)
+      assert.ok(unrelated.pid)
+      const descendants = {
+        childPid: child.pid,
+        grandchildPid: unrelated.pid,
+      }
+      observed.push(descendants)
+      let disposePromise: Promise<void> | undefined
+      return {
+        adapter,
+        async descendants() {
+          return descendants
+        },
+        dispose() {
+          disposePromise ??= terminateFixtureTree(child, unrelated.pid)
+          return disposePromise
+        },
+      }
+    },
+  }
+}
+
+function rogueIntermediaryProcessFixture(
+  adapter: AgentHostAdapter,
+  observed: Array<{
+    intermediaryPid: number
+    childPid: number
+    grandchildPid: number
+  }> = [],
+): QualificationProcessTreeFixture {
+  return {
+    async create() {
+      const { NODE_V8_COVERAGE: _coverageDirectory, ...fixtureEnvironment } =
+        process.env
+      const grandchildProgram = "setInterval(() => {}, 1000)"
+      const childProgram = [
+        'const { spawn } = require("node:child_process")',
+        `const grandchild = spawn(process.execPath, ["-e", ${JSON.stringify(grandchildProgram)}], { stdio: "ignore" })`,
+        'process.stdout.write(String(grandchild.pid) + "\\n")',
+        "setInterval(() => {}, 1000)",
+      ].join(";")
+      const intermediaryProgram = [
+        'const { spawn } = require("node:child_process")',
+        `const child = spawn(process.execPath, ["-e", ${JSON.stringify(childProgram)}], { stdio: ["ignore", "pipe", "ignore"] })`,
+        'child.stdout.once("data", (chunk) => process.stdout.write(String(child.pid) + " " + chunk))',
+        "setInterval(() => {}, 1000)",
+      ].join(";")
+      const intermediary = spawn(
+        process.execPath,
+        ["-e", intermediaryProgram],
+        {
+          detached: false,
+          env: fixtureEnvironment,
+          stdio: ["ignore", "pipe", "ignore"],
+        },
+      )
+      assert.ok(intermediary.pid)
+      let handshakeTimer: ReturnType<typeof setTimeout> | undefined
+      let childPid: number
+      let grandchildPid: number
+      try {
+        ;({ childPid, grandchildPid } = await new Promise<{
+          childPid: number
+          grandchildPid: number
+        }>((resolve, reject) => {
+          let carry = ""
+          handshakeTimer = setTimeout(
+            () => reject(new Error("rogue intermediary fixture timed out")),
+            5_000,
+          )
+          intermediary.stdout?.on("data", (chunk: Buffer) => {
+            carry += chunk.toString("utf8")
+            const match = carry.match(/^(\d+)\s+(\d+)\n/)
+            if (!match) return
+            resolve({ childPid: Number(match[1]), grandchildPid: Number(match[2]) })
+          })
+          intermediary.once("error", reject)
+        }))
+      } catch (error) {
+        await terminateFixtureTree(intermediary)
+        throw error
+      } finally {
+        if (handshakeTimer !== undefined) clearTimeout(handshakeTimer)
+      }
+      intermediary.stdout?.destroy()
+      intermediary.unref()
+      const descendants = { childPid, grandchildPid }
+      observed.push({
+        intermediaryPid: intermediary.pid,
+        ...descendants,
+      })
+      let disposePromise: Promise<void> | undefined
+      return {
+        adapter,
+        async descendants() {
+          return descendants
+        },
+        dispose() {
+          disposePromise ??= (async () => {
+            for (const pid of [grandchildPid, childPid]) {
+              if (!pidAlive(pid)) continue
+              try {
+                process.kill(pid, "SIGTERM")
+              } catch (error) {
+                if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error
+              }
+            }
+            await waitForPidsGone([childPid, grandchildPid])
+            for (const pid of [grandchildPid, childPid]) {
+              if (!pidAlive(pid)) continue
+              try {
+                process.kill(pid, "SIGKILL")
+              } catch (error) {
+                if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error
+              }
+            }
+            await waitForPidsGone([childPid, grandchildPid])
+            await terminateFixtureTree(intermediary)
+          })()
+          return disposePromise
+        },
+      }
+    },
+  }
+}
+
 test("a conforming built-in-class adapter earns the fixture axis without live evidence", async () => {
   const directory = await workingDirectory()
-  const record = await runQualificationSuite(qualificationAdapter(), {
+  const observed: Array<{ childPid: number; grandchildPid: number }> = []
+  const adapter = qualificationAdapter()
+  const record = await runQualificationSuite(adapter, {
     workingDirectory: directory,
     generatedAt: GENERATED_AT,
+    caseTimeoutMs: 10_000,
+    processTreeFixture: realProcessTreeFixture(
+      adapter,
+      observed,
+    ),
   })
 
   assert.equal(record.schema, ADAPTER_QUALIFICATION_SCHEMA_ID)
@@ -169,13 +617,20 @@ test("a conforming built-in-class adapter earns the fixture axis without live ev
     implemented: true,
     fixtureConformant: true,
     liveQualified: false,
-  })
+  }, JSON.stringify(record.cases.filter((entry) => !entry.passed)))
   assert.equal(record.liveEvidence, undefined)
-  assert.equal(record.cases.length, 9)
+  assert.equal(record.cases.length, 13)
   assert.ok(record.cases.every((entry) => entry.passed))
   for (const domain of QUALIFICATION_DOMAINS) {
     assert.equal(record.domains[domain].failed, 0, domain)
   }
+  assert.equal(observed.length, 3)
+  assert.ok(
+    observed.every(
+      ({ childPid, grandchildPid }) =>
+        !pidAlive(childPid) && !pidAlive(grandchildPid),
+    ),
+  )
   assert.equal(
     record.policyDigest,
     createHash("sha256")
@@ -184,6 +639,608 @@ test("a conforming built-in-class adapter earns the fixture axis without live ev
       )
       .digest("hex"),
   )
+})
+
+test("qualification cases use the frozen bounded timeout range", async () => {
+  assert.equal(DEFAULT_QUALIFICATION_CASE_TIMEOUT_MS, 30_000)
+  assert.equal(MIN_QUALIFICATION_CASE_TIMEOUT_MS, 1_000)
+  assert.equal(MAX_QUALIFICATION_CASE_TIMEOUT_MS, 600_000)
+  const directory = await workingDirectory()
+  for (const caseTimeoutMs of [999, 600_001, 1_000.5, Number.NaN]) {
+    await assert.rejects(
+      () =>
+        runQualificationSuite(qualificationAdapter(), {
+          workingDirectory: directory,
+          generatedAt: GENERATED_AT,
+          caseTimeoutMs,
+        }),
+      (error: unknown) =>
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "INVALID_QUALIFICATION_CASE_TIMEOUT",
+    )
+  }
+})
+
+test("a hung case times out with a stable result and the suite continues", async () => {
+  const directory = await workingDirectory()
+  const startedAt = Date.now()
+  const record = await runQualificationSuite(
+    qualificationAdapter({ hangEventStream: true }),
+    {
+      workingDirectory: directory,
+      generatedAt: GENERATED_AT,
+      caseTimeoutMs: 1_000,
+    },
+  )
+  assert.ok(Date.now() - startedAt < 4_000)
+  const eventCases = record.cases.filter(
+    (entry) =>
+      entry.id === "events_well_formed" ||
+      entry.id === "exactly_one_terminal",
+  )
+  assert.equal(eventCases.length, 2)
+  assert.ok(
+    eventCases.every(
+      (entry) => !entry.passed && entry.code === "qualification_case_timeout",
+    ),
+  )
+  assert.ok(
+    record.cases.some(
+      (entry) =>
+        entry.id === "terminal_output_matches_schema" && entry.passed,
+    ),
+  )
+})
+
+test("deadline cancellation starts the run before cancelling and requires one failed terminal", async () => {
+  const directory = await workingDirectory()
+  const lifecycle: string[] = []
+  const record = await runQualificationSuite(
+    qualificationAdapter({ lifecycle }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  assert.deepEqual(
+    lifecycle.filter((entry) => entry.includes("qualification-cancel")),
+    ["run:qualification-cancel", "cancel:qualification-cancel"],
+  )
+  const cancelCase = record.cases.find(
+    (entry) => entry.id === "cancel_stops_active_run",
+  )
+  assert.deepEqual(cancelCase, {
+    domain: "deadline_cancel",
+    id: "cancel_stops_active_run",
+    passed: true,
+    code: "cancel_stops_active_run_ok",
+  })
+
+  const completed = await runQualificationSuite(
+    qualificationAdapter({ cancelCompletes: true }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  assert.equal(
+    completed.cases.find((entry) => entry.id === "cancel_stops_active_run")
+      ?.code,
+    "cancel_completed_terminal",
+  )
+  const lateEvent = await runQualificationSuite(
+    qualificationAdapter({ eventAfterCancel: true }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  assert.equal(
+    lateEvent.cases.find((entry) => entry.id === "cancel_stops_active_run")
+      ?.code,
+    "cancel_event_after_terminal",
+  )
+})
+
+test("cleanup fails closed without real child and grandchild evidence", async () => {
+  const directory = await workingDirectory()
+  const record = await runQualificationSuite(qualificationAdapter(), {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+  })
+  const cleanup = record.cases.filter(
+    (entry) => entry.domain === "process_tree_cleanup",
+  )
+  assert.deepEqual(
+    cleanup.map((entry) => entry.id),
+    [
+      "descendants_disposed_normal",
+      "descendants_disposed_timeout",
+      "descendants_disposed_cancel",
+    ],
+  )
+  assert.ok(
+    cleanup.every(
+      (entry) =>
+        !entry.passed && entry.code === "process_tree_fixture_unavailable",
+    ),
+  )
+  assert.equal(record.axes.fixtureConformant, false)
+})
+
+test("process evidence rejects substitute adapters, drifted configuration and unrelated pids", async () => {
+  const directory = await workingDirectory()
+
+  const outer = qualificationAdapter()
+  const substituteObserved: Array<{ childPid: number; grandchildPid: number }> = []
+  const substitute = await runQualificationSuite(outer, {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+    caseTimeoutMs: 10_000,
+    processTreeFixture: realProcessTreeFixture(
+      qualificationAdapter(),
+      substituteObserved,
+    ),
+  })
+  assert.ok(
+    substitute.cases
+      .filter((entry) => entry.domain === "process_tree_cleanup")
+      .every(
+        (entry) =>
+          !entry.passed && entry.code === "process_tree_adapter_mismatch",
+      ),
+  )
+  assert.ok(
+    substituteObserved.every(
+      ({ childPid, grandchildPid }) =>
+        !pidAlive(childPid) && !pidAlive(grandchildPid),
+    ),
+  )
+
+  const drifted = qualificationAdapter()
+  let identityCalls = 0
+  drifted.qualificationIdentity = async () => {
+    identityCalls += 1
+    return {
+      configurationDigest: createHash("sha256")
+        .update(identityCalls === 1 ? "bound-config" : "drifted-config")
+        .digest("hex"),
+      ownerPid: process.pid,
+    }
+  }
+  const driftedRecord = await runQualificationSuite(drifted, {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+    caseTimeoutMs: 10_000,
+    processTreeFixture: realProcessTreeFixture(drifted),
+  })
+  assert.ok(
+    driftedRecord.cases
+      .filter((entry) => entry.domain === "process_tree_cleanup")
+      .every(
+        (entry) =>
+          !entry.passed && entry.code === "process_tree_binding_mismatch",
+      ),
+  )
+
+  const lineageAdapter = qualificationAdapter()
+  const unrelatedRecord = await runQualificationSuite(lineageAdapter, {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+    caseTimeoutMs: 10_000,
+    processTreeFixture: unrelatedProcessFixture(lineageAdapter),
+  })
+  assert.ok(
+    unrelatedRecord.cases
+      .filter((entry) => entry.domain === "process_tree_cleanup")
+      .every(
+        (entry) =>
+          !entry.passed && entry.code === "process_tree_lineage_unverified",
+      ),
+  )
+})
+
+test("process evidence rejects a same-identity tree hidden behind a rogue intermediary", async () => {
+  const directory = await workingDirectory()
+  const adapter = qualificationAdapter()
+  const observed: Array<{
+    intermediaryPid: number
+    childPid: number
+    grandchildPid: number
+  }> = []
+  const record = await runQualificationSuite(adapter, {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+    caseTimeoutMs: 10_000,
+    processTreeFixture: rogueIntermediaryProcessFixture(adapter, observed),
+  })
+  assert.ok(
+    record.cases
+      .filter((entry) => entry.domain === "process_tree_cleanup")
+      .every(
+        (entry) =>
+          !entry.passed && entry.code === "process_tree_lineage_unverified",
+      ),
+    JSON.stringify(record.cases.filter((entry) => entry.domain === "process_tree_cleanup")),
+  )
+  assert.equal(observed.length, 3)
+  assert.ok(
+    observed.every(
+      ({ intermediaryPid, childPid, grandchildPid }) =>
+        !pidAlive(intermediaryPid) &&
+        !pidAlive(childPid) &&
+        !pidAlive(grandchildPid),
+    ),
+  )
+})
+
+test("network and undeclared MCP deny paths must be exercised directly", async () => {
+  const directory = await workingDirectory()
+  const acceptedNetwork = await runQualificationSuite(
+    qualificationAdapter({ acceptNetworkDeny: true }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  assert.equal(
+    acceptedNetwork.cases.find((entry) => entry.id === "network_deny_refused")
+      ?.code,
+    "network_deny_accepted",
+  )
+  const acceptedMcp = await runQualificationSuite(
+    qualificationAdapter({ acceptMcpDeny: true }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  assert.equal(
+    acceptedMcp.cases.find((entry) => entry.id === "mcp_deny_refused")?.code,
+    "mcp_deny_accepted",
+  )
+  const failedAtRun = await runQualificationSuite(
+    qualificationAdapter({
+      failNetworkDenyAtRun: true,
+      failMcpDenyAtRun: true,
+    }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  for (const id of ["network_deny_refused", "mcp_deny_refused"]) {
+    assert.equal(
+      failedAtRun.cases.find((entry) => entry.id === id)?.passed,
+      true,
+      id,
+    )
+  }
+})
+
+test("generic preflight failures are not accepted as direct policy-denial evidence", async () => {
+  const directory = await workingDirectory()
+  const record = await runQualificationSuite(
+    qualificationAdapter({
+      genericNetworkDeny: true,
+      genericMcpDeny: true,
+    }), {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+  })
+  for (const id of ["network_deny_refused", "mcp_deny_refused"]) {
+    const result = record.cases.find((entry) => entry.id === id)
+    assert.equal(result?.passed, false, id)
+    assert.match(result?.code ?? "", /policy_evidence_invalid$/)
+  }
+})
+
+test("a generic hostile-write preflight failure is not typed policy-denial evidence", async () => {
+  const directory = await workingDirectory()
+  const adapter = qualificationAdapter()
+  const originalPreflight = adapter.preflight.bind(adapter)
+  let observedOperation = ""
+  adapter.preflight = async (request) => {
+    const operation = qualificationOperation(request)
+    if (
+      operation === "filesystem.write" ||
+      request.policy.filesystem.write.length > 0
+    ) {
+      observedOperation = operation
+      throw new Error("database unavailable")
+    }
+    return await originalPreflight(request)
+  }
+  const record = await runQualificationSuite(adapter, {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+  })
+  const result = record.cases.find(
+    (entry) => entry.id === "hostile_write_refused",
+  )
+  assert.equal(observedOperation, "filesystem.write")
+  assert.equal(result?.passed, false)
+  assert.equal(result?.code, "filesystem_deny_policy_evidence_invalid")
+})
+
+test("unrelated failed terminals and no-attempt streams are not policy evidence", async () => {
+  const directory = await workingDirectory()
+  for (const behavior of [
+    { wrongNetworkDenyAtRun: true, wrongMcpDenyAtRun: true },
+    { omitNetworkDenyAttempt: true, omitMcpDenyAttempt: true },
+  ]) {
+    const record = await runQualificationSuite(qualificationAdapter(behavior), {
+      workingDirectory: directory,
+      generatedAt: GENERATED_AT,
+    })
+    for (const id of ["network_deny_refused", "mcp_deny_refused"]) {
+      const result = record.cases.find((entry) => entry.id === id)
+      assert.equal(result?.passed, false, `${id}: ${JSON.stringify(behavior)}`)
+      assert.match(result?.code ?? "", /policy_evidence_invalid$/)
+    }
+  }
+})
+
+test("each case awaits cancel and iterator return before starting the next case", async () => {
+  const directory = await workingDirectory()
+  const lifecycle: string[] = []
+  const adapter = qualificationAdapter({ lifecycle })
+  const normalRun = adapter.run.bind(adapter)
+  adapter.run = (request) => {
+    if (request.runId !== "qualification-event_stream") {
+      lifecycle.push(`next:${request.runId}`)
+      return normalRun(request)
+    }
+    let index = 0
+    const events: AgentHostEvent[] = [
+      {
+        type: "run.started",
+        runId: request.runId,
+        timestamp: GENERATED_AT,
+      },
+      {
+        type: "run.completed",
+        runId: request.runId,
+        timestamp: GENERATED_AT,
+        output: { status: "done" },
+      },
+    ]
+    const iterator: AsyncIterator<AgentHostEvent> &
+      AsyncIterable<AgentHostEvent> = {
+      [Symbol.asyncIterator]() {
+        return this
+      },
+      async next() {
+        const value = events[index]
+        index += 1
+        return value === undefined
+          ? { done: true, value: undefined }
+          : { done: false, value }
+      },
+      async return() {
+        await new Promise<void>((resolve) => setTimeout(resolve, 25))
+        lifecycle.push("return:settled")
+        throw new Error(`late cleanup ${SENTINEL}`)
+      },
+    }
+    return iterator
+  }
+
+  const record = await runQualificationSuite(adapter, {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+  })
+  const cancelIndex = lifecycle.indexOf("cancel:qualification-event_stream")
+  const returnIndex = lifecycle.indexOf("return:settled")
+  const nextIndex = lifecycle.findIndex((entry) =>
+    entry.startsWith("next:qualification-cancel"),
+  )
+  assert.ok(cancelIndex !== -1 && cancelIndex < returnIndex)
+  assert.ok(returnIndex !== -1 && returnIndex < nextIndex)
+  assert.equal(
+    record.cases.find((entry) => entry.id === "no_metadata_echo")?.code,
+    "metadata_secret_echoed",
+  )
+})
+
+test("process fixture disposal settles before the following qualification case", async () => {
+  const directory = await workingDirectory()
+  const lifecycle: string[] = []
+  const adapter = qualificationAdapter({ lifecycle })
+  const baseFixture = realProcessTreeFixture(adapter)
+  const fixture: QualificationProcessTreeFixture = {
+    async create(scenario) {
+      const instance = await baseFixture.create(scenario)
+      return {
+        ...instance,
+        async dispose() {
+          await instance.dispose()
+          await new Promise<void>((resolve) => setTimeout(resolve, 20))
+          lifecycle.push(`dispose:settled:${scenario}`)
+        },
+      }
+    },
+  }
+  await runQualificationSuite(adapter, {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+    caseTimeoutMs: 10_000,
+    processTreeFixture: fixture,
+  })
+  for (const [scenario, followingRun] of [
+    ["normal", "qualification-process_tree_timeout"],
+    ["timeout", "qualification-process_tree_cancel"],
+    ["cancel", "qualification-credential"],
+  ] as const) {
+    const disposed = lifecycle.indexOf(`dispose:settled:${scenario}`)
+    const following = lifecycle.indexOf(`run:${followingRun}`)
+    assert.ok(disposed !== -1 && disposed < following, scenario)
+  }
+})
+
+test("an uncooperative teardown aborts the suite with a stable bounded error", async () => {
+  const directory = await workingDirectory()
+  const adapter = qualificationAdapter({ hangEventStream: true })
+  adapter.cancel = async (runId) => {
+    if (runId === "qualification-event_stream") {
+      await new Promise<void>(() => {})
+    }
+  }
+  const startedAt = Date.now()
+  await assert.rejects(
+    () =>
+      runQualificationSuite(adapter, {
+        workingDirectory: directory,
+        generatedAt: GENERATED_AT,
+        caseTimeoutMs: 1_000,
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "QUALIFICATION_CLEANUP_TIMEOUT",
+  )
+  assert.ok(Date.now() - startedAt < 3_500)
+})
+
+test("an outer process-case timeout cancels the exact fixture owner and disposes descendants", async () => {
+  const directory = await workingDirectory()
+  const lifecycle: string[] = []
+  const adapter = qualificationAdapter({ lifecycle })
+  const observed: Array<{ childPid: number; grandchildPid: number }> = []
+  const baseFixture = realProcessTreeFixture(adapter, observed)
+  const fixture: QualificationProcessTreeFixture = {
+    async create(scenario) {
+      const instance = await baseFixture.create(scenario)
+      return scenario === "normal"
+        ? {
+            ...instance,
+            async descendants() {
+              await new Promise<void>(() => {})
+              return await instance.descendants()
+            },
+          }
+        : instance
+    },
+  }
+  await assert.rejects(
+    () =>
+      runQualificationSuite(adapter, {
+        workingDirectory: directory,
+        generatedAt: GENERATED_AT,
+        caseTimeoutMs: 1_000,
+        processTreeFixture: fixture,
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "QUALIFICATION_CLEANUP_TIMEOUT",
+  )
+  assert.ok(lifecycle.includes("cancel:qualification-process_tree_normal"))
+  assert.ok(
+    observed.every(
+      ({ childPid, grandchildPid }) =>
+        !pidAlive(childPid) && !pidAlive(grandchildPid),
+    ),
+  )
+})
+
+test("sentinel scanning covers conforming, malformed, rejected and thrown paths", async () => {
+  const directory = await workingDirectory()
+  const makeAdapter = (
+    mode: "conforming" | "malformed" | "rejected" | "thrown",
+  ): AgentHostAdapter => {
+    const adapter = qualificationAdapter()
+    if (mode === "conforming") return adapter
+    const run = adapter.run.bind(adapter)
+    adapter.run = (request) => {
+      if (request.runId !== "qualification-credential") return run(request)
+      if (mode === "thrown") throw new Error(`thrown ${SENTINEL}`)
+      if (mode === "rejected") {
+        return {
+          [Symbol.asyncIterator]() {
+            return {
+              next: async () => {
+                throw new Error(`rejected ${SENTINEL}`)
+              },
+            }
+          },
+        }
+      }
+      return (async function* () {
+        yield {
+          type: "malformed",
+          secret: SENTINEL,
+        } as unknown as AgentHostEvent
+      })()
+    }
+    return adapter
+  }
+
+  for (const mode of [
+    "conforming",
+    "malformed",
+    "rejected",
+    "thrown",
+  ] as const) {
+    const record = await runQualificationSuite(makeAdapter(mode), {
+      workingDirectory: directory,
+      generatedAt: GENERATED_AT,
+    })
+    const credentialCase = record.cases.find(
+      (entry) => entry.id === "no_metadata_echo",
+    )
+    assert.equal(
+      credentialCase?.code,
+      mode === "conforming" ? "no_metadata_echo_ok" : "metadata_secret_echoed",
+      mode,
+    )
+    assert.equal(JSON.stringify(record).includes(SENTINEL), false, mode)
+  }
+})
+
+test("qualification accepts exactly the two canonical capability sources", async () => {
+  const directory = await workingDirectory()
+  for (const capabilitySource of [
+    "adapter_declaration",
+    "conformance_test",
+  ] as const) {
+    const record = await runQualificationSuite(
+      qualificationAdapter({ capabilitySource }),
+      { workingDirectory: directory, generatedAt: GENERATED_AT },
+    )
+    assert.equal(record.axes.implemented, true, capabilitySource)
+    assert.equal(
+      record.cases.find((entry) => entry.id === "probe_contract")?.passed,
+      true,
+      capabilitySource,
+    )
+  }
+  for (const capabilitySource of ["vendor_claim", "", undefined]) {
+    const adapter = qualificationAdapter({ capabilitySource })
+    if (capabilitySource === undefined) {
+      const originalProbe = adapter.probe.bind(adapter)
+      adapter.probe = async () => {
+        const probe = (await originalProbe()) as unknown as Record<string, unknown>
+        delete probe.capabilitySource
+        return probe as unknown as AgentHostProbeResult
+      }
+    }
+    const record = await runQualificationSuite(adapter, {
+      workingDirectory: directory,
+      generatedAt: GENERATED_AT,
+    })
+    assert.equal(record.axes.implemented, false, String(capabilitySource))
+    assert.equal(
+      record.cases.find((entry) => entry.id === "probe_contract")?.passed,
+      false,
+      String(capabilitySource),
+    )
+  }
+})
+
+test("responding qualification hosts require an exact bounded version", async () => {
+  const directory = await workingDirectory()
+  const boundary = await runQualificationSuite(
+    qualificationAdapter({ hostVersion: "v".repeat(256) }),
+    { workingDirectory: directory, generatedAt: GENERATED_AT },
+  )
+  assert.equal(boundary.hostVersion.length, 256)
+  for (const hostVersion of ["", "v".repeat(257)]) {
+    await assert.rejects(
+      () =>
+        runQualificationSuite(qualificationAdapter({ hostVersion }), {
+          workingDirectory: directory,
+          generatedAt: GENERATED_AT,
+        }),
+      (error: unknown) =>
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "INVALID_QUALIFICATION_HOST_VERSION",
+    )
+  }
 })
 
 test("a stream violation can never be reported as fixture-conformant", async () => {
@@ -256,7 +1313,7 @@ test("an adapter that accepts hostile writes fails the enforcement domain", asyn
     (entry) => entry.id === "hostile_write_refused",
   )
   assert.equal(fsCase?.passed, false)
-  assert.equal(fsCase?.code, "hostile_write_accepted")
+  assert.equal(fsCase?.code, "filesystem_deny_accepted")
   assert.equal(record.axes.fixtureConformant, false)
 })
 
@@ -391,6 +1448,204 @@ test("the record validator enforces schema, axis consistency and full domain cov
   assert.throws(() => validateAdapterQualificationRecord(null))
 })
 
+test("record validation fails closed on accessors without invoking them", async () => {
+  const directory = await workingDirectory()
+  const record = await runQualificationSuite(qualificationAdapter(), {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+  })
+  let invoked = 0
+  Object.defineProperty(record, Symbol("opaque"), {
+    enumerable: true,
+    get() {
+      invoked += 1
+      return SENTINEL
+    },
+  })
+  assert.throws(
+    () => validateAdapterQualificationRecord(record),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "QUALIFICATION_EVIDENCE_SCAN_INCOMPLETE",
+  )
+  assert.equal(invoked, 0)
+})
+
+test("record scanning recognizes only native Error stack accessors without invoking custom getters", async () => {
+  const directory = await workingDirectory()
+  const makeRecord = async () =>
+    await runQualificationSuite(qualificationAdapter(), {
+      workingDirectory: directory,
+      generatedAt: GENERATED_AT,
+    })
+
+  const nativeErrorRecord = await makeRecord()
+  Object.defineProperty(nativeErrorRecord, Symbol("native-error"), {
+    value: new Error("ordinary native error"),
+  })
+  assert.doesNotThrow(() => validateAdapterQualificationRecord(nativeErrorRecord))
+
+  let customGetterCalls = 0
+  const customStackRecord = await makeRecord()
+  const customStack = new Error("custom stack descriptor")
+  Object.defineProperty(customStack, "stack", {
+    configurable: true,
+    enumerable: false,
+    get() {
+      customGetterCalls += 1
+      return "custom stack"
+    },
+  })
+  Object.defineProperty(customStackRecord, Symbol("custom-stack"), {
+    value: customStack,
+  })
+  assert.throws(
+    () => validateAdapterQualificationRecord(customStackRecord),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "QUALIFICATION_EVIDENCE_SCAN_INCOMPLETE",
+  )
+  assert.equal(customGetterCalls, 0)
+
+  const sentinelRecord = await makeRecord()
+  const sentinelStack = new Error("custom stack with symbol evidence")
+  Object.defineProperty(sentinelStack, "stack", {
+    configurable: true,
+    enumerable: false,
+    get() {
+      customGetterCalls += 1
+      return SENTINEL
+    },
+  })
+  Object.defineProperty(sentinelStack, Symbol("external-record"), {
+    value: { leaked: SENTINEL },
+  })
+  Object.defineProperty(sentinelRecord, Symbol("custom-stack"), {
+    value: sentinelStack,
+  })
+  assert.throws(
+    () => validateAdapterQualificationRecord(sentinelRecord),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "QUALIFICATION_EVIDENCE_SECRET_DETECTED",
+  )
+  assert.equal(customGetterCalls, 0)
+})
+
+test("record scanning inspects symbol data and fails closed on proxies and budget exhaustion", async () => {
+  const directory = await workingDirectory()
+  const makeRecord = async () =>
+    await runQualificationSuite(qualificationAdapter(), {
+      workingDirectory: directory,
+      generatedAt: GENERATED_AT,
+    })
+
+  const symbolEvidence = await makeRecord()
+  Object.defineProperty(symbolEvidence, Symbol("qualification-evidence"), {
+    value: { leaked: SENTINEL },
+    enumerable: false,
+  })
+  assert.throws(
+    () => validateAdapterQualificationRecord(symbolEvidence),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "QUALIFICATION_EVIDENCE_SECRET_DETECTED",
+  )
+
+  const proxied = new Proxy(await makeRecord(), {
+    ownKeys() {
+      throw new Error("proxy keys unavailable")
+    },
+  })
+  assert.throws(
+    () => validateAdapterQualificationRecord(proxied),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "QUALIFICATION_EVIDENCE_SCAN_INCOMPLETE",
+  )
+
+  const overBudget = await makeRecord()
+  Object.defineProperty(overBudget, Symbol("wide-evidence"), {
+    value: Array.from({ length: 4_097 }, () => ({ safe: true })),
+  })
+  assert.throws(
+    () => validateAdapterQualificationRecord(overBudget),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "QUALIFICATION_EVIDENCE_SCAN_INCOMPLETE",
+  )
+})
+
+test("record validation supports the legacy 1.0 contract and derives all summaries", async () => {
+  const directory = await workingDirectory()
+  const current = await runQualificationSuite(qualificationAdapter(), {
+    workingDirectory: directory,
+    generatedAt: GENERATED_AT,
+  })
+  const legacyCases = current.cases
+    .filter(
+      (entry) =>
+        ![
+          "descendants_disposed_timeout",
+          "descendants_disposed_cancel",
+          "network_deny_refused",
+          "mcp_deny_refused",
+        ].includes(entry.id),
+    )
+    .map((entry) =>
+      entry.id === "cancel_stops_active_run"
+        ? { ...entry, id: "cancel_stops_run", code: "cancel_stops_run_ok" }
+        : entry.id === "descendants_disposed_normal"
+          ? { ...entry, id: "stream_terminates", code: "stream_terminates_ok" }
+          : entry,
+    )
+  const legacyDomains = Object.fromEntries(
+    QUALIFICATION_DOMAINS.map((domain) => {
+      const entries = legacyCases.filter((entry) => entry.domain === domain)
+      return [
+        domain,
+        {
+          passed: entries.filter((entry) => entry.passed).length,
+          failed: entries.filter((entry) => !entry.passed).length,
+        },
+      ]
+    }),
+  )
+  const legacy = {
+    ...current,
+    kitVersion: "1.0.0",
+    cases: legacyCases,
+    domains: legacyDomains,
+    axes: {
+      implemented: true,
+      fixtureConformant: legacyCases.every((entry) => entry.passed),
+      liveQualified: false,
+    },
+  }
+  assert.doesNotThrow(() => validateAdapterQualificationRecord(legacy))
+  assert.throws(() =>
+    validateAdapterQualificationRecord({
+      ...legacy,
+      domains: {
+        ...legacyDomains,
+        output_schema: { passed: 99, failed: 0 },
+      },
+    }),
+  )
+  assert.throws(() =>
+    validateAdapterQualificationRecord({
+      ...legacy,
+      axes: { ...legacy.axes, fixtureConformant: !legacy.axes.fixtureConformant },
+    }),
+  )
+})
+
 test("qualification records stay machine readable and never embed the credential sentinel", async () => {
   const directory = await workingDirectory()
   const record: AdapterQualificationRecord = await runQualificationSuite(
@@ -510,6 +1765,30 @@ function fakeStdioHost(options: StdioHostOptions = {}) {
         ]
       }
       if (request.kind === "preflight") {
+        const operation = qualificationOperation(payload)
+        if (
+          operation === "filesystem.write" ||
+          operation === "network.connect" ||
+          operation === "mcp.invoke"
+        ) {
+          return [
+            envelope({
+              id: request.id,
+              kind: "response",
+              ok: false,
+              error: {
+                code:
+                  operation === "filesystem.write"
+                    ? QUALIFICATION_FILESYSTEM_DENIAL_CODE
+                    : operation === "network.connect"
+                      ? QUALIFICATION_NETWORK_DENIAL_CODE
+                      : QUALIFICATION_MCP_DENIAL_CODE,
+                message: "qualification deny fixture",
+                retryable: false,
+              },
+            }),
+          ]
+        }
         return [
           envelope({
             id: request.id,
@@ -571,6 +1850,8 @@ function builtinStdioAdapter(
   options: StdioHostOptions = {},
 ): AgentHostAdapter {
   const host = fakeStdioHost(options)
+  const cancelled = new Set<string>()
+  const cancelWaiters = new Map<string, () => void>()
   const exchange = (message: Record<string, unknown>): string[] =>
     host.handle(
       encodeAgentHostStdioLine({
@@ -585,6 +1866,10 @@ function builtinStdioAdapter(
     }
     return message
   }
+  const wireRequest = (request: AgentHostRunRequest): AgentHostRunRequest => {
+    const { signal: _signal, ...wire } = request
+    return wire
+  }
   return {
     hostId: STDIO_HOST_ID,
     async probe() {
@@ -597,22 +1882,81 @@ function builtinStdioAdapter(
       )
     },
     async preflight(request) {
-      return probeResultFromStdioResponse(
-        expectOk(
-          exchange({
-            id: `preflight-${request.runId}`,
-            kind: "preflight",
-            payload: request,
-          }),
-        ),
+      const message = parseAgentHostStdioHostLine(
+        exchange({
+          id: `preflight-${request.runId}`,
+          kind: "preflight",
+          payload: wireRequest(request),
+        })[0],
         STDIO_HOST_ID,
       )
+      if (message.kind !== "response" || message.ok !== true) {
+        const error =
+          message.kind === "response" && message.ok === false
+            ? message.error
+            : {
+                code: "agent_host_stdio_host_error",
+                message: "builtin stdio host refused the exchange",
+                retryable: false,
+              }
+        throw new CoreError(error.code, error.message, {
+          status: 403,
+          retryable: error.retryable,
+        })
+      }
+      return probeResultFromStdioResponse(message, STDIO_HOST_ID)
     },
     async *run(request) {
+      const operation = qualificationOperation(request)
+      if (
+        operation === "lifecycle.wait_for_cancel" ||
+        (operation === "process_tree" &&
+          request.runId !== "qualification-process_tree_normal")
+      ) {
+        const startedLine = encodeAgentHostStdioLine({
+          protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+          id: `run-${request.runId}`,
+          kind: "event",
+          event: {
+            type: "run.started",
+            runId: request.runId,
+            timestamp: STDIO_TIMESTAMP,
+          },
+        })
+        const started = parseAgentHostStdioHostLine(
+          startedLine,
+          STDIO_HOST_ID,
+        )
+        assert.equal(started.kind, "event")
+        yield started.event
+        await new Promise<void>((resolve) => {
+          cancelWaiters.set(request.runId, resolve)
+          if (cancelled.has(request.runId)) resolve()
+        })
+        const failedLine = encodeAgentHostStdioLine({
+          protocol: AGENT_HOST_STDIO_PROTOCOL_VERSION,
+          id: `run-${request.runId}`,
+          kind: "event",
+          event: {
+            type: "run.failed",
+            runId: request.runId,
+            timestamp: STDIO_TIMESTAMP,
+            error: {
+              code: "agent_host_cancelled",
+              message: "run cancelled",
+              retryable: false,
+            },
+          },
+        })
+        const failed = parseAgentHostStdioHostLine(failedLine, STDIO_HOST_ID)
+        assert.equal(failed.kind, "event")
+        yield failed.event
+        return
+      }
       const lines = exchange({
         id: `run-${request.runId}`,
         kind: "run",
-        payload: request,
+        payload: wireRequest(request),
       })
       for (const line of lines) {
         const message = parseAgentHostStdioHostLine(line, STDIO_HOST_ID)
@@ -622,26 +1966,39 @@ function builtinStdioAdapter(
       }
     },
     async cancel(runId) {
+      cancelled.add(runId)
+      cancelWaiters.get(runId)?.()
       expectOk(
         exchange({ id: `cancel-${runId}`, kind: "cancel", payload: { runId } }),
       )
+    },
+    async qualificationIdentity() {
+      return {
+        configurationDigest: createHash("sha256")
+          .update("builtin-stdio-host/default-config")
+          .digest("hex"),
+        ownerPid: process.pid,
+      }
     },
   }
 }
 
 test("the built-in stdio adapter earns the fixture axis offline through the versioned wire", async () => {
   const directory = await workingDirectory()
-  const record = await runQualificationSuite(builtinStdioAdapter(), {
+  const adapter = builtinStdioAdapter()
+  const record = await runQualificationSuite(adapter, {
     workingDirectory: directory,
     generatedAt: GENERATED_AT,
+    caseTimeoutMs: 10_000,
+    processTreeFixture: realProcessTreeFixture(adapter),
   })
   assert.equal(record.hostId, STDIO_HOST_ID)
   assert.deepEqual(record.axes, {
     implemented: true,
     fixtureConformant: true,
     liveQualified: false,
-  })
-  assert.equal(record.cases.length, 9)
+  }, JSON.stringify(record.cases.filter((entry) => !entry.passed)))
+  assert.equal(record.cases.length, 13)
   assert.ok(record.cases.every((entry) => entry.passed))
   for (const domain of QUALIFICATION_DOMAINS) {
     assert.equal(record.domains[domain].failed, 0, domain)
@@ -785,6 +2142,17 @@ test("the record validator rejects hostVersion exceeding 256 characters", async 
     validateAdapterQualificationRecord({
       ...record,
       hostVersion: "v".repeat(256),
+    }),
+  )
+  assert.throws(() =>
+    validateAdapterQualificationRecord({ ...record, hostVersion: "" }),
+  )
+  assert.throws(() =>
+    validateAdapterQualificationRecord({
+      ...record,
+      cases: record.cases.map((entry, index) =>
+        index === 0 ? { ...entry, code: "UPPER CASE" } : entry,
+      ),
     }),
   )
 })

--- a/tests/core/adapter-qualification.test.ts
+++ b/tests/core/adapter-qualification.test.ts
@@ -1127,6 +1127,82 @@ test("an outer process-case timeout cancels the exact fixture owner and disposes
   )
 })
 
+test("emergency cleanup claims runs and cleanups registered after its initial drain", async () => {
+  const directory = await workingDirectory()
+  const lifecycle: string[] = []
+  const adapter = qualificationAdapter({ lifecycle })
+  const originalProbe = adapter.probe.bind(adapter)
+  const originalRun = adapter.run.bind(adapter)
+  let delayProcessProbe = false
+  let primaryCleanupStarted = 0
+  let lateIteratorCleanup = 0
+
+  adapter.probe = async () => {
+    if (delayProcessProbe) {
+      delayProcessProbe = false
+      await new Promise<void>((resolve) => setTimeout(resolve, 2_500))
+    }
+    return await originalProbe()
+  }
+  adapter.run = (request) => {
+    const source = originalRun(request)
+    if (request.runId !== "qualification-process_tree_normal") return source
+    return {
+      [Symbol.asyncIterator]() {
+        const iterator = source[Symbol.asyncIterator]()
+        return {
+          next: () => iterator.next(),
+          return: async () => {
+            lateIteratorCleanup += 1
+            return iterator.return
+              ? await iterator.return()
+              : { done: true as const, value: undefined }
+          },
+        }
+      },
+    }
+  }
+
+  const fixture: QualificationProcessTreeFixture = {
+    async create() {
+      delayProcessProbe = true
+      return {
+        adapter,
+        async descendants() {
+          return { childPid: process.pid + 1, grandchildPid: process.pid + 2 }
+        },
+        async dispose() {
+          primaryCleanupStarted += 1
+          await new Promise<void>(() => {})
+        },
+      }
+    },
+  }
+  const startedAt = Date.now()
+  await assert.rejects(
+    () =>
+      runQualificationSuite(adapter, {
+        workingDirectory: directory,
+        generatedAt: GENERATED_AT,
+        caseTimeoutMs: 1_000,
+        processTreeFixture: fixture,
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "QUALIFICATION_CLEANUP_TIMEOUT",
+  )
+  assert.equal(primaryCleanupStarted, 1)
+  assert.equal(
+    lifecycle.filter(
+      (entry) => entry === "cancel:qualification-process_tree_normal",
+    ).length,
+    1,
+  )
+  assert.equal(lateIteratorCleanup, 1)
+  assert.ok(Date.now() - startedAt < 3_500)
+})
+
 test("sentinel scanning covers conforming, malformed, rejected and thrown paths", async () => {
   const directory = await workingDirectory()
   const makeAdapter = (


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/52
- Consumed revision: R1
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | `packages/core/src/adapter-qualification.ts` | Bounded timeout, active cancel, awaited teardown, and continuation tests |
| REQ-002 / AC-002 | Qualification policy drivers, scanner, reference host | Exact filesystem, network, and MCP denial plus sentinel mutation tests |
| REQ-003 / AC-003 | Core qualification record validator and public exports | Capability source, host version, record-shape, and legacy contract tests |
| REQ-004 / AC-004 | Reference stdio host, fixture lineage, and cleanup harness | Real owner, child, and grandchild lifecycle tests for normal, timeout, and cancel |

## File domains

- Core qualification: bounded case runner, typed policy evidence, record validation, secret scanning, process identity, and v1.0/v1.1 compatibility.
- Reference host: deterministic typed qualification drivers and real two-generation process fixtures without run-ID magic.
- Documentation and tests: public qualification contract, stdio integration notes, exact negative controls, and changelog.
- Deploy, channel, provider, and marketplace behavior: unchanged.

## Scope and non-goals

Make every advertised qualification domain evidence-backed and fail closed. Cases
now have bounded execution and awaited cleanup, direct policy-denial evidence,
tri-state credential scanning, strict metadata, and exact process lineage. This
does not certify a live provider, loosen default-deny policy, add a channel, or
turn fixture conformance into entitlement evidence.

## Validation

- Exact commands: `npm run check`; `npm run test:coverage`; `npm audit --omit=dev --audit-level=high`; `npm run release:check`; `git diff --check`
- Observed counts/results: full check 865/865 PASS with typecheck, build, and security PASS; coverage test body 865/865 PASS but local reporter failed while aggregating JSON; audit found 0 vulnerabilities; release check PASS; diff check PASS
- Check URLs: NOT VERIFIED: exact-head GitHub checks start only after this Draft pull request is created

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 / AC-001 | A hung case times out, teardown settles, and the suite continues only from a clean boundary | Run core focused and full repository tests | macOS, Node.js 24, exact commit | Stable timeout and cleanup errors; no late terminal or unhandled rejection | Focused and full tests PASS | PASS |
| V2 | REQ-002 / AC-002 | Generic failures never count as filesystem, network, or MCP policy evidence | Run typed-denial and counterexample tests | macOS, offline fixtures | Only exact operation and denial code can pass | Generic database and unrelated-terminal counterexamples fail closed | PASS |
| V3 | REQ-002 / AC-002 | Accessors, symbols, proxies, budget exhaustion, and late teardown evidence cannot hide the sentinel | Run scanner mutation tests | Node.js 24 | Detected or incomplete scans fail closed without invoking getters | All scanner counterexamples PASS | PASS |
| V4 | REQ-004 / AC-004 | The exact adapter owner directly owns a child that owns a grandchild in one process group | Run real lineage and rogue intermediary tests | macOS process table and isolated fixture | Normal, timeout, and cancel remove both descendants; rogue intermediary is rejected | Three cleanup modes PASS; nine rogue-tree PIDs absent | PASS |
| V5 | REQ-003 / AC-003 | Current and legacy records preserve exact domain and axis consistency | Run record compatibility tests | Node.js 24 | v1.0 and v1.1 accepted only with derived summaries and exact metadata | Compatibility matrix PASS | PASS |
| V6 | REQ-001 through REQ-004 | Repository behavior remains compatible | `npm run check` | macOS, Node.js 24, exact commit | All tests and security check pass | 865/865 PASS; security check PASS | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source and process inspection is bounded and local.
- [x] Credential evidence is scanned through malformed, thrown, rejected, symbol, and accessor paths.
- [x] The legacy qualification record remains explicitly supported.
- [x] No dependency changed; audit found 0 vulnerabilities.
- [x] Full repository and security gates pass.

The process proof binds the same adapter instance, probe fingerprint, host
version, configuration digest, owner PID, start identities, parent-child links,
and process group. Cleanup uses bounded TERM and KILL handling and verifies
absence before a record can be issued.

## Known limitations

The local Node experimental coverage reporter ended with `Unexpected end of JSON
input` after all 865 tests passed, so local coverage percentages are NOT
VERIFIED. The GitHub Node 22 coverage job is the authoritative exact-head gate.
This remains fixture conformance, not live-provider or model-entitlement proof.
The upstream merge-order gate through Issue 89 remains unchanged.

## Risk and rollback

The main risk is stricter qualification rejecting previously optimistic records
or increasing fixture runtime. Revert this single commit to restore the prior
kit. No persistent product data, remote provider resource, channel state, or
credential migration is involved.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @Bindy-lbb
- Milestone or release packet: N/A: this is Host qualification hardening and remains behind its recorded merge-order gate
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
