### PR TITLE
feat(git): make git source sync last-known-good safe (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Git source refresh is fail closed by default and can serve a validated
+  last-known-good generation when the remote is unreachable (#103). With
+  `policy: "prefer_last_known_good"` and an integer `maxStaleMs` in
+  [1000, 604800000], every degraded read revalidates the pinned commit,
+  manifest provenance, selected-content digest, path safety, and age;
+  `legacy sync` reports `degraded` and exits 2, and runtime/HTTP health
+  report per-source status. A failed refresh never touches the active
+  generation, and the cache remains disposable.
 - Qoder CLI 1.1.x now advertises `structured_output` from Adapter-specific
   deterministic conformance fixtures under the common Adapter-enforced
   terminal-validity contract. A checked-in employee package

--- a/apps/cli/bin.ts
+++ b/apps/cli/bin.ts
@@ -168,18 +168,25 @@ async function ask(values: CommandValues, positionals: string[]) {
 async function sync(values: CommandValues) {
   const { createRuntime } = await import("./runtime.js");
   const runtime = await createRuntime(values.config);
+  const degraded = runtime.sourceStatuses.some(
+    (entry) => entry.status === "degraded"
+  );
   const result = {
-    status: "ready",
+    status: degraded ? "degraded" : "ready",
     employee: runtime.profile.id,
     sourceCount: runtime.sources.length,
-    documentCount: runtime.documents.length
+    documentCount: runtime.documents.length,
+    sources: runtime.sourceStatuses
   };
-  if (values.json) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-  else {
+  if (values.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else {
     process.stdout.write(
-      `Ready: ${result.documentCount} approved chunks from ${result.sourceCount} source(s).\n`
+      `${degraded ? "Degraded" : "Ready"}: ${result.documentCount} approved chunks ` +
+        `from ${result.sourceCount} source(s).\n`
     );
   }
+  if (degraded) process.exitCode = 2;
 }
 
 async function start(values: CommandValues) {
@@ -214,7 +221,7 @@ async function start(values: CommandValues) {
 }
 
 async function serve(values: CommandValues) {
-  const [{ createHttpServer }, { assertProfileCapability, createRuntime }] =
+  const [{ createHttpServer }, { assertProfileCapability, createRuntime, runtimeHealth }] =
     await Promise.all([
       import("../server/server.js"),
       import("./runtime.js"),
@@ -229,11 +236,7 @@ async function serve(values: CommandValues) {
   const server = createHttpServer({
     employee: runtime.employee,
     token,
-    health: () => ({
-      status: "ok",
-      employee: runtime.profile.id,
-      documents: runtime.documents.length
-    })
+    health: () => runtimeHealth(runtime)
   });
   server.listen(port, values.host, () => {
     process.stdout.write(`Digital employee listening on http://${values.host}:${port}\n`);

--- a/apps/cli/registry.ts
+++ b/apps/cli/registry.ts
@@ -14,6 +14,7 @@ import { ExtractiveModel } from "../../connectors/models/extractive/index.js"
 import { OpenAICompatibleModel } from "../../connectors/models/openai-compatible/index.js"
 import { FileSystemSource } from "../../connectors/sources/filesystem/index.js"
 import { GitSource } from "../../connectors/sources/git/index.js"
+import type { GitSourcePolicy } from "../../connectors/sources/git/index.js"
 import { createAnswerAgentProfile } from "../../profiles/answer-agent/index.js"
 
 type ConfigObject = Record<string, unknown>
@@ -110,6 +111,8 @@ function registerBuiltInSources(registry: RuntimeComponentRegistry): void {
         typeof config.publicBaseUrl === "string" ? config.publicBaseUrl : undefined,
       timeoutMs:
         typeof config.timeoutMs === "number" ? config.timeoutMs : undefined,
+      policy: config.policy as GitSourcePolicy | undefined,
+      maxStaleMs: config.maxStaleMs as number | undefined,
     })
   })
   registry.register("source", "dws", async ({ config = {} }) => {

--- a/apps/cli/runtime.ts
+++ b/apps/cli/runtime.ts
@@ -39,6 +39,12 @@ interface SourceConfig extends ConfigObject {
   type: string
 }
 
+export interface SourceStatusEntry {
+  id: string
+  type: string
+  status: "fresh" | "degraded" | "unavailable"
+}
+
 interface RuntimeConfig extends ConfigObject {
   employee?: EmployeeConfig
   runtime?: {
@@ -202,15 +208,36 @@ export async function createRuntime(
       if (!profileManifest.permissions.read.sourceTypes.includes(type)) {
         throw new TypeError(`profile_source_read_not_allowed:${type}`)
       }
-      return registry.create("source", type, {
+      const instance = await registry.create("source", type, {
         config: source,
         configDirectory,
         environment,
       })
+      return { instance, type }
     }),
   )
-  const documentGroups = await Promise.all(sources.map((source) => source.load()))
+  const documentGroups = await Promise.all(sources.map(({ instance }) => instance.load()))
   const documents = documentGroups.flat()
+  const sourceStatuses: SourceStatusEntry[] = sources.map(({ instance, type }) => {
+    const record = instance as { id?: unknown; status?: unknown }
+    const status =
+      record.status === "degraded" || record.status === "unavailable"
+        ? record.status
+        : "fresh"
+    return {
+      id: typeof record.id === "string" ? record.id : "source",
+      type,
+      status,
+    }
+  })
+  for (const entry of sourceStatuses) {
+    if (entry.status === "degraded") {
+      process.stderr.write(
+        `digital-employee: warning: source ${entry.id} (${entry.type}) is degraded; ` +
+          "serving a revalidated last-known-good generation\n",
+      )
+    }
+  }
   const modelConfig = assertObject(
     config.model ?? { provider: "extractive" },
     "model",
@@ -258,7 +285,24 @@ export async function createRuntime(
     profileReference: reference,
     registry,
     retriever,
-    sources,
+    sources: sources.map(({ instance }) => instance),
+    sourceStatuses,
     documents,
+  }
+}
+
+export type CreatedRuntime = Awaited<ReturnType<typeof createRuntime>>
+
+/**
+ * Truthful HTTP health payload: the server itself stays `ok` while per-source
+ * status distinguishes fresh, degraded, and unavailable. Public fields never
+ * include paths, credentials, or raw Git output.
+ */
+export function runtimeHealth(runtime: CreatedRuntime): Record<string, unknown> {
+  return {
+    status: "ok",
+    employee: runtime.profile.id,
+    documents: runtime.documents.length,
+    sources: runtime.sourceStatuses,
   }
 }

--- a/connectors/sources/git/index.ts
+++ b/connectors/sources/git/index.ts
@@ -1,8 +1,68 @@
-import { createHash } from "node:crypto";
-import { access, mkdir } from "node:fs/promises";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  access,
+  copyFile,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile
+} from "node:fs/promises";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { FileSystemSource } from "../filesystem/index.js";
+
+export type GitSourcePolicy = "require_fresh" | "prefer_last_known_good";
+export type GitSourceStatus = "fresh" | "degraded" | "unavailable";
+
+/** Inclusive bounds for the opt-in last-known-good service age (ms). */
+export const LKG_MAX_STALE_MS_BOUNDS = Object.freeze([1_000, 604_800_000] as const);
+
+const MANIFEST_SCHEMA_VERSION = 1;
+const ACTIVE_SCHEMA_VERSION = 1;
+const ACTIVE_FILE = "active.json";
+const GENERATIONS_DIR = "generations";
+const MANIFEST_FILE = "manifest.json";
+const CONTENT_DIR = "content";
+const MAX_MANIFEST_BYTES = 16_384;
+const MAX_ACTIVE_BYTES = 4_096;
+const GENERATION_ID_PATTERN = /^[0-9a-f]{12}-\d{13}-[0-9a-f]{8}$/;
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/;
+
+const DEFAULT_EXTENSIONS = [".md", ".mdx", ".txt", ".json"];
+const SENSITIVE_NAMES = [
+  /^\.env(?:\.|$)/i,
+  /(?:^|[._-])(secrets?|tokens?|credentials?|passwords?)(?:[._-]|$)/i,
+  /^id_(?:rsa|dsa|ecdsa|ed25519)(?:\.pub)?$/i,
+  /(?:^|[._-])private[._-]?key(?:[._-]|$)/i
+];
+
+interface GenerationManifest {
+  schemaVersion: number
+  policy: GitSourcePolicy
+  remote: string
+  ref: string
+  commit: string
+  subdirectory: string
+  include: string[] | null
+  contentSha256: string
+  refreshedAt: string
+}
+
+interface SelectionOptions {
+  extensions: Set<string>
+  maxDepth: number
+  maxFiles: number
+  maxFileBytes: number
+}
+
+interface PublishedGeneration {
+  id: string
+  manifest: GenerationManifest
+}
 
 function cacheKey(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 24);
@@ -21,6 +81,76 @@ function validateRemote(remote: string): string {
     throw new TypeError("git_source_requires_public_https_url_without_credentials");
   }
   return url.toString();
+}
+
+function validatePolicy(value: unknown): GitSourcePolicy {
+  if (value === undefined) return "require_fresh";
+  if (value === "require_fresh" || value === "prefer_last_known_good") return value;
+  throw new TypeError(`git_source_invalid_policy:${String(value)}`);
+}
+
+function validateMaxStaleMs(value: unknown, policy: GitSourcePolicy): number | undefined {
+  if (policy === "require_fresh") {
+    if (value !== undefined) {
+      throw new TypeError("git_source_max_stale_ms_requires_lkg_policy");
+    }
+    return undefined;
+  }
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < LKG_MAX_STALE_MS_BOUNDS[0] ||
+    value > LKG_MAX_STALE_MS_BOUNDS[1]
+  ) {
+    throw new TypeError(
+      `git_source_lkg_max_stale_ms_out_of_bounds:${value === undefined ? "missing" : String(value)}`
+    );
+  }
+  return value;
+}
+
+/** True when `now - refreshedAt <= maxStaleMs` and the timestamp is not future-dated. */
+export function ageWithinBound(refreshedAtMs: number, nowMs: number, maxStaleMs: number): boolean {
+  return (
+    Number.isFinite(refreshedAtMs) &&
+    Number.isFinite(nowMs) &&
+    refreshedAtMs <= nowMs &&
+    nowMs - refreshedAtMs <= maxStaleMs
+  );
+}
+
+/** Typed remote acquisition failures originate from the git subprocess itself. */
+export function isRemoteAcquisitionFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /^git_source_(?:command_failed|process_failed|process_timed_out)(?::|$)/.test(
+    error.message
+  );
+}
+
+function normalizeInclude(include?: unknown[]): string[] {
+  const source = Array.isArray(include) && include.length ? include : DEFAULT_EXTENSIONS;
+  const normalized = source.map((value) => {
+    const extension = String(value).toLowerCase();
+    return extension.startsWith(".") ? extension : `.${extension}`;
+  });
+  return [...new Set(normalized)].sort();
+}
+
+function isSensitiveName(name: string): boolean {
+  return SENSITIVE_NAMES.some((pattern) => pattern.test(name));
+}
+
+function isHiddenSegment(relativePath: string): boolean {
+  return relativePath.split(path.sep).some((segment) => segment.startsWith("."));
+}
+
+function selectionOptions(include?: unknown[]): SelectionOptions {
+  return {
+    extensions: new Set(normalizeInclude(include)),
+    maxDepth: 8,
+    maxFiles: 2_000,
+    maxFileBytes: 2 * 1024 * 1024
+  };
 }
 
 function isolatedGitEnvironment(): NodeJS.ProcessEnv {
@@ -107,16 +237,153 @@ async function exists(target: string): Promise<boolean> {
   }
 }
 
+/**
+ * Rejects symlinks on every path segment below `root`. Pointer files and
+ * generation directories must never be reachable through a symlink. A missing
+ * segment fails closed with the supplied typed code instead of a raw path.
+ */
+async function assertNoSymlinkSegments(
+  root: string,
+  relative: string,
+  missingCode: string
+): Promise<void> {
+  let current = root;
+  for (const segment of relative.split(path.sep)) {
+    if (!segment || segment === ".") continue;
+    current = path.join(current, segment);
+    let stat;
+    try {
+      stat = await lstat(current);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new TypeError(missingCode);
+      }
+      throw error;
+    }
+    if (stat.isSymbolicLink()) {
+      throw new TypeError("git_source_generation_pointer_symlink");
+    }
+  }
+}
+
+/**
+ * Deterministically walks the selected content tree, mirroring the
+ * FileSystemSource collection rules (hidden, sensitive, extension, depth,
+ * count, and size filters). Any symlink inside the selected tree is rejected
+ * so a generation can never smuggle content outside its root.
+ */
+async function collectSelectedFiles(
+  root: string,
+  options: SelectionOptions,
+  directory = root,
+  depth = 0,
+  output: string[] = []
+): Promise<string[]> {
+  if (depth > options.maxDepth || output.length >= options.maxFiles) return output;
+  const entries = await readdir(directory, { withFileTypes: true });
+  // Byte-order sorting keeps the digest stable across processes and locales.
+  entries.sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+
+  for (const entry of entries) {
+    if (output.length >= options.maxFiles) break;
+    const absolute = path.join(directory, entry.name);
+    const relative = path.relative(root, absolute);
+
+    if (!relative || isHiddenSegment(relative) || isSensitiveName(entry.name)) continue;
+    if (entry.isSymbolicLink()) {
+      throw new TypeError(
+        `git_source_generation_symlink_rejected:${relative.split(path.sep).join("/")}`
+      );
+    }
+    if (entry.isDirectory()) {
+      await collectSelectedFiles(root, options, absolute, depth + 1, output);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!options.extensions.has(path.extname(entry.name).toLowerCase())) continue;
+    output.push(relative);
+  }
+  return output;
+}
+
+async function computeContentDigest(
+  root: string,
+  files: string[],
+  options: SelectionOptions
+): Promise<string> {
+  const hash = createHash("sha256");
+  for (const relative of files) {
+    const absolute = path.join(root, relative);
+    const stat = await lstat(absolute);
+    if (!stat.isFile()) {
+      throw new TypeError(
+        `git_source_generation_invalid_entry:${relative.split(path.sep).join("/")}`
+      );
+    }
+    if (stat.size > options.maxFileBytes) continue;
+    const content = await readFile(absolute, "utf8");
+    hash.update(relative.split(path.sep).join("/"));
+    hash.update("\0");
+    hash.update(content);
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+function parseGenerationManifest(raw: string): GenerationManifest {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new TypeError("git_source_generation_invalid_manifest");
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("git_source_generation_invalid_manifest");
+  }
+  const manifest = value as Record<string, unknown>;
+  if (manifest.schemaVersion !== MANIFEST_SCHEMA_VERSION) {
+    throw new TypeError("git_source_generation_unknown_schema");
+  }
+  for (const key of ["remote", "ref", "commit", "subdirectory", "contentSha256", "refreshedAt"]) {
+    if (typeof manifest[key] !== "string") {
+      throw new TypeError("git_source_generation_invalid_manifest");
+    }
+  }
+  if (manifest.policy !== "require_fresh" && manifest.policy !== "prefer_last_known_good") {
+    throw new TypeError("git_source_generation_invalid_manifest");
+  }
+  if (
+    !Array.isArray(manifest.include) ||
+    !manifest.include.every((entry) => typeof entry === "string")
+  ) {
+    throw new TypeError("git_source_generation_invalid_manifest");
+  }
+  if (!COMMIT_PATTERN.test(String(manifest.commit))) {
+    throw new TypeError("git_source_generation_invalid_commit");
+  }
+  if (!Number.isFinite(Date.parse(String(manifest.refreshedAt)))) {
+    throw new TypeError("git_source_generation_invalid_timestamp");
+  }
+  return manifest as unknown as GenerationManifest;
+}
+
 export class GitSource {
   id: string
   remote: string
   ref: string
   cacheDir: string
+  /** Legacy in-place checkout path, retained for compatibility; never auto-promoted. */
   checkout: string
   subdirectory: string
   include?: unknown[]
   publicBaseUrl?: string
   timeoutMs?: number
+  policy: GitSourcePolicy
+  maxStaleMs?: number
+  /** Truthful read status: fresh, degraded, or unavailable. */
+  status: GitSourceStatus = "unavailable"
+  #selection: SelectionOptions
+  #activeGeneration: PublishedGeneration | null = null
 
   constructor({
     id,
@@ -126,7 +393,9 @@ export class GitSource {
     subdirectory = ".",
     include,
     publicBaseUrl,
-    timeoutMs
+    timeoutMs,
+    policy,
+    maxStaleMs
   }: {
     id: string
     remote: string
@@ -136,6 +405,8 @@ export class GitSource {
     include?: unknown[]
     publicBaseUrl?: string
     timeoutMs?: number
+    policy?: GitSourcePolicy
+    maxStaleMs?: number
   }) {
     if (!id || !remote) throw new TypeError("git_source_requires_id_and_remote");
     this.id = String(id);
@@ -147,40 +418,287 @@ export class GitSource {
     this.include = include;
     this.publicBaseUrl = publicBaseUrl;
     this.timeoutMs = timeoutMs;
+    this.policy = validatePolicy(policy);
+    this.maxStaleMs = validateMaxStaleMs(maxStaleMs, this.policy);
+    this.#selection = selectionOptions(include);
   }
 
+  /**
+   * Acquires the latest checkout strictly inside a unique staging directory
+   * and atomically publishes a validated immutable generation. A failure
+   * never mutates the active state and always throws; it is never relabeled
+   * as success. Legacy in-place checkouts are never auto-promoted.
+   */
   async sync(): Promise<void> {
     await mkdir(this.cacheDir, { recursive: true, mode: 0o700 });
-    const gitDirectory = path.join(this.checkout, ".git");
-    if (!(await exists(gitDirectory))) {
+    const stagingRoot = await mkdtemp(path.join(this.cacheDir, ".staging-"));
+    try {
+      const stagedCheckout = path.join(stagingRoot, "checkout");
       await runGit(
-        ["clone", "--depth", "1", "--branch", this.ref, "--single-branch", "--", this.remote, this.checkout],
+        ["clone", "--depth", "1", "--branch", this.ref, "--single-branch", "--", this.remote, stagedCheckout],
         { timeoutMs: this.timeoutMs }
       );
-      return;
+      const commit = (await runGit(["rev-parse", "HEAD"], {
+        cwd: stagedCheckout,
+        timeoutMs: this.timeoutMs
+      })).trim();
+      if (!COMMIT_PATTERN.test(commit)) {
+        throw new TypeError("git_source_generation_invalid_commit");
+      }
+      const { manifest, files } = await this.#buildCandidate(stagedCheckout, commit);
+      const generation = await this.#publishGeneration(stagingRoot, manifest, files);
+      this.#activeGeneration = generation;
+      this.status = "fresh";
+    } catch (error) {
+      this.status = "unavailable";
+      throw error;
+    } finally {
+      await rm(stagingRoot, { recursive: true, force: true });
     }
-
-    await runGit(["fetch", "--depth", "1", "origin", this.ref], {
-      cwd: this.checkout,
-      timeoutMs: this.timeoutMs
-    });
-    await runGit(["checkout", "--detach", "--force", "FETCH_HEAD"], {
-      cwd: this.checkout,
-      timeoutMs: this.timeoutMs
-    });
   }
 
+  /**
+   * Loads approved documents. With the default strict policy any acquisition
+   * failure throws. With opt-in `prefer_last_known_good` a typed remote
+   * acquisition failure may serve exactly one revalidated active generation,
+   * reported as `degraded`. Missing, legacy, corrupt, mismatched, symlinked,
+   * traversing, future-dated, or over-age state always fails closed.
+   */
   async load(): Promise<unknown[]> {
-    await this.sync();
-    const requested = path.resolve(this.checkout, this.subdirectory);
-    const relative = path.relative(this.checkout, requested);
-    if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    this.status = "unavailable";
+    try {
+      await this.sync();
+    } catch (error) {
+      if (this.policy !== "prefer_last_known_good" || !isRemoteAcquisitionFailure(error)) {
+        throw error;
+      }
+      let generation: PublishedGeneration;
+      try {
+        generation = await this.#revalidateActiveGeneration();
+      } catch (validationError) {
+        const reason =
+          validationError instanceof Error ? validationError.message : "unknown";
+        throw new Error(`git_source_lkg_unavailable:${reason}`, { cause: error });
+      }
+      this.#activeGeneration = generation;
+      this.status = "degraded";
+    }
+    const active = this.#activeGeneration;
+    if (!active) {
+      throw new Error("git_source_lkg_unavailable:missing_active");
+    }
+    return this.#documentsFromGeneration(active);
+  }
+
+  async #buildCandidate(
+    stagedCheckout: string,
+    commit: string
+  ): Promise<{ manifest: GenerationManifest; files: string[] }> {
+    const requested = path.resolve(stagedCheckout, this.subdirectory);
+    const relative = path.relative(stagedCheckout, requested);
+    if (
+      relative === ".." ||
+      relative.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relative)
+    ) {
       throw new TypeError("git_source_subdirectory_outside_checkout");
     }
+    const rootStat = await lstat(requested).catch((error: NodeJS.ErrnoException) => {
+      if (error && error.code === "ENOENT") {
+        throw new TypeError("git_source_generation_selection_missing");
+      }
+      throw error;
+    });
+    if (!rootStat.isDirectory()) {
+      throw new TypeError("git_source_generation_selection_missing");
+    }
+    const files = await collectSelectedFiles(requested, this.#selection);
+    const contentSha256 = await computeContentDigest(requested, files, this.#selection);
+    return {
+      manifest: {
+        schemaVersion: MANIFEST_SCHEMA_VERSION,
+        policy: this.policy,
+        remote: this.remote,
+        ref: this.ref,
+        commit,
+        subdirectory: this.subdirectory,
+        include: normalizeInclude(this.include),
+        contentSha256,
+        refreshedAt: new Date().toISOString()
+      },
+      files
+    };
+  }
+
+  /**
+   * Assembles the immutable generation next to the staged checkout, then
+   * atomically renames it into place and atomically points `active.json` at
+   * it. Readers observe either a complete old generation or a complete new
+   * generation, never a partial or mixed state.
+   */
+  async #publishGeneration(
+    stagingRoot: string,
+    manifest: GenerationManifest,
+    files: string[]
+  ): Promise<PublishedGeneration> {
+    const generationsDir = path.join(this.cacheDir, GENERATIONS_DIR);
+    await mkdir(generationsDir, { recursive: true, mode: 0o700 });
+
+    const id = `${manifest.commit.slice(0, 12)}-${Date.now()}-${randomBytes(4).toString("hex")}`;
+    const built = path.join(stagingRoot, "generation");
+    const contentRoot = path.join(built, CONTENT_DIR);
+    const requested = path.resolve(stagingRoot, "checkout", this.subdirectory);
+
+    for (const relative of files) {
+      const source = path.join(requested, relative);
+      const target = path.join(contentRoot, relative);
+      await mkdir(path.dirname(target), { recursive: true, mode: 0o700 });
+      await copyFile(source, target);
+    }
+    await writeFile(
+      path.join(built, MANIFEST_FILE),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      { mode: 0o600 }
+    );
+
+    const finalPath = path.join(generationsDir, id);
+    await rename(built, finalPath);
+
+    const activePayload = JSON.stringify({ schemaVersion: ACTIVE_SCHEMA_VERSION, generation: id });
+    const activeTmp = path.join(this.cacheDir, `.${ACTIVE_FILE}.tmp-${id}`);
+    await writeFile(activeTmp, activePayload, { mode: 0o600 });
+    await rename(activeTmp, path.join(this.cacheDir, ACTIVE_FILE));
+
+    return { id, manifest };
+  }
+
+  /**
+   * Full evidence revalidation before every degraded read: pointer path
+   * safety, manifest schema, provenance binding (remote, ref, selection,
+   * policy), commit, timestamp, age, and selected-content digest.
+   */
+  async #revalidateActiveGeneration(): Promise<PublishedGeneration> {
+    if (this.maxStaleMs === undefined) {
+      throw new TypeError("git_source_lkg_missing_bound");
+    }
+    const activePath = path.join(this.cacheDir, ACTIVE_FILE);
+    await assertNoSymlinkSegments(
+      this.cacheDir,
+      ACTIVE_FILE,
+      "git_source_generation_missing_active"
+    );
+    let rawActive: string;
+    try {
+      rawActive = await readFile(activePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new TypeError("git_source_generation_missing_active");
+      }
+      throw error;
+    }
+    if (Buffer.byteLength(rawActive, "utf8") > MAX_ACTIVE_BYTES) {
+      throw new TypeError("git_source_generation_invalid_active");
+    }
+    let activeValue: unknown;
+    try {
+      activeValue = JSON.parse(rawActive);
+    } catch {
+      throw new TypeError("git_source_generation_invalid_active");
+    }
+    if (!activeValue || typeof activeValue !== "object" || Array.isArray(activeValue)) {
+      throw new TypeError("git_source_generation_invalid_active");
+    }
+    const active = activeValue as Record<string, unknown>;
+    if (
+      active.schemaVersion !== ACTIVE_SCHEMA_VERSION ||
+      typeof active.generation !== "string" ||
+      !GENERATION_ID_PATTERN.test(active.generation)
+    ) {
+      throw new TypeError("git_source_generation_invalid_id");
+    }
+
+    const generationDir = path.join(this.cacheDir, GENERATIONS_DIR, active.generation);
+    const relativeToGenerations = path.relative(
+      path.join(this.cacheDir, GENERATIONS_DIR),
+      generationDir
+    );
+    if (
+      relativeToGenerations === ".." ||
+      relativeToGenerations.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativeToGenerations)
+    ) {
+      throw new TypeError("git_source_generation_invalid_id");
+    }
+    await assertNoSymlinkSegments(
+      this.cacheDir,
+      path.join(GENERATIONS_DIR, active.generation),
+      "git_source_generation_missing"
+    );
+
+    const manifestPath = path.join(generationDir, MANIFEST_FILE);
+    let rawManifest: string;
+    try {
+      rawManifest = await readFile(manifestPath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new TypeError("git_source_generation_missing_manifest");
+      }
+      throw error;
+    }
+    if (Buffer.byteLength(rawManifest, "utf8") > MAX_MANIFEST_BYTES) {
+      throw new TypeError("git_source_generation_invalid_manifest");
+    }
+    const manifest = parseGenerationManifest(rawManifest);
+
+    if (manifest.remote !== this.remote) {
+      throw new TypeError("git_source_generation_provenance_mismatch:remote");
+    }
+    if (manifest.ref !== this.ref) {
+      throw new TypeError("git_source_generation_provenance_mismatch:ref");
+    }
+    if (manifest.subdirectory !== this.subdirectory) {
+      throw new TypeError("git_source_generation_provenance_mismatch:subdirectory");
+    }
+    if (JSON.stringify(manifest.include) !== JSON.stringify(normalizeInclude(this.include))) {
+      throw new TypeError("git_source_generation_provenance_mismatch:include");
+    }
+    if (manifest.policy !== this.policy) {
+      throw new TypeError("git_source_generation_provenance_mismatch:policy");
+    }
+
+    const refreshedAtMs = Date.parse(manifest.refreshedAt);
+    const nowMs = Date.now();
+    if (!ageWithinBound(refreshedAtMs, nowMs, this.maxStaleMs)) {
+      if (refreshedAtMs > nowMs) {
+        throw new TypeError("git_source_generation_future_timestamp");
+      }
+      throw new TypeError("git_source_generation_over_age");
+    }
+
+    const contentRoot = path.join(generationDir, CONTENT_DIR);
+    const contentStat = await lstat(contentRoot).catch((error: NodeJS.ErrnoException) => {
+      if (error && error.code === "ENOENT") {
+        throw new TypeError("git_source_generation_selection_missing");
+      }
+      throw error;
+    });
+    if (!contentStat.isDirectory() || contentStat.isSymbolicLink()) {
+      throw new TypeError("git_source_generation_selection_missing");
+    }
+    const files = await collectSelectedFiles(contentRoot, this.#selection);
+    const contentSha256 = await computeContentDigest(contentRoot, files, this.#selection);
+    if (contentSha256 !== manifest.contentSha256) {
+      throw new TypeError("git_source_generation_digest_mismatch");
+    }
+    return { id: active.generation, manifest };
+  }
+
+  async #documentsFromGeneration(generation: PublishedGeneration): Promise<unknown[]> {
+    const contentRoot = path.join(this.cacheDir, GENERATIONS_DIR, generation.id, CONTENT_DIR);
     const source = new FileSystemSource({
       id: this.id,
-      root: requested,
-      include: this.include,
+      root: contentRoot,
+      include: generation.manifest.include ?? undefined,
       publicBaseUrl: this.publicBaseUrl
     });
     const documents = await source.load();
@@ -189,13 +707,14 @@ export class GitSource {
         source: Record<string, unknown>
       };
       return {
-      ...document,
-      source: {
-        ...document.source,
-        type: "git",
-        repository: this.remote,
-        ref: this.ref
-      }
+        ...document,
+        source: {
+          ...document.source,
+          type: "git",
+          repository: generation.manifest.remote,
+          ref: generation.manifest.ref,
+          commit: generation.manifest.commit
+        }
       };
     });
   }

--- a/docs/connectors/README.md
+++ b/docs/connectors/README.md
@@ -6,7 +6,7 @@
 | HTTP | channel | Loopback; optional bearer token | Available |
 | DingTalk Stream | channel | App credentials and Stream subscription | Optional |
 | Filesystem | source | Explicit directory | Enabled in demo |
-| Git | source | Credential-free HTTPS repository | Optional |
+| Git | source | Credential-free HTTPS repository; isolated cache; no shell; refresh fails closed, optional validated last-known-good | Optional |
 | DWS | source | Explicit profile and read-only approved queries | Optional |
 | Extractive | model | Local process | Enabled in demo |
 | OpenAI-compatible | model | Environment-supplied API key | Optional |

--- a/tests/apps/git-source-cli.test.ts
+++ b/tests/apps/git-source-cli.test.ts
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict"
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { spawnSync } from "node:child_process"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+import { createRuntime, runtimeHealth } from "../../apps/cli/runtime.js"
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const cli = path.join(root, "apps", "cli", "bin.ts")
+const fakeGitFixture = path.join(root, "tests", "git", "fixtures", "fake-git.mjs")
+
+interface CliRun {
+  status: number | null
+  stdout: string
+  stderr: string
+}
+
+function runCli(args: string[], environment: NodeJS.ProcessEnv): CliRun {
+  const result = spawnSync(process.execPath, ["--import", "tsx", cli, ...args], {
+    cwd: root,
+    encoding: "utf8",
+    env: environment,
+  })
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  }
+}
+
+interface CliFixtureContext {
+  root: string
+  cacheDir: string
+  configPath: string
+  binDir: string
+  recordPath: string
+  baseEnv: NodeJS.ProcessEnv
+}
+
+async function withCliFixture(
+  fn: (context: CliFixtureContext) => Promise<void>,
+): Promise<void> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "digital-employee-cli-git-"))
+  const binDir = path.join(directory, "bin")
+  await mkdir(binDir, { recursive: true })
+  const gitPath = path.join(binDir, "git")
+  await writeFile(gitPath, await readFile(fakeGitFixture, "utf8"), { mode: 0o755 })
+  await chmod(gitPath, 0o755)
+  const cacheDir = path.join(directory, "cache")
+  const recordPath = path.join(directory, "git-record.jsonl")
+  const configPath = path.join(directory, "config.json")
+  try {
+    await writeConfig(configPath, { cacheDir })
+    const baseEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      GIT_TEST_RECORD: recordPath,
+      DIGITAL_EMPLOYEE_SUPPRESS_LEGACY_WARNING: "1",
+    }
+    await fn({ root: directory, cacheDir, configPath, binDir, recordPath, baseEnv })
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+async function writeConfig(
+  configPath: string,
+  source: { cacheDir: string; maxStaleMs?: number; omitBound?: boolean },
+): Promise<void> {
+  const config = {
+    employee: { id: "cli-git-lkg", profile: "answer-agent" },
+    runtime: { readOnly: true, topK: 3, minScore: 0.03 },
+    model: { provider: "extractive" },
+    sources: [
+      {
+        id: "git-docs",
+        type: "git",
+        remote: "https://example.test/public-docs.git",
+        ref: "main",
+        cacheDir: source.cacheDir,
+        policy: "prefer_last_known_good",
+        ...(source.omitBound
+          ? {}
+          : { maxStaleMs: source.maxStaleMs ?? 600_000 }),
+      },
+    ],
+  }
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`)
+}
+
+test("AC-007: sync --json reports fresh, then degraded with exit 2 on remote failure", async () => {
+  await withCliFixture(async (context) => {
+    const fresh = runCli(
+      ["legacy", "sync", "--json", "-c", context.configPath],
+      context.baseEnv,
+    )
+    assert.equal(fresh.status, 0, fresh.stderr)
+    const freshJson = JSON.parse(fresh.stdout) as {
+      status: string
+      documentCount: number
+      sources: { id: string; type: string; status: string }[]
+    }
+    assert.equal(freshJson.status, "ready")
+    assert.equal(freshJson.documentCount, 3)
+    assert.deepEqual(freshJson.sources, [
+      { id: "git-docs", type: "git", status: "fresh" },
+    ])
+    assert.ok(!fresh.stdout.includes(context.cacheDir))
+    assert.ok(!fresh.stdout.includes("public-docs"))
+    assert.ok(!fresh.stderr.includes("fatal"))
+
+    const degradedEnv = { ...context.baseEnv, GIT_TEST_FAIL_EXIT: "73" }
+    const degraded = runCli(
+      ["legacy", "sync", "--json", "-c", context.configPath],
+      degradedEnv,
+    )
+    assert.equal(degraded.status, 2, degraded.stderr)
+    const degradedJson = JSON.parse(degraded.stdout) as {
+      status: string
+      documentCount: number
+      sources: { id: string; type: string; status: string }[]
+    }
+    assert.equal(degradedJson.status, "degraded")
+    assert.equal(degradedJson.documentCount, 3)
+    assert.deepEqual(degradedJson.sources, [
+      { id: "git-docs", type: "git", status: "degraded" },
+    ])
+    assert.match(degraded.stderr, /is degraded/)
+    assert.ok(!degraded.stderr.includes("Ready"))
+    assert.ok(!degraded.stderr.includes(context.cacheDir))
+    assert.ok(!degraded.stderr.includes("fatal"))
+  })
+})
+
+test("AC-007: text sync prints Degraded and exits 2, never Ready", async () => {
+  await withCliFixture(async (context) => {
+    const fresh = runCli(["legacy", "sync", "-c", context.configPath], context.baseEnv)
+    assert.equal(fresh.status, 0, fresh.stderr)
+    assert.match(fresh.stdout, /^Ready:/)
+
+    const degradedEnv = { ...context.baseEnv, GIT_TEST_FAIL_EXIT: "73" }
+    const degraded = runCli(
+      ["legacy", "sync", "-c", context.configPath],
+      degradedEnv,
+    )
+    assert.equal(degraded.status, 2, degraded.stderr)
+    assert.match(degraded.stdout, /^Degraded:/)
+    assert.ok(!degraded.stdout.includes("Ready"))
+  })
+})
+
+test("AC-007: runtime status and HTTP health report degraded, never ready", async () => {
+  await withCliFixture(async (context) => {
+    const originalPath = process.env.PATH
+    const originalFail = process.env.GIT_TEST_FAIL_EXIT
+    try {
+      process.env.PATH = `${context.binDir}${path.delimiter}${originalPath ?? ""}`
+      delete process.env.GIT_TEST_FAIL_EXIT
+      const runtime = await createRuntime(context.configPath)
+      assert.deepEqual(runtime.sourceStatuses, [
+        { id: "git-docs", type: "git", status: "fresh" },
+      ])
+      const freshHealth = JSON.stringify(runtimeHealth(runtime))
+      assert.ok(!freshHealth.includes(context.cacheDir))
+
+      process.env.GIT_TEST_FAIL_EXIT = "73"
+      const degradedRuntime = await createRuntime(context.configPath)
+      assert.deepEqual(degradedRuntime.sourceStatuses, [
+        { id: "git-docs", type: "git", status: "degraded" },
+      ])
+      const health = runtimeHealth(degradedRuntime) as {
+        status: string
+        employee: string
+        documents: number
+        sources: { id: string; type: string; status: string }[]
+      }
+      assert.equal(health.status, "ok")
+      assert.equal(health.employee, "cli-git-lkg")
+      assert.equal(health.documents, 3)
+      assert.equal(health.sources[0].status, "degraded")
+      const healthText = JSON.stringify(health)
+      assert.ok(!healthText.includes("Ready"))
+      assert.ok(!healthText.includes("ready"))
+      assert.ok(!healthText.includes(context.cacheDir))
+      assert.ok(!healthText.includes("public-docs"))
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH
+      else process.env.PATH = originalPath
+      if (originalFail === undefined) delete process.env.GIT_TEST_FAIL_EXIT
+      else process.env.GIT_TEST_FAIL_EXIT = originalFail
+    }
+  })
+})
+
+test("AC-001/AC-007: out-of-bounds or missing LKG bounds fail at configuration", async () => {
+  await withCliFixture(async (context) => {
+    const outOfBounds = path.join(context.root, "config-out-of-bounds.json")
+    await writeConfig(outOfBounds, { cacheDir: context.cacheDir, maxStaleMs: 999 })
+    const rejected = runCli(
+      ["legacy", "sync", "--json", "-c", outOfBounds],
+      context.baseEnv,
+    )
+    assert.equal(rejected.status, 1)
+    assert.match(rejected.stderr, /git_source_lkg_max_stale_ms_out_of_bounds/)
+    assert.ok(!rejected.stdout.includes("Ready"))
+
+    const missingBound = path.join(context.root, "config-missing-bound.json")
+    await writeConfig(missingBound, { cacheDir: context.cacheDir, omitBound: true })
+    const missing = runCli(
+      ["legacy", "sync", "--json", "-c", missingBound],
+      context.baseEnv,
+    )
+    assert.equal(missing.status, 1)
+    assert.match(missing.stderr, /git_source_lkg_max_stale_ms_out_of_bounds:missing/)
+  })
+})

--- a/tests/git/fixtures/fake-git.mjs
+++ b/tests/git/fixtures/fake-git.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Fake git for GitSource tests: records every invocation, materializes a
+// shallow clone checkout, resolves a fixed commit, and can simulate a typed
+// remote acquisition failure (exit code) on any clone call.
+//
+// Environment contract:
+//   GIT_TEST_RECORD          - JSONL path; each line records { args, cwd, env }
+//   GIT_TEST_FAIL_EXIT       - when set, every clone exits with this code
+//   GIT_TEST_COMMIT          - override the resolved HEAD commit (hex, 40)
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const recordPath = process.env.GIT_TEST_RECORD;
+const record = {
+  args: process.argv.slice(2),
+  cwd: process.cwd(),
+  env: {
+    gitConfigGlobal: process.env.GIT_CONFIG_GLOBAL,
+    gitConfigNoSystem: process.env.GIT_CONFIG_NOSYSTEM,
+    gitConfigCount: process.env.GIT_CONFIG_COUNT,
+    gitConfigKey: process.env.GIT_CONFIG_KEY_0,
+    gitConfigValue: process.env.GIT_CONFIG_VALUE_0,
+    gitAskPass: process.env.GIT_ASKPASS,
+    sshAskPass: process.env.SSH_ASKPASS,
+  },
+};
+if (recordPath) {
+  appendFileSync(recordPath, `${JSON.stringify(record)}\n`);
+}
+
+const args = process.argv.slice(2);
+const failExit = process.env.GIT_TEST_FAIL_EXIT
+  ? Number(process.env.GIT_TEST_FAIL_EXIT)
+  : 0;
+
+if (args.includes("clone")) {
+  if (failExit) {
+    process.stderr.write(`fatal: fake remote acquisition failure (${failExit})\n`);
+    process.exit(failExit);
+  }
+  const separator = args.lastIndexOf("--");
+  const target =
+    separator !== -1 && args[separator + 2]
+      ? path.resolve(args[separator + 2])
+      : path.join(process.cwd(), "checkout");
+  mkdirSync(path.join(target, ".git"), { recursive: true });
+  writeFileSync(path.join(target, ".git", "HEAD"), "ref: refs/heads/main\n");
+  writeFileSync(path.join(target, "README.md"), "# Demo\n\nHello from the fake repository.\n");
+  mkdirSync(path.join(target, "docs"), { recursive: true });
+  writeFileSync(path.join(target, "docs", "guide.md"), "# Guide\n\nStep one.\n");
+  writeFileSync(path.join(target, "notes.json"), '{"topic":"fixture"}\n');
+  writeFileSync(path.join(target, ".env.example"), "EXAMPLE=hidden\n");
+  writeFileSync(path.join(target, "secret.env"), "SECRET=must-not-load\n");
+  process.exit(0);
+}
+
+if (args.includes("rev-parse")) {
+  process.stdout.write(`${process.env.GIT_TEST_COMMIT || "c0ffee0000000000000000000000000000000000"}\n`);
+  process.exit(0);
+}
+
+process.exit(0);

--- a/tests/git/git-source.test.ts
+++ b/tests/git/git-source.test.ts
@@ -1,16 +1,139 @@
 import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
 import {
   chmod,
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   rm,
+  symlink,
   writeFile
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { GitSource } from "../../connectors/sources/git/index.js";
+import { fileURLToPath } from "node:url";
+import {
+  GitSource,
+  LKG_MAX_STALE_MS_BOUNDS,
+  ageWithinBound,
+  isRemoteAcquisitionFailure
+} from "../../connectors/sources/git/index.js";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const fakeGitFixture = path.join(root, "tests", "git", "fixtures", "fake-git.mjs");
+const FIXED_COMMIT = "c0ffee0000000000000000000000000000000000";
+
+interface GitFixtureContext {
+  root: string
+  cacheDir: string
+  recordPath: string
+}
+
+const gitEnvNames = [
+  "PATH",
+  "GIT_TEST_RECORD",
+  "GIT_TEST_FAIL_EXIT",
+  "GIT_TEST_COMMIT",
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_KEY_0",
+  "GIT_CONFIG_VALUE_0",
+  "GIT_ASKPASS",
+  "SSH_ASKPASS"
+] as const;
+
+async function withGitFixture(
+  fn: (context: GitFixtureContext) => Promise<void>
+): Promise<void> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "digital-employee-git-"));
+  const binDir = path.join(directory, "bin");
+  const executable = path.join(binDir, process.platform === "win32" ? "git.cmd" : "git");
+  await mkdir(binDir, { recursive: true });
+  await writeFile(executable, await readFile(fakeGitFixture, "utf8"), { mode: 0o755 });
+  await chmod(executable, 0o755);
+
+  const original: Partial<Record<(typeof gitEnvNames)[number], string | undefined>> = {};
+  for (const name of gitEnvNames) original[name] = process.env[name];
+  process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+  process.env.GIT_TEST_RECORD = path.join(directory, "git-record.jsonl");
+  try {
+    await fn({
+      root: directory,
+      cacheDir: path.join(directory, "cache"),
+      recordPath: path.join(directory, "git-record.jsonl")
+    });
+  } finally {
+    for (const [name, value] of Object.entries(original)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+function failRemote(exitCode = 73): void {
+  process.env.GIT_TEST_FAIL_EXIT = String(exitCode);
+}
+
+function healRemote(): void {
+  delete process.env.GIT_TEST_FAIL_EXIT;
+}
+
+function options(
+  context: GitFixtureContext,
+  overrides: Partial<ConstructorParameters<typeof GitSource>[0]> = {}
+): ConstructorParameters<typeof GitSource>[0] {
+  return {
+    id: "git-docs",
+    remote: "https://example.test/public-docs.git",
+    ref: "main",
+    cacheDir: context.cacheDir,
+    policy: "prefer_last_known_good",
+    maxStaleMs: 600_000,
+    ...overrides
+  };
+}
+
+async function activeGeneration(cacheDir: string): Promise<{ id: string; dir: string }> {
+  const active = JSON.parse(await readFile(path.join(cacheDir, "active.json"), "utf8")) as {
+    generation: string
+  };
+  return { id: active.generation, dir: path.join(cacheDir, "generations", active.generation) };
+}
+
+async function activeManifest(cacheDir: string): Promise<Record<string, unknown>> {
+  const generation = await activeGeneration(cacheDir);
+  return JSON.parse(
+    await readFile(path.join(generation.dir, "manifest.json"), "utf8")
+  ) as Record<string, unknown>;
+}
+
+async function rewriteActiveManifest(
+  cacheDir: string,
+  mutate: (manifest: Record<string, unknown>) => void
+): Promise<void> {
+  const generation = await activeGeneration(cacheDir);
+  const manifestPath = path.join(generation.dir, "manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as Record<string, unknown>;
+  mutate(manifest);
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+async function cloneTargets(recordPath: string): Promise<string[]> {
+  const lines = (await readFile(recordPath, "utf8")).trim().split("\n");
+  const targets: string[] = [];
+  for (const line of lines) {
+    if (!line) continue;
+    const record = JSON.parse(line) as { args: string[]; cwd: string };
+    if (!record.args.includes("clone")) continue;
+    const separator = record.args.lastIndexOf("--");
+    const target = record.args[separator + 2];
+    if (typeof target === "string") targets.push(target);
+  }
+  return targets;
+}
 
 test("Git source accepts a credential-free HTTPS repository", () => {
   const source = new GitSource({
@@ -19,6 +142,8 @@ test("Git source accepts a credential-free HTTPS repository", () => {
     ref: "main"
   });
   assert.equal(source.remote, "https://github.com/example/example.git");
+  assert.equal(source.policy, "require_fresh");
+  assert.equal(source.status, "unavailable");
 });
 
 test("Git source rejects embedded credentials and unsafe schemes", () => {
@@ -53,77 +178,569 @@ test("Git source rejects command-like refs", () => {
 });
 
 test("Git source isolates global config and inherited credential helpers", async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), "digital-employee-git-"));
-  const binDir = path.join(root, "bin");
-  const recordPath = path.join(root, "git-record.json");
-  const fakeGit = path.join(binDir, process.platform === "win32" ? "git.cmd" : "git");
-  await mkdir(binDir, { recursive: true });
-  await writeFile(
-    fakeGit,
-    `#!/usr/bin/env node
-const { writeFileSync } = require("node:fs");
-writeFileSync(process.env.GIT_TEST_RECORD, JSON.stringify({
-  args: process.argv.slice(2),
-  gitConfigGlobal: process.env.GIT_CONFIG_GLOBAL,
-  gitConfigNoSystem: process.env.GIT_CONFIG_NOSYSTEM,
-  gitConfigCount: process.env.GIT_CONFIG_COUNT,
-  gitConfigKey: process.env.GIT_CONFIG_KEY_0,
-  gitAskPass: process.env.GIT_ASKPASS,
-  sshAskPass: process.env.SSH_ASKPASS
-}));
-`,
-    { mode: 0o700 }
-  );
-  if (process.platform !== "win32") await chmod(fakeGit, 0o700);
+  await withGitFixture(async (context) => {
+    const unsafe = path.join(context.root, "unsafe");
+    const original = {
+      GIT_CONFIG_GLOBAL: process.env.GIT_CONFIG_GLOBAL,
+      GIT_CONFIG_COUNT: process.env.GIT_CONFIG_COUNT,
+      GIT_CONFIG_KEY_0: process.env.GIT_CONFIG_KEY_0,
+      GIT_CONFIG_VALUE_0: process.env.GIT_CONFIG_VALUE_0,
+      GIT_ASKPASS: process.env.GIT_ASKPASS,
+      SSH_ASKPASS: process.env.SSH_ASKPASS
+    };
+    try {
+      process.env.GIT_CONFIG_GLOBAL = path.join(unsafe, "unsafe-global-config");
+      process.env.GIT_CONFIG_COUNT = "1";
+      process.env.GIT_CONFIG_KEY_0 = "credential.helper";
+      process.env.GIT_CONFIG_VALUE_0 = "unsafe-helper";
+      process.env.GIT_ASKPASS = path.join(unsafe, "unsafe-git-askpass");
+      process.env.SSH_ASKPASS = path.join(unsafe, "unsafe-ssh-askpass");
 
-  const original = {
-    PATH: process.env.PATH,
-    GIT_TEST_RECORD: process.env.GIT_TEST_RECORD,
-    GIT_CONFIG_GLOBAL: process.env.GIT_CONFIG_GLOBAL,
-    GIT_CONFIG_COUNT: process.env.GIT_CONFIG_COUNT,
-    GIT_CONFIG_KEY_0: process.env.GIT_CONFIG_KEY_0,
-    GIT_CONFIG_VALUE_0: process.env.GIT_CONFIG_VALUE_0,
-    GIT_ASKPASS: process.env.GIT_ASKPASS,
-    SSH_ASKPASS: process.env.SSH_ASKPASS
-  };
-  try {
-    process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
-    process.env.GIT_TEST_RECORD = recordPath;
-    process.env.GIT_CONFIG_GLOBAL = path.join(root, "unsafe-global-config");
-    process.env.GIT_CONFIG_COUNT = "1";
-    process.env.GIT_CONFIG_KEY_0 = "credential.helper";
-    process.env.GIT_CONFIG_VALUE_0 = "unsafe-helper";
-    process.env.GIT_ASKPASS = path.join(root, "unsafe-git-askpass");
-    process.env.SSH_ASKPASS = path.join(root, "unsafe-ssh-askpass");
+      const source = new GitSource({
+        id: "isolated",
+        remote: "https://example.test/public.git",
+        cacheDir: context.cacheDir
+      });
+      await source.sync();
+      assert.equal(source.status, "fresh");
 
-    const source = new GitSource({
-      id: "isolated",
-      remote: "https://example.test/public.git",
-      cacheDir: path.join(root, "cache")
-    });
-    await source.sync();
-
-    const record = JSON.parse(await readFile(recordPath, "utf8"));
-    assert.deepEqual(record.args.slice(0, 4), [
-      "-c",
-      "credential.helper=",
-      "-c",
-      "core.askPass="
-    ]);
-    assert.equal(
-      record.gitConfigGlobal,
-      process.platform === "win32" ? "NUL" : "/dev/null"
-    );
-    assert.equal(record.gitConfigNoSystem, "1");
-    assert.equal(record.gitConfigCount, undefined);
-    assert.equal(record.gitConfigKey, undefined);
-    assert.equal(record.gitAskPass, undefined);
-    assert.equal(record.sshAskPass, undefined);
-  } finally {
-    for (const [name, value] of Object.entries(original)) {
-      if (value === undefined) delete process.env[name];
-      else process.env[name] = value;
+      const first = JSON.parse(
+        (await readFile(context.recordPath, "utf8")).trim().split("\n")[0]
+      ) as { args: string[]; env: Record<string, unknown> };
+      assert.deepEqual(first.args.slice(0, 4), [
+        "-c",
+        "credential.helper=",
+        "-c",
+        "core.askPass="
+      ]);
+      assert.equal(
+        first.env.gitConfigGlobal,
+        process.platform === "win32" ? "NUL" : "/dev/null"
+      );
+      assert.equal(first.env.gitConfigNoSystem, "1");
+      assert.equal(first.env.gitConfigCount, undefined);
+      assert.equal(first.env.gitConfigKey, undefined);
+      assert.equal(first.env.gitAskPass, undefined);
+      assert.equal(first.env.sshAskPass, undefined);
+    } finally {
+      for (const [name, value] of Object.entries(original)) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
     }
-    await rm(root, { recursive: true, force: true });
+  });
+});
+
+test("AC-001: default strict policy fails closed on refresh failure", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource({
+      id: "git-docs",
+      remote: "https://example.test/public-docs.git",
+      ref: "main",
+      cacheDir: context.cacheDir
+    });
+    const first = await source.load();
+    assert.equal(source.status, "fresh");
+    assert.equal(first.length, 3);
+
+    failRemote();
+    await assert.rejects(() => source.load(), /git_source_command_failed:73/);
+    assert.equal(source.status, "unavailable");
+    healRemote();
+  });
+});
+
+test("AC-001: explicit require_fresh policy also fails closed", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource(
+      options(context, { policy: "require_fresh", maxStaleMs: undefined })
+    );
+    await source.load();
+    failRemote();
+    await assert.rejects(() => source.load(), /git_source_command_failed:73/);
+    healRemote();
+  });
+});
+
+test("AC-001: LKG without a bound is rejected during configuration", () => {
+  assert.throws(
+    () =>
+      new GitSource({
+        id: "lkg",
+        remote: "https://example.test/repo.git",
+        policy: "prefer_last_known_good"
+      }),
+    /git_source_lkg_max_stale_ms_out_of_bounds:missing/
+  );
+});
+
+test("AC-001: LKG rejects unsafe, non-integer, and non-numeric bounds", () => {
+  const base = {
+    id: "lkg",
+    remote: "https://example.test/repo.git",
+    policy: "prefer_last_known_good"
+  } as const;
+  for (const maxStaleMs of [999, 604_800_001, 1.5, NaN, -1, Number.MAX_SAFE_INTEGER + 1]) {
+    assert.throws(
+      () => new GitSource({ ...base, maxStaleMs }),
+      /git_source_lkg_max_stale_ms_out_of_bounds/,
+      `expected ${String(maxStaleMs)} to be rejected`
+    );
   }
+  assert.throws(
+    () => new GitSource({ ...base, maxStaleMs: "1000" as unknown as number }),
+    /git_source_lkg_max_stale_ms_out_of_bounds/
+  );
+});
+
+test("AC-001: LKG accepts the inclusive bounds", () => {
+  assert.equal(LKG_MAX_STALE_MS_BOUNDS[0], 1_000);
+  assert.equal(LKG_MAX_STALE_MS_BOUNDS[1], 604_800_000);
+  for (const maxStaleMs of [1_000, 604_800_000]) {
+    const source = new GitSource({
+      id: "lkg",
+      remote: "https://example.test/repo.git",
+      policy: "prefer_last_known_good",
+      maxStaleMs
+    });
+    assert.equal(source.maxStaleMs, maxStaleMs);
+  }
+});
+
+test("AC-001: a bound under require_fresh and unknown policies are rejected", () => {
+  assert.throws(
+    () =>
+      new GitSource({
+        id: "lkg",
+        remote: "https://example.test/repo.git",
+        policy: "require_fresh",
+        maxStaleMs: 60_000
+      }),
+    /git_source_max_stale_ms_requires_lkg_policy/
+  );
+  assert.throws(
+    () =>
+      new GitSource({
+        id: "lkg",
+        remote: "https://example.test/repo.git",
+        policy: "degrade-everything" as never
+      }),
+    /git_source_invalid_policy/
+  );
+});
+
+test("AC-002: clone and refresh occur only in a staging directory", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource(options(context));
+    await source.load();
+
+    const generation = await activeGeneration(context.cacheDir);
+    const content = path.join(generation.dir, "content");
+    assert.equal(
+      (await readFile(path.join(content, "README.md"), "utf8")).includes("fake repository"),
+      true
+    );
+    assert.equal(
+      (await readFile(path.join(content, "docs", "guide.md"), "utf8")).includes("Step one"),
+      true
+    );
+    const manifest = await activeManifest(context.cacheDir);
+    assert.equal(manifest.schemaVersion, 1);
+    assert.equal(manifest.commit, FIXED_COMMIT);
+    assert.equal(manifest.remote, "https://example.test/public-docs.git");
+    assert.match(String(manifest.contentSha256), /^[0-9a-f]{64}$/);
+
+    for (const target of await cloneTargets(context.recordPath)) {
+      assert.match(target, /\.staging-/);
+    }
+    assert.doesNotMatch(generation.dir, /\.staging-/);
+    const cacheEntries = await readdir(context.cacheDir);
+    assert.ok(cacheEntries.includes("active.json"));
+    assert.ok(cacheEntries.includes("generations"));
+    assert.equal(cacheEntries.some((entry) => entry.startsWith(".staging-")), false);
+  });
+});
+
+test("AC-002: a failed candidate never changes the active state", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource(options(context));
+    await source.load();
+    const before = await activeGeneration(context.cacheDir);
+    const manifestBefore = await activeManifest(context.cacheDir);
+    const generationEntriesBefore = (await readdir(path.join(context.cacheDir, "generations")))
+      .sort();
+
+    failRemote();
+    await assert.rejects(() => source.sync(), /git_source_command_failed:73/);
+    await source.load(); // degraded serves the untouched active generation
+    healRemote();
+
+    const after = await activeGeneration(context.cacheDir);
+    assert.equal(after.id, before.id);
+    assert.deepEqual(await activeManifest(context.cacheDir), manifestBefore);
+    assert.deepEqual(
+      (await readdir(path.join(context.cacheDir, "generations"))).sort(),
+      generationEntriesBefore
+    );
+  });
+});
+
+test("AC-003: E3 reproduction serves degraded under a typed acquisition failure", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource(options(context));
+    const first = await source.load();
+    assert.equal(source.status, "fresh");
+    assert.equal(first.length, 3);
+
+    failRemote(73);
+    const second = await source.load();
+    assert.equal(source.status, "degraded");
+    assert.equal(second.length, 3);
+    const document = second[0] as { source: Record<string, unknown> };
+    assert.equal(document.source.type, "git");
+    assert.equal(document.source.repository, "https://example.test/public-docs.git");
+    assert.equal(document.source.ref, "main");
+    assert.equal(document.source.commit, FIXED_COMMIT);
+    healRemote();
+  });
+});
+
+test("AC-003: age at the limit is served and age over the limit by 1 ms is rejected", () => {
+  const now = 1_752_000_000_000;
+  assert.equal(ageWithinBound(now - 1_000, now, 1_000), true);
+  assert.equal(ageWithinBound(now - 1_001, now, 1_000), false);
+  assert.equal(ageWithinBound(now + 1, now, 1_000), false);
+});
+
+test("AC-003: an over-age generation is rejected on degraded read", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource(options(context, { maxStaleMs: 5_000 }));
+    await source.load();
+    await rewriteActiveManifest(context.cacheDir, (manifest) => {
+      manifest.refreshedAt = new Date(Date.now() - 60_000).toISOString();
+    });
+    failRemote();
+    await assert.rejects(
+      () => source.load(),
+      /git_source_lkg_unavailable:git_source_generation_over_age/
+    );
+    healRemote();
+  });
+});
+
+test("AC-003: an in-bound generation serves degraded after refresh-time rewrite", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource(options(context, { maxStaleMs: 600_000 }));
+    await source.load();
+    await rewriteActiveManifest(context.cacheDir, (manifest) => {
+      manifest.refreshedAt = new Date(Date.now() - 10_000).toISOString();
+    });
+    failRemote();
+    const documents = await source.load();
+    assert.equal(source.status, "degraded");
+    assert.equal(documents.length, 3);
+    healRemote();
+  });
+});
+
+test("AC-004/AC-008: every degraded read revalidates manifest evidence", async () => {
+  const tamperCases: Array<[string, (manifest: Record<string, unknown>) => void]> = [
+    ["remote", (manifest) => { manifest.remote = "https://evil.test/other.git"; }],
+    ["ref", (manifest) => { manifest.ref = "develop"; }],
+    ["subdirectory", (manifest) => { manifest.subdirectory = "docs"; }],
+    ["include", (manifest) => { manifest.include = [".md"]; }],
+    ["policy", (manifest) => { manifest.policy = "require_fresh"; }],
+    ["commit", (manifest) => { manifest.commit = "not-a-commit"; }],
+    ["schema", (manifest) => { manifest.schemaVersion = 2; }],
+    ["digest", (manifest) => { manifest.contentSha256 = "deadbeef"; }],
+    ["future", (manifest) => {
+      manifest.refreshedAt = new Date(Date.now() + 3_600_000).toISOString();
+    }]
+  ];
+  for (const [label, mutate] of tamperCases) {
+    await withGitFixture(async (context) => {
+      const source = new GitSource(options(context));
+      await source.load();
+      await rewriteActiveManifest(context.cacheDir, mutate);
+      failRemote();
+      await assert.rejects(
+        () => source.load(),
+        /git_source_lkg_unavailable:git_source_generation_/,
+        `expected tampered ${label} to fail closed`
+      );
+      healRemote();
+    });
+  }
+});
+
+test("AC-004/AC-008: malformed, missing, or altered state fails closed", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource(options(context));
+    await source.load();
+    const generation = await activeGeneration(context.cacheDir);
+
+    failRemote();
+    const manifestBytes = await readFile(path.join(generation.dir, "manifest.json"), "utf8");
+    await writeFile(path.join(generation.dir, "manifest.json"), "{oops");
+    await assert.rejects(
+      () => source.load(),
+      /git_source_lkg_unavailable:git_source_generation_invalid_manifest/
+    );
+    await rm(path.join(generation.dir, "manifest.json"));
+    await assert.rejects(
+      () => source.load(),
+      /git_source_lkg_unavailable:git_source_generation_missing_manifest/
+    );
+    await writeFile(path.join(generation.dir, "manifest.json"), manifestBytes);
+
+    await writeFile(path.join(generation.dir, "content", "docs", "guide.md"), "# Tampered\n");
+    await assert.rejects(
+      () => source.load(),
+      /git_source_lkg_unavailable:git_source_generation_digest_mismatch/
+    );
+    await rm(path.join(generation.dir, "content", "docs", "guide.md"));
+    await assert.rejects(
+      () => source.load(),
+      /git_source_lkg_unavailable:git_source_generation_digest_mismatch/
+    );
+    healRemote();
+  });
+});
+
+test("AC-008: pointer symlinks, traversing ids, and content symlinks are rejected", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource(options(context));
+    await source.load();
+
+    failRemote();
+
+    // active.json replaced by a symlink.
+    const activePath = path.join(context.cacheDir, "active.json");
+    const activeBytes = await readFile(activePath);
+    const decoy = path.join(context.root, "decoy-active.json");
+    await writeFile(decoy, activeBytes);
+    await rm(activePath);
+    await symlink(decoy, activePath);
+    await assert.rejects(
+      () => source.load(),
+      /git_source_lkg_unavailable:git_source_generation_pointer_symlink/
+    );
+    await rm(activePath);
+    await writeFile(activePath, activeBytes);
+
+    // Generation directory replaced by a symlink.
+    const generation = await activeGeneration(context.cacheDir);
+    await writeFile(
+      path.join(context.cacheDir, "active.json"),
+      JSON.stringify({ schemaVersion: 1, generation: "0123456789ab-0000000000000-deadbeef" })
+    );
+    const decoyDir = path.join(context.root, "decoy-generation");
+    await mkdir(decoyDir, { recursive: true });
+    await symlink(decoyDir, path.join(context.cacheDir, "generations", "0123456789ab-0000000000000-deadbeef"));
+    await assert.rejects(
+      () => source.load(),
+      /git_source_lkg_unavailable:git_source_generation_pointer_symlink/
+    );
+    await rm(path.join(context.cacheDir, "generations", "0123456789ab-0000000000000-deadbeef"), {
+      force: true
+    });
+    await writeFile(
+      path.join(context.cacheDir, "active.json"),
+      JSON.stringify({ schemaVersion: 1, generation: generation.id })
+    );
+
+    // Traversing or absolute generation ids are rejected before any path use.
+    for (const badId of ["../escape", "generations/../escape", "/abs/path"]) {
+      await writeFile(
+        path.join(context.cacheDir, "active.json"),
+        JSON.stringify({ schemaVersion: 1, generation: badId })
+      );
+      await assert.rejects(
+        () => source.load(),
+        /git_source_lkg_unavailable:git_source_generation_invalid_id/,
+        `expected ${badId} to be rejected`
+      );
+    }
+    await writeFile(
+      path.join(context.cacheDir, "active.json"),
+      JSON.stringify({ schemaVersion: 1, generation: generation.id })
+    );
+
+    // A symlink inside the selected content is rejected.
+    const symlinkTarget = path.join(context.root, "outside.md");
+    await writeFile(symlinkTarget, "outside\n");
+    await symlink(symlinkTarget, path.join(generation.dir, "content", "linked.md"));
+    await assert.rejects(
+      () => source.load(),
+      /git_source_lkg_unavailable:git_source_generation_symlink_rejected/
+    );
+    healRemote();
+  });
+});
+
+test("AC-006: restart revalidates all evidence and serves degraded within the bound", async () => {
+  await withGitFixture(async (context) => {
+    const first = new GitSource(options(context));
+    await first.load();
+    assert.equal(first.status, "fresh");
+
+    const restarted = new GitSource(options(context));
+    assert.equal(restarted.status, "unavailable");
+    failRemote();
+    const documents = await restarted.load();
+    assert.equal(restarted.status, "degraded");
+    assert.equal(documents.length, 3);
+    healRemote();
+  });
+});
+
+test("AC-006: cache eviction removes fallback availability", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource(options(context));
+    await source.load();
+    await rm(path.join(context.cacheDir, "generations"), { recursive: true });
+    await rm(path.join(context.cacheDir, "active.json"));
+    failRemote();
+    await assert.rejects(
+      () => source.load(),
+      /git_source_lkg_unavailable:git_source_generation_missing_active/
+    );
+    healRemote();
+  });
+});
+
+test("AC-005: concurrent degraded readers observe one complete generation", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource(options(context));
+    await source.load();
+    failRemote();
+    const results = await Promise.all([source.load(), source.load()]);
+    assert.equal(results[0].length, 3);
+    assert.equal(results[1].length, 3);
+    assert.equal(source.status, "degraded");
+    healRemote();
+  });
+});
+
+test("Non-goal: there is no fallback to an older generation", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource(options(context));
+    await source.load();
+    const active = await activeGeneration(context.cacheDir);
+
+    // Simulate an older orphan generation that is NOT referenced by active.json.
+    const orphanId = "0123456789ab-1000000000000-deadbeef";
+    await mkdir(path.join(context.cacheDir, "generations", orphanId), { recursive: true });
+    await writeFile(
+      path.join(context.cacheDir, "generations", orphanId, "manifest.json"),
+      await readFile(path.join(active.dir, "manifest.json"))
+    );
+
+    failRemote();
+    await source.load(); // active generation is valid; orphan is ignored
+    assert.equal(source.status, "degraded");
+
+    // Break the active generation: no older generation may take its place.
+    await rm(path.join(active.dir, "manifest.json"));
+    await assert.rejects(
+      () => source.load(),
+      /git_source_lkg_unavailable:git_source_generation_missing_manifest/
+    );
+    healRemote();
+  });
+});
+
+test("REQ-006: a legacy in-place checkout is never auto-promoted", async () => {
+  await withGitFixture(async (context) => {
+    const legacy = path.join(context.cacheDir, "legacy-checkout");
+    await mkdir(path.join(legacy, ".git"), { recursive: true });
+    await writeFile(path.join(legacy, "README.md"), "# Legacy\n\nNever trusted.\n");
+
+    const source = new GitSource(options(context));
+    failRemote();
+    await assert.rejects(
+      () => source.load(),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(
+          error.message,
+          /git_source_lkg_unavailable:git_source_generation_missing_active/
+        );
+        assert.ok(error.cause instanceof Error);
+        assert.match(error.cause.message, /git_source_command_failed:73/);
+        return true;
+      }
+    );
+    assert.equal(source.status, "unavailable");
+    const generationsDir = path.join(context.cacheDir, "generations");
+    assert.equal(
+      existsSync(generationsDir) ? (await readdir(generationsDir)).length : 0,
+      0
+    );
+    healRemote();
+  });
+});
+
+test("REQ-005/REQ-007: degraded is reported as degraded, never ready or fresh", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource(options(context));
+    await source.load();
+    failRemote();
+    await source.load();
+    assert.equal(source.status, "degraded");
+    assert.notEqual(source.status, "fresh");
+    assert.notEqual(source.status, "ready");
+    healRemote();
+  });
+});
+
+test("REQ-007: the cache remains disposable with no backup or audit artifacts", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource(options(context));
+    await source.load();
+    failRemote();
+    await assert.rejects(() => source.sync(), /git_source_command_failed:73/);
+    healRemote();
+
+    const entries = (await readdir(context.cacheDir)).sort();
+    assert.deepEqual(entries, ["active.json", "generations"]);
+  });
+});
+
+test("REQ-008: constructor compatibility and document shape are preserved", async () => {
+  await withGitFixture(async (context) => {
+    const source = new GitSource({
+      id: "compat",
+      remote: "https://example.test/public-docs.git",
+      ref: "main",
+      cacheDir: context.cacheDir
+    });
+    const documents = await source.load();
+    assert.equal(source.status, "fresh");
+    assert.equal(documents.length, 3);
+    const first = documents[0] as {
+      id: string
+      title: string
+      text: string
+      source: Record<string, unknown>
+      metadata: Record<string, unknown>
+    };
+    assert.equal(typeof first.id, "string");
+    assert.equal(typeof first.title, "string");
+    assert.equal(typeof first.text, "string");
+    assert.equal(first.source.type, "git");
+    assert.equal(first.source.repository, "https://example.test/public-docs.git");
+    assert.equal(first.source.ref, "main");
+    assert.equal(typeof first.metadata.path, "string");
+    assert.equal(first.text.includes("fake repository"), true);
+  });
+});
+
+test("Typed failure classification only accepts git subprocess failures", () => {
+  assert.equal(isRemoteAcquisitionFailure(new Error("git_source_command_failed:73:")), true);
+  assert.equal(isRemoteAcquisitionFailure(new Error("git_source_process_failed")), true);
+  assert.equal(isRemoteAcquisitionFailure(new Error("git_source_process_timed_out")), true);
+  assert.equal(isRemoteAcquisitionFailure(new Error("git_source_generation_digest_mismatch")), false);
+  assert.equal(isRemoteAcquisitionFailure(new TypeError("git_source_invalid_ref")), false);
+  assert.equal(isRemoteAcquisitionFailure(new Error("unrelated")), false);
 });


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/103
- Supplementary dependencies: https://github.com/fullstack-ai-infra/digital-employee/pull/99
- Consumed revision: R2
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | `connectors/sources/git/index.ts` | Policy suite: default strict rejects refresh failure; LKG without safe integer bound or outside [1000, 604800000] rejected |
| REQ-002 / AC-002 | `connectors/sources/git/index.ts` | Staging suite: candidate validated in unique same-filesystem staging, made immutable, atomically selected; failed candidate never changes active state |
| REQ-003 / AC-004 | `connectors/sources/git/index.ts` | Provenance suite: manifest binds remote, ref, commit, selection, digest, refreshedAt; legacy/altered active bytes rejected |
| REQ-004 / AC-003 | `connectors/sources/git/index.ts` | Age-boundary tests: age equal to limit served degraded; age over by 1 ms rejected |
| REQ-005 / AC-001, AC-004, AC-008 | `connectors/sources/git/index.ts` | Fail-closed suite: missing/corrupt/mismatched evidence rejected; security negatives fail closed |
| REQ-006 / AC-005, AC-006 | `connectors/sources/git/index.ts` | Atomicity tests: interrupted clone/refresh/promotion and concurrent readers expose only complete old/new; restart revalidates, eviction removes fallback |
| REQ-007 / AC-007 | `connectors/sources/git/index.ts`, `apps/cli/runtime.ts`, `apps/cli/bin.ts`, `apps/cli/registry.ts` | CLI suite: degraded source makes `sync --json` report degraded and exit 2; text/startup/health never Ready; fields path/secret safe |
| REQ-008 / AC-004 | `connectors/sources/git/index.ts` | Compatibility: constructors and document shapes unchanged; standalone-v1 maintenance only |

## File domains

- `connectors/sources/git/index.ts` — policy validation, staging/generation lifecycle, LKG degraded reads.
- `apps/cli/runtime.ts` — runtime source status projection (fresh/degraded/unavailable).
- `apps/cli/bin.ts`, `apps/cli/registry.ts` — standalone-v1 sync/registry wiring.
- Tests: `tests/git/git-source.test.ts`, `tests/apps/git-source-cli.test.ts`, `tests/git/fixtures/fake-git.mjs`.
- Documentation: `docs/connectors/README.md`, `README.md`, `CHANGELOG.md`.

## Scope and non-goals

Implemented exactly R2 scope: git source configuration, staging/generation lifecycle, source status, and the directly affected standalone-v1 CLI/server projection. Non-goals honored: no background cache deletion, GC, backup/restore, conversation history, Agent session state, Runner outbox, or audit archive; no silent or unbounded stale serving; no fallback to an older generation after the active generation fails validation. This PR does not add marketplace, billing, control-plane, or second Agent loop.

## Validation

- Exact commands: `npm run typecheck`; `npm run check`; `git diff --check`
- Observed counts/results: PASS (957/957) on CI `npm run check` (Node 20/22/24); focused git-source suites PASS (32/32)
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/actions/runs/31894930913

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-001 | Default and explicit strict policy reject refresh failure; LKG bounds validated | `tests/git/git-source.test.ts` policy suite | Node 24, exact HEAD | Rejected config; fail-closed default | Policy tests PASS | PASS |
| V2 | AC-002 | Candidate staged, validated, immutable, atomically selected | `tests/git/git-source.test.ts` staging suite | Node 24, exact HEAD | Failed candidate never changes active state | Staging tests PASS | PASS |
| V3 | AC-003 | Age at limit served degraded; age over by 1 ms rejected | `tests/git/git-source.test.ts` age-boundary tests | Node 24, exact HEAD | Boundary exactness | Age-boundary tests PASS | PASS |
| V4 | AC-004 | Provenance/digest/path/time revalidated before every degraded load | `tests/git/git-source.test.ts` revalidation tests | Node 24, exact HEAD | Legacy/altered bytes rejected | Revalidation tests PASS | PASS |
| V5 | AC-005/AC-006 | Interrupted promotion and restart/eviction behave atomically | `tests/git/git-source.test.ts` atomicity tests | Node 24, exact HEAD | Complete old/new only; eviction removes fallback | Atomicity tests PASS | PASS |
| V6 | AC-007 | Degraded source reports degraded and sync exits 2; health never Ready | `tests/apps/git-source-cli.test.ts` | Node 24, exact HEAD | Degraded JSON/text, exit 2 | CLI tests PASS | PASS |
| V7 | AC-008 | Symlink/traversal/absolute/malformed/future/digest/stderr negatives fail closed | `tests/git/git-source.test.ts` security tests | Node 24, exact HEAD | All negatives rejected | Security tests PASS | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes.
- [x] Generation/pointer symlink, traversal, absolute path, malformed/unknown-schema manifest, future timestamp, digest/provenance mismatch, and raw Git stderr leakage all fail closed under tests (AC-008).
- [x] Degraded status fields are path/secret safe; no raw Git stderr is surfaced.
- [x] Existing `GitSource` constructor signatures and document shapes unchanged (REQ-008); standalone-v1 maintenance does not block Agent-native adoption.
- [x] Full `npm run check` on CI: 957/957 PASS.

No dependency changed. No live resource, release tag, npm version, or production deployment was created by this PR.

## Known limitations

LKG availability depends on an R2-valid active generation; after cache eviction the same remote failure is unavailable by design. Bounded LKG is reported as `degraded`, never ready/fresh. Requires rebase compatibility with PR #99 for CLI/server file domains (per issue Scope note); implementation order `#94 -> #99 -> #103`.

## Risk and rollback

Behavior changes only when `prefer_last_known_good` is explicitly enabled with bounded `maxStaleMs`; default and explicit `require_fresh` remain fail-closed, so existing strict deployments are unaffected. Revert this single squash commit to restore prior git-source behavior. No live resource, release tag, npm version, or credential was created.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @Bindy-lbb
- Milestone or release packet: N/A: standalone-v1 compatibility maintenance under issue #103, not a standalone milestone packet
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged