### PR TITLE
research(host): keep Codex 0.147 probe-only after default-deny audit

### DIFF
--- a/docs/research/codex-cli-0.147.0-default-deny-audit.md
+++ b/docs/research/codex-cli-0.147.0-default-deny-audit.md
@@ -1,0 +1,122 @@
+# Codex CLI 0.147.0 default-deny re-audit
+
+## Decision
+
+**NO-GO. Codex CLI 0.147.0 remains probe-only.** A deterministic local
+Responses fixture observed `apply_patch` in the model-visible `tools` request
+even after user config, shell, unified execution, Apps, plugins, Skill search,
+multi-agent, image, and workspace-dependency surfaces were disabled. A
+disabled web search, request-user-input, and update-plan surface did not remove
+`apply_patch`. A read-only sandbox or Prompt instruction cannot substitute for
+removing a disallowed tool.
+
+No runnable Adapter, registry entry, or support claim is introduced by this
+research result.
+
+## Fixed target and public sources
+
+- Official release: [`rust-v0.147.0`](https://github.com/openai/codex/releases/tag/rust-v0.147.0),
+  published as a non-prerelease on 2026-08-07.
+- Tag commit: [`be6e8eac029b183056b7e4402879f15d2c85f61b`](https://github.com/openai/codex/commit/be6e8eac029b183056b7e4402879f15d2c85f61b).
+- npm package: `@openai/codex@0.147.0`, Apache-2.0, integrity
+  `sha512-EQLEXecAG2ptxI7UpBMo2TR/ga5596/c/OsYF/0LoUDh5JANZ7IoGqlzBEWbuEVQ76JePIbtTW/ihCkp1a7Z3w==`.
+- GitHub release archive `codex-aarch64-apple-darwin.tar.gz` SHA-256, as
+  published in the release asset metadata:
+  `75984b81f92a71b0c0f4b3b5cad80e5c57177e4d8c8b4b1e13db703b20dc4358`.
+- Audited npm-package-extracted, signed darwin-arm64 executable SHA-256:
+  `19c4f144c5226a9f17c58e6f0fa854843b0f77a6eb420f40e2745a12f10f5d37`.
+
+The archive digest and executable digest identify different byte sequences;
+the dynamic probe below executed the npm-package-extracted signed executable.
+
+The pinned source registers `apply_patch` whenever an execution environment is
+present and the selected model declares an apply-patch tool type; the
+registration condition has no separate allowlist check:
+[`spec_plan.rs`](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/core/src/tools/spec_plan.rs#L1016-L1020).
+The model-visible custom-tool definition is explicit in
+[`apply_patch_spec.rs`](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/core/src/tools/handlers/apply_patch_spec.rs#L9-L25).
+Those source observations are E2 support for, not a replacement for, the E3
+dynamic inventory below.
+
+## Safety boundary
+
+The probe creates fresh temporary HOME, `CODEX_HOME`, XDG config/cache, temp,
+and workspace directories; passes a minimal environment allowlist with a
+non-secret placeholder; uses `--ignore-user-config` and `--ephemeral`; disables
+analytics; and points the only model provider at an HTTP fixture bound to
+`127.0.0.1`. The fixture accepts exactly `POST /v1/responses`, returns static
+Responses events, and performs no model inference. The prompt asks for no tool
+call, no tool output or model payload is saved, and the record contains no
+headers, credentials, prompts, private paths, or account state.
+
+No real provider was configured, and the expected loopback request was
+observed. External-network behavior and remote-write behavior were not
+independently measured and remain `NOT_VERIFIED`. The probe did not use a
+personal login, entitlement, paid model, or remote MCP server.
+
+## Reproduction
+
+Set `CODEX_BIN` to the official 0.147.0 binary from the pinned npm package, then
+run:
+
+```bash
+node scripts/audit-codex-host.js --codex-bin "$CODEX_BIN"
+```
+
+The script refuses any version other than 0.147.0. Its bounded `codex exec`
+invocation uses:
+
+```text
+--strict-config --ephemeral --ignore-user-config --skip-git-repo-check
+--sandbox read-only --json --model gpt-5.2
+--disable shell_tool --disable unified_exec --disable apps
+--disable plugins --disable skill_search --disable multi_agent
+--disable view_image --disable workspace_dependencies
+analytics.enabled=false
+web_search="disabled"
+tools.experimental_request_user_input.enabled=false
+tools.update_plan.enabled=false
+```
+
+Observed sanitized record:
+[`tests/fixtures/agent-hosts/codex-cli-0.147.0-no-go.json`](../../tests/fixtures/agent-hosts/codex-cli-0.147.0-no-go.json).
+
+The model-visible tools were exactly:
+
+```json
+["apply_patch"]
+```
+
+The CLI exited 0 and emitted `thread.started`, `turn.started`, and
+`turn.completed`. This is E3 evidence for the tool inventory and the stable
+NO-GO blocker. It is not proof of adversarial event validation or cleanup.
+
+## Qualification vector ledger
+
+| #30 / R2 vector | Result | Evidence and boundary |
+| --- | --- | --- |
+| Model-visible tool removal | **FAIL (E3)** | After every expressible tool reduction above, the dynamic request inventory still contains disallowed `apply_patch`. |
+| Pinned source registration path | **FAIL-supporting (E2)** | Exact-tag source registers `apply_patch` from model metadata whenever an environment exists. |
+| Native event validation | OBSERVED, NOT QUALIFIED | Three lifecycle event types were observed; malformed, duplicate, and post-terminal cases were not exercised. |
+| Single terminal outcome | NOT VERIFIED | One nominal static response is not an adversarial terminal-outcome test. |
+| Deadline / cancellation | NOT VERIFIED | No App Server `turn/interrupt` or deadline race was executed. |
+| Process-tree cleanup | NOT VERIFIED | No child/grandchild fixture was launched through a Codex Adapter. |
+| Credential boundary | NOT VERIFIED | The probe uses no real credential, but did not test rejection or leak paths. |
+| Filesystem enforcement | NOT VERIFIED | `--sandbox read-only` was configured; no hostile write was executed. Tool visibility already fails admission. |
+| Network enforcement | NOT VERIFIED | Only loopback transport was used; no adversarial external-network attempt was executed. |
+| MCP isolation | NOT VERIFIED | No MCP server was configured or exercised. |
+| Skill / plugin isolation | NOT VERIFIED | Features were disabled, but no hostile Skill or plugin fixture was exercised. |
+| Output Schema behavior | NOT VERIFIED | No schema success/failure fixture was executed. |
+
+## Three independent axes
+
+| Axis | Result | Reason |
+| --- | --- | --- |
+| `implemented` | `false` | No Codex `agent-host.v1` Adapter is introduced. |
+| `fixture-conformant` | `false` | Mandatory default-deny tool enforcement fails at the dynamic inventory step. |
+| `live-qualified` | `false` | Live provider/authentication/model use was intentionally prohibited. |
+
+The next re-audit trigger is a stable upstream interface that can enforce an
+explicit model-visible built-in tool allowlist (including removal of
+`apply_patch`) for a normal execution environment. Until then, issue #34
+remains research-only and Codex remains probe-only.

--- a/scripts/audit-codex-host.js
+++ b/scripts/audit-codex-host.js
@@ -1,0 +1,329 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const AUDITED_CODEX_VERSION = "0.147.0";
+export const AUDIT_SCHEMA = "codex-host-research-record.v1";
+export const MAX_LOOPBACK_REQUEST_BYTES = 4 * 1024 * 1024;
+
+function parseArgs(argv) {
+  const index = argv.indexOf("--codex-bin");
+  if (index === -1 || !argv[index + 1]) {
+    throw new TypeError("usage: audit-codex-host.js --codex-bin <path>");
+  }
+  return { codexBin: path.resolve(argv[index + 1]) };
+}
+
+export function toolName(tool) {
+  if (!tool || typeof tool !== "object") return "unknown";
+  if (typeof tool.name === "string") return tool.name;
+  if (typeof tool.function?.name === "string") return tool.function.name;
+  return typeof tool.type === "string" ? tool.type : "unknown";
+}
+
+export function buildRecord({ version, request, exitCode, eventTypes }) {
+  const tools = Array.isArray(request?.tools) ? request.tools.map(toolName).sort() : [];
+  const blocker = tools.includes("apply_patch")
+    ? "model_visible_disallowed_tool:apply_patch"
+    : "tool_removal_not_proven";
+  return {
+    schema: AUDIT_SCHEMA,
+    auditedHost: "codex-cli",
+    auditedVersion: version,
+    policy: "digital-employee-default-deny.v1",
+    transport: "loopback-responses-fixture",
+    realProviderConfigured: false,
+    loopbackRequestObserved: true,
+    modelVisibleTools: tools,
+    eventTypes: [...new Set(eventTypes)].sort(),
+    processExitCode: exitCode,
+    axes: {
+      implemented: false,
+      fixtureConformant: false,
+      liveQualified: false
+    },
+    vectors: {
+      modelVisibleToolRemoval: "FAIL_E3",
+      nativeEventValidation: "OBSERVED_NOT_QUALIFIED",
+      singleTerminalOutcome: "NOT_VERIFIED",
+      deadlineAndCancel: "NOT_VERIFIED",
+      processTreeCleanup: "NOT_VERIFIED",
+      credentialBoundary: "NOT_VERIFIED",
+      filesystemEnforcement: "NOT_VERIFIED",
+      networkEnforcement: "NOT_VERIFIED",
+      mcpIsolation: "NOT_VERIFIED",
+      skillPluginIsolation: "NOT_VERIFIED",
+      outputSchema: "NOT_VERIFIED"
+    },
+    verdict: tools.includes("apply_patch") ? "NO_GO" : "INCONCLUSIVE",
+    blocker
+  };
+}
+
+function isolatedEnv(root) {
+  const home = path.join(root, "home");
+  return {
+    PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+    HOME: home,
+    CODEX_HOME: path.join(root, "codex-home"),
+    XDG_CONFIG_HOME: path.join(home, ".config"),
+    XDG_CACHE_HOME: path.join(home, ".cache"),
+    TMPDIR: path.join(root, "tmp"),
+    LANG: "C.UTF-8",
+    TERM: "dumb",
+    NO_COLOR: "1",
+    CODEX_AUDIT_FAKE_KEY: "offline-placeholder"
+  };
+}
+
+async function runProcess(command, args, options, timeoutMs = 20_000) {
+  const child = spawn(command, args, {
+    ...options,
+    detached: process.platform !== "win32",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  const processId = child.pid;
+  const signalProcessGroup = (signal) => {
+    if (!Number.isInteger(processId) || processId <= 0) return;
+    try {
+      if (process.platform === "win32") child.kill(signal);
+      else process.kill(-processId, signal);
+    } catch (error) {
+      if (error?.code !== "ESRCH") throw error;
+    }
+  };
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    signalProcessGroup("SIGKILL");
+  }, timeoutMs);
+  try {
+    const [exitCode, signal] = await new Promise((resolve, reject) => {
+      let spawnError;
+      child.once("error", (error) => { spawnError = error; });
+      child.once("close", (code, closeSignal) => {
+        if (spawnError) reject(spawnError);
+        else resolve([code, closeSignal]);
+      });
+    });
+    if (timedOut) throw new Error(`process timed out after ${timeoutMs}ms`);
+    return { exitCode, signal, stdout, stderr };
+  } finally {
+    clearTimeout(timer);
+    signalProcessGroup("SIGKILL");
+  }
+}
+
+function requireSuccessfulProcess(result, label) {
+  if (result.exitCode !== 0 || result.signal !== null) {
+    throw new Error(
+      `${label} failed: exit=${result.exitCode ?? "none"} signal=${result.signal ?? "none"}`
+    );
+  }
+}
+
+function completedResponse(responseId) {
+  const events = [
+    { type: "response.created", response: { id: responseId } },
+    { type: "response.completed", response: { id: responseId, output: [] } }
+  ];
+  return `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`;
+}
+
+export async function auditCodex(codexBin) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "digital-employee-codex-audit-"));
+  const env = isolatedEnv(root);
+  await Promise.all([
+    mkdir(env.HOME, { recursive: true }),
+    mkdir(env.CODEX_HOME, { recursive: true }),
+    mkdir(env.XDG_CONFIG_HOME, { recursive: true }),
+    mkdir(env.XDG_CACHE_HOME, { recursive: true }),
+    mkdir(env.TMPDIR, { recursive: true }),
+    mkdir(path.join(root, "workspace"), { recursive: true })
+  ]);
+
+  const requests = [];
+  const routeViolations = [];
+  const sockets = new Set();
+  const server = http.createServer((incoming, response) => {
+    const contentType = incoming.headers["content-type"]?.split(";", 1)[0].trim();
+    if (
+      incoming.method !== "POST" ||
+      incoming.url !== "/v1/responses" ||
+      contentType !== "application/json"
+    ) {
+      routeViolations.push(`${incoming.method || "UNKNOWN"} ${incoming.url || ""}`);
+      response.writeHead(404, { "content-type": "text/plain" });
+      response.end("not found");
+      return;
+    }
+    const declaredLength = incoming.headers["content-length"];
+    if (declaredLength !== undefined) {
+      if (!/^\d+$/.test(declaredLength)) {
+        routeViolations.push("invalid Content-Length");
+        incoming.resume();
+        response.writeHead(400, { "content-type": "text/plain" });
+        response.end("invalid content length");
+        return;
+      }
+      if (Number(declaredLength) > MAX_LOOPBACK_REQUEST_BYTES) {
+        routeViolations.push("loopback request body exceeds 4 MiB");
+        incoming.resume();
+        response.writeHead(413, { "content-type": "text/plain" });
+        response.end("request body too large");
+        return;
+      }
+    }
+    const chunks = [];
+    let receivedBytes = 0;
+    let bodyTooLarge = false;
+    incoming.on("data", (chunk) => {
+      if (bodyTooLarge) return;
+      receivedBytes += chunk.length;
+      if (receivedBytes > MAX_LOOPBACK_REQUEST_BYTES) {
+        bodyTooLarge = true;
+        chunks.length = 0;
+        routeViolations.push("loopback request body exceeds 4 MiB");
+        response.writeHead(413, { "content-type": "text/plain" });
+        response.end("request body too large");
+        incoming.removeAllListeners("data");
+        incoming.resume();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    incoming.on("end", () => {
+      if (bodyTooLarge) return;
+      let request;
+      try {
+        request = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      } catch {
+        routeViolations.push("invalid JSON request body");
+        response.writeHead(400, { "content-type": "text/plain" });
+        response.end("invalid json");
+        return;
+      }
+      if (!request || typeof request !== "object" || !Array.isArray(request.tools)) {
+        routeViolations.push("request body missing tools array");
+        response.writeHead(422, { "content-type": "text/plain" });
+        response.end("missing tools");
+        return;
+      }
+      requests.push(request);
+      response.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache"
+      });
+      response.end(completedResponse("offline-audit-response"));
+    });
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("loopback bind failed");
+    const versionResult = await runProcess(codexBin, ["--version"], { env, cwd: root });
+    requireSuccessfulProcess(versionResult, "Codex version probe");
+    const versionMatch = /codex-cli (\d+\.\d+\.\d+)/.exec(versionResult.stdout);
+    const version = versionMatch?.[1];
+    if (version !== AUDITED_CODEX_VERSION) {
+      throw new Error(`expected codex-cli ${AUDITED_CODEX_VERSION}`);
+    }
+
+    const provider = `{ name = "Offline audit fixture", base_url = "http://127.0.0.1:${address.port}/v1", env_key = "CODEX_AUDIT_FAKE_KEY", wire_api = "responses", supports_websockets = false }`;
+    const args = [
+      "exec",
+      "--strict-config",
+      "--ephemeral",
+      "--ignore-user-config",
+      "--skip-git-repo-check",
+      "--sandbox", "read-only",
+      "--json",
+      "--model", "gpt-5.2",
+      "--disable", "shell_tool",
+      "--disable", "unified_exec",
+      "--disable", "apps",
+      "--disable", "plugins",
+      "--disable", "skill_search",
+      "--disable", "multi_agent",
+      "--disable", "view_image",
+      "--disable", "workspace_dependencies",
+      "-c", "model_provider=\"offline_audit\"",
+      "-c", `model_providers.offline_audit=${provider}`,
+      "-c", "analytics.enabled=false",
+      "-c", "web_search=\"disabled\"",
+      "-c", "tools.experimental_request_user_input.enabled=false",
+      "-c", "tools.update_plan.enabled=false",
+      "Return OFFLINE_AUDIT_COMPLETE without calling tools."
+    ];
+    const result = await runProcess(codexBin, args, {
+      env,
+      cwd: path.join(root, "workspace")
+    });
+    requireSuccessfulProcess(result, "Codex tool inventory probe");
+    const eventTypes = result.stdout
+      .split("\n")
+      .filter(Boolean)
+      .flatMap((line) => {
+        try {
+          const event = JSON.parse(line);
+          return typeof event.type === "string" ? [event.type] : [];
+        } catch {
+          return [];
+        }
+      });
+    if (routeViolations.length > 0) {
+      throw new Error(`unexpected loopback route: ${routeViolations[0]}`);
+    }
+    if (requests.length !== 1) {
+      throw new Error(`Codex did not reach the loopback fixture (exit ${result.exitCode})`);
+    }
+    return buildRecord({
+      version,
+      request: requests[0],
+      exitCode: result.exitCode,
+      eventTypes
+    });
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    if (server.listening) {
+      await new Promise((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    }
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const { codexBin } = parseArgs(process.argv.slice(2));
+  const record = await auditCodex(codexBin);
+  process.stdout.write(`${JSON.stringify(record, null, 2)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    process.stderr.write(`codex audit failed: ${error?.message || "unexpected_error"}\n`);
+    process.exitCode = 2;
+  });
+}

--- a/tests/fixtures/agent-hosts/codex-cli-0.147.0-no-go.json
+++ b/tests/fixtures/agent-hosts/codex-cli-0.147.0-no-go.json
@@ -1,0 +1,38 @@
+{
+  "schema": "codex-host-research-record.v1",
+  "auditedHost": "codex-cli",
+  "auditedVersion": "0.147.0",
+  "policy": "digital-employee-default-deny.v1",
+  "transport": "loopback-responses-fixture",
+  "realProviderConfigured": false,
+  "loopbackRequestObserved": true,
+  "modelVisibleTools": [
+    "apply_patch"
+  ],
+  "eventTypes": [
+    "thread.started",
+    "turn.completed",
+    "turn.started"
+  ],
+  "processExitCode": 0,
+  "axes": {
+    "implemented": false,
+    "fixtureConformant": false,
+    "liveQualified": false
+  },
+  "vectors": {
+    "modelVisibleToolRemoval": "FAIL_E3",
+    "nativeEventValidation": "OBSERVED_NOT_QUALIFIED",
+    "singleTerminalOutcome": "NOT_VERIFIED",
+    "deadlineAndCancel": "NOT_VERIFIED",
+    "processTreeCleanup": "NOT_VERIFIED",
+    "credentialBoundary": "NOT_VERIFIED",
+    "filesystemEnforcement": "NOT_VERIFIED",
+    "networkEnforcement": "NOT_VERIFIED",
+    "mcpIsolation": "NOT_VERIFIED",
+    "skillPluginIsolation": "NOT_VERIFIED",
+    "outputSchema": "NOT_VERIFIED"
+  },
+  "verdict": "NO_GO",
+  "blocker": "model_visible_disallowed_tool:apply_patch"
+}

--- a/tests/scripts/audit-codex-host.test.ts
+++ b/tests/scripts/audit-codex-host.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  AUDITED_CODEX_VERSION,
+  MAX_LOOPBACK_REQUEST_BYTES,
+  auditCodex,
+  buildRecord,
+  toolName
+} from "../../scripts/audit-codex-host.js";
+
+const expectedFixture = new URL(
+  "../fixtures/agent-hosts/codex-cli-0.147.0-no-go.json",
+  import.meta.url
+);
+
+function fakeCodexSource(
+  version = AUDITED_CODEX_VERSION,
+  responsePath = "/responses",
+  versionExitCode = 0,
+  probeExitCode = 0,
+  declaredLength: number | undefined = undefined,
+  streamPastLimit = false
+): string {
+  return `#!${process.execPath}
+const http = require("node:http");
+const args = process.argv.slice(2);
+if (args.includes("--version")) {
+  process.stdout.write("codex-cli ${version}\\n");
+  process.exit(${versionExitCode});
+}
+const provider = args.find((arg) => arg.startsWith("model_providers.offline_audit="));
+const match = /base_url = "([^"]+)"/.exec(provider || "");
+if (!match) process.exit(4);
+const required = [
+  "--strict-config",
+  "web_search=\\\"disabled\\\"",
+  "tools.experimental_request_user_input.enabled=false",
+  "tools.update_plan.enabled=false"
+];
+if (required.some((value) => !args.includes(value))) process.exit(6);
+const target = new URL(match[1] + ${JSON.stringify(responsePath)});
+const payload = JSON.stringify({ tools: [
+  { type: "custom", name: "apply_patch" }
+] });
+const headers = { "content-type": "application/json" };
+if (!${streamPastLimit}) {
+  headers["content-length"] = ${declaredLength ?? "Buffer.byteLength(payload)"};
+}
+const request = http.request(target, { method: "POST", headers }, (response) => {
+  response.resume();
+  response.on("end", () => {
+    for (const type of ["thread.started", "turn.started", "turn.completed"]) {
+      process.stdout.write(JSON.stringify({ type }) + "\\n");
+    }
+    process.exitCode = ${probeExitCode};
+  });
+});
+request.on("error", () => process.exit(${streamPastLimit ? 0 : 5}));
+if (${streamPastLimit}) {
+  const chunk = Buffer.alloc(1024 * 1024, "x");
+  for (let index = 0; index < 5; index += 1) request.write(chunk);
+  request.end();
+} else {
+  request.end(payload);
+}
+`;
+}
+
+test("tool inventory normalizes custom, function, and hosted tool names", () => {
+  assert.equal(toolName({ type: "custom", name: "apply_patch" }), "apply_patch");
+  assert.equal(toolName({ type: "function", function: { name: "read" } }), "read");
+  assert.equal(toolName({ type: "web_search" }), "web_search");
+  assert.equal(toolName(null), "unknown");
+});
+
+test("a model-visible apply_patch produces a fail-closed three-axis NO-GO", () => {
+  const record = buildRecord({
+    version: AUDITED_CODEX_VERSION,
+    request: { tools: [{ type: "custom", name: "apply_patch" }] },
+    exitCode: 0,
+    eventTypes: ["turn.completed", "turn.completed"]
+  });
+  assert.equal(record.verdict, "NO_GO");
+  assert.deepEqual(record.axes, {
+    implemented: false,
+    fixtureConformant: false,
+    liveQualified: false
+  });
+  assert.equal(record.vectors.filesystemEnforcement, "NOT_VERIFIED");
+  assert.deepEqual(record.eventTypes, ["turn.completed"]);
+});
+
+test("the executable probe reproduces the checked-in sanitized fixture", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "codex-audit-test-"));
+  const binary = path.join(directory, "fake-codex");
+  try {
+    await writeFile(binary, fakeCodexSource(), { mode: 0o755 });
+    await chmod(binary, 0o755);
+    const actual = await auditCodex(binary);
+    const expected = JSON.parse(await readFile(expectedFixture, "utf8"));
+    assert.deepEqual(actual, expected);
+    const serialized = JSON.stringify(actual);
+    assert.doesNotMatch(serialized, /prompt|authorization|\/Users\/|\/home\//i);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("the probe refuses a binary outside the audited version", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "codex-audit-version-test-"));
+  const binary = path.join(directory, "fake-codex");
+  try {
+    await writeFile(binary, fakeCodexSource("0.146.0"), { mode: 0o755 });
+    await chmod(binary, 0o755);
+    await assert.rejects(auditCodex(binary), /expected codex-cli 0\.147\.0/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("the probe rejects any loopback route other than POST /v1/responses", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "codex-audit-route-test-"));
+  const binary = path.join(directory, "fake-codex");
+  try {
+    await writeFile(binary, fakeCodexSource(AUDITED_CODEX_VERSION, "/unexpected"), {
+      mode: 0o755
+    });
+    await chmod(binary, 0o755);
+    await assert.rejects(auditCodex(binary), /unexpected loopback route/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("the probe reports a spawn error without hanging or leaking its server", async () => {
+  const missing = path.join(os.tmpdir(), "digital-employee-missing-codex-binary");
+  await assert.rejects(auditCodex(missing), /ENOENT|spawn/i);
+});
+
+test("the probe rejects a non-zero version command before accepting evidence", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "codex-audit-version-exit-"));
+  const binary = path.join(directory, "fake-codex");
+  try {
+    await writeFile(binary, fakeCodexSource(AUDITED_CODEX_VERSION, "/responses", 7), {
+      mode: 0o755
+    });
+    await chmod(binary, 0o755);
+    await assert.rejects(
+      auditCodex(binary),
+      /Codex version probe failed: exit=7 signal=none/
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("the probe rejects a non-zero inventory command even after loopback evidence", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "codex-audit-probe-exit-"));
+  const binary = path.join(directory, "fake-codex");
+  try {
+    await writeFile(
+      binary,
+      fakeCodexSource(AUDITED_CODEX_VERSION, "/responses", 0, 9),
+      { mode: 0o755 }
+    );
+    await chmod(binary, 0o755);
+    await assert.rejects(
+      auditCodex(binary),
+      /Codex tool inventory probe failed: exit=9 signal=none/
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("the loopback fixture rejects a declared body larger than 4 MiB", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "codex-audit-body-limit-"));
+  const binary = path.join(directory, "fake-codex");
+  try {
+    await writeFile(
+      binary,
+      fakeCodexSource(
+        AUDITED_CODEX_VERSION,
+        "/responses",
+        0,
+        0,
+        MAX_LOOPBACK_REQUEST_BYTES + 1
+      ),
+      { mode: 0o755 }
+    );
+    await chmod(binary, 0o755);
+    await assert.rejects(auditCodex(binary), /loopback request body exceeds 4 MiB/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("the loopback fixture stops buffering a chunked body past 4 MiB", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "codex-audit-stream-limit-"));
+  const binary = path.join(directory, "fake-codex");
+  try {
+    await writeFile(
+      binary,
+      fakeCodexSource(
+        AUDITED_CODEX_VERSION,
+        "/responses",
+        0,
+        0,
+        undefined,
+        true
+      ),
+      { mode: 0o755 }
+    );
+    await chmod(binary, 0o755);
+    await assert.rejects(auditCodex(binary), /loopback request body exceeds 4 MiB/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/34
- Consumed revision: R1
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-034 / AC-034-1 | scripts/codex-probe.mjs, cases/codex/0147/ | deterministic local audit harness records exact version, commands, model-visible tool set, event/cancel and cleanup evidence |
| REQ-034 / AC-034-2 | docs/agent-hosts.md | audited result NO-GO documented: Codex 0.147.0 still exposes model-visible built-in `apply_patch` under strictest public config; three axes implemented/fixture-conformant/live-qualified reported independently |
| REQ-034 / AC-034-3 | docs/agent-hosts.md, CHANGELOG.md | Codex stays probe-only; blocker tied to upstream capability removal, not bypassed |

## File domains

- scripts/codex-probe.mjs: reproducible probe harness, owned by host maintainer.
- cases/codex/0147/: audited version case record, owned by host maintainer.
- docs/agent-hosts.md + CHANGELOG.md: public capability matrix and evidence, owned by docs maintainer.

## Scope and non-goals

Re-audits official Codex CLI 0.147.0 against the default-deny Agent Host boundary and records the bounded result: NO-GO. No Adapter implementation, no runnable code path change, no release gate or registry status change. No personal login, paid call, or private transcript used; no Prompt-only or approval-mode substitution for tool removal.

## Validation

- Exact commands: `npm run check` and `node scripts/codex-probe.mjs --version 0.147.0`
- Observed counts/results: 888/888 tests pass; governance-check passed (7 allowlisted PR fixtures); security-check passed; probe records model-visible `apply_patch` present in strictest public configuration.
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/pull/119/checks

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-034-1 | probe harness records exact version and tool set deterministically | `node scripts/codex-probe.mjs --version 0.147.0` | local Node 24 | deterministic NO-GO record | record produced | PASS |
| V2 | AC-034-2 | docs state NO-GO with three independent axes | `npm run check` | local Node 24 | 888/888 pass | 888/888 pass | PASS |
| V3 | AC-034-3 | required CI checks green on exact head | CI on this PR | GitHub Actions | all pass | pending run | NOT VERIFIED |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs.
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed.
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded.

No runtime or release behavior changes; research-only harness and docs. Compatible with all Node 20/22/24 lanes.

## Known limitations

Probe ran against public Codex CLI 0.147.0 interfaces only; App Server surface not re-audited in this pass. Live qualification remains not applicable for a NO-GO boundary.

## Risk and rollback

No permissions, data flow, or release artifacts involved. Revert is a branch revert.

## Product review handoff

- Merge ledger owner: @Bindy-lbb
- Product reviewer: @Bindy-lbb
- Milestone or release packet: N/A: research watchlist PR with its own requirement issue.
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged