### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 # Contributor guide for coding agents
 
-## Quick start (public npm 0.3.0)
+## Quick start (public npm 0.4.0)
 
 To install and set up this framework as a dependency (no source checkout):
 
 ```bash
-npm install @fullstack-ai-infra/digital-employee@0.3.0
+npm install @fullstack-ai-infra/digital-employee@0.4.0
 npx digital-employee doctor --json
 npx digital-employee init ./my-employee \
   --recipe minimal-answer.v1 \
@@ -14,12 +14,10 @@ npx digital-employee validate ./my-employee --json
 npx digital-employee eval ./my-employee --json
 ```
 
-The current public npm version is `0.3.0`; the public quick path uses its
-`init`, `doctor`, `validate`, `eval`, and `run` commands. It does not contain
-the newer `setup` or package-bound `deploy` commands. Treat both as
-source-only, unreleased previews until a later public release explicitly
-includes them. For source evaluation, run `npm ci && npm run build` and invoke
-the desired preview command from that exact checkout.
+The current public npm version is `0.4.0`; the public quick path uses its
+`init`, `doctor`, `validate`, `eval`, `run`, `setup`, and package-bound
+`deploy` commands. For source evaluation, run `npm ci && npm run build` and
+invoke the desired command from that exact checkout.
 
 See [INSTALL.md](./INSTALL.md) for the full Agent-readable install path.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-16
+
 ### Added
 
 - Git source refresh is fail closed by default and can serve a validated

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,13 +6,9 @@ and ask it to set up the framework.
 
 ## Published-versus-source boundary
 
-The current public npm release is `0.3.0`. It contains the Agent-native `init`,
-`doctor`, `validate`, `eval`, and `run` paths. It does not contain the newer
-`setup` convenience command or package-bound `deploy` command. Both commands
-on the current source branch are unreleased previews. Do not present
-`npx digital-employee setup` or `npx digital-employee deploy` as an
-installed-package capability until a later public release explicitly includes
-them.
+The current public npm release is `0.4.0`. It contains the Agent-native `init`,
+`doctor`, `validate`, `eval`, and one-shot `run` paths, the convenience
+`setup` command, and the package-bound `deploy` command.
 
 ## Prerequisites
 
@@ -24,12 +20,12 @@ them.
 ```bash
 # 1. Install the published package as a dependency
 npm init -y 2>/dev/null || true
-npm install @fullstack-ai-infra/digital-employee@0.3.0
+npm install @fullstack-ai-infra/digital-employee@0.4.0
 
 # 2. Diagnose the installed Agent Hosts without invoking a model
 npx digital-employee doctor --json
 
-# 3. Scaffold an employee package with a command shipped in 0.3.0
+# 3. Scaffold an employee package with a command shipped in 0.4.0
 npx digital-employee init ./my-employee \
   --recipe minimal-answer.v1 \
   --author your-team
@@ -71,21 +67,6 @@ After initialization and verification complete:
 
 Credentials are never needed during `doctor`, `init`, `validate`, or `eval`.
 They are requested only when executing a live `run`.
-
-## Current-source previews (unreleased)
-
-To evaluate `setup` or package-bound `deploy`, use a reviewed source checkout
-and run `npm ci && npm run build`. From the empty workspace you want to
-scaffold, invoke the built `setup` command by its checkout path:
-
-```bash
-cd /path/to/empty/workspace
-node /path/to/reviewed/digital-employee/dist/apps/cli/bin.js setup --json
-```
-
-Invoke `node ./dist/apps/cli/bin.js deploy ...` from the exact checkout when
-evaluating deploy. These commands prove only the source commit you built; they
-are not evidence that npm `0.3.0` contains `setup` or `deploy`.
 
 ## Failure semantics
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ evidence.
 > Digital Employee is under active development. Interfaces and package formats
 > may change before a stable release.
 
-The public npm release is `0.3.0`. It includes `init`, `doctor`, `validate`,
-`eval`, and one-shot `run`. The convenience `setup` command and package-bound
-`deploy` command are newer than `0.3.0`; both are unreleased previews available
-only from a reviewed source checkout until a later release publishes them. See
-the [install guide](INSTALL.md) for the exact published-versus-source boundary.
+The public npm release is `0.4.0`. It includes `init`, `doctor`, `validate`,
+`eval`, one-shot `run`, the convenience `setup` command, and the package-bound
+`deploy` command. See the [install guide](INSTALL.md) for the exact published
+boundary.
 
 ## Run
 
@@ -32,7 +31,7 @@ Start with the exact public release:
 mkdir digital-employee-workspace
 cd digital-employee-workspace
 npm init -y
-npm install @fullstack-ai-infra/digital-employee@0.3.0
+npm install @fullstack-ai-infra/digital-employee@0.4.0
 npx digital-employee doctor --json
 npx digital-employee init ./my-employee \
   --recipe minimal-answer.v1 \
@@ -65,23 +64,21 @@ node ./dist/apps/cli/bin.js validate ./my-employee
 node ./dist/apps/cli/bin.js eval ./my-employee --json
 ```
 
-### Try the source setup preview
+### Try the setup command
 
-`setup` is not part of npm `0.3.0`. The current source preview combines the
-model-free host probe and package scaffolding steps. After building an exact,
-reviewed checkout, invoke its CLI from the empty workspace you want it to
-scaffold:
+`setup` combines the model-free host probe and package scaffolding steps.
+From a clean workspace:
 
 ```bash
 cd /path/to/empty/workspace
 node /path/to/reviewed/digital-employee/dist/apps/cli/bin.js setup --json
 ```
 
-### Try the source deploy preview
+### Try the deploy command
 
-The source CLI can bind a validated package to a truthful local deployment
-outcome. This HTTP example requires both the selected Agent Host credential and
-an explicit HTTP bearer token. It also requires Qoder CLI 1.1.x to be installed:
+`deploy` binds a validated package to a truthful local deployment outcome.
+This HTTP example requires both the selected Agent Host credential and an
+explicit HTTP bearer token. It also requires Qoder CLI 1.1.x to be installed:
 
 ```bash
 export QODER_PERSONAL_ACCESS_TOKEN='...'
@@ -173,21 +170,21 @@ be terminated and verified before a terminal event is published.
 
 ## Release status
 
-The tagged `0.3.0` release is public through the root and core npm packages,
+The tagged `0.4.0` release is public through the root and core npm packages,
 GHCR, and GitHub Releases:
 
 | Channel | Command or download |
 | --- | --- |
-| npm (CLI) | `npm install --global @fullstack-ai-infra/digital-employee@0.3.0` |
-| npm (core) | `npm install @fullstack-ai-infra/digital-employee-core@0.3.0` |
-| GHCR | `docker pull ghcr.io/fullstack-ai-infra/digital-employee:0.3.0` |
-| GitHub Release | Download the root/core packages and checksums from [`v0.3.0`](https://github.com/fullstack-ai-infra/digital-employee/releases/tag/v0.3.0) |
+| npm (CLI) | `npm install --global @fullstack-ai-infra/digital-employee@0.4.0` |
+| npm (core) | `npm install @fullstack-ai-infra/digital-employee-core@0.4.0` |
+| GHCR | `docker pull ghcr.io/fullstack-ai-infra/digital-employee:0.4.0` |
+| GitHub Release | Download the root/core packages and checksums from [`v0.4.0`](https://github.com/fullstack-ai-infra/digital-employee/releases/tag/v0.4.0) |
 
-The standalone `@fullstack-ai-infra/digital-employee-core@0.3.0` package is
+The standalone `@fullstack-ai-infra/digital-employee-core@0.4.0` package is
 public. Its one-time registry bootstrap is complete, and subsequent versions
 publish from `release.yml` through npm Trusted Publishing. The current `main`
 branch contains changes made after the tag and is not itself a published
-release. Do not retag or overwrite `0.3.0` or `0.1.0`.
+release. Do not retag or overwrite `0.4.0`, `0.3.0` or `0.1.0`.
 
 The frozen `0.1.0` compatibility release is distributed through three public
 channels:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,16 +94,16 @@ V0.3 源码已经提供可嵌入的 one-shot Runner 执行内核和签名续租�
 
 ## 版本状态
 
-标签版本 `0.3.0` 已通过 root/core npm 包、GHCR 和 GitHub Releases 公开发布：
+标签版本 `0.4.0` 已通过 root/core npm 包、GHCR 和 GitHub Releases 公开发布：
 
 | 渠道 | 安装或下载方式 |
 | --- | --- |
-| npm（CLI） | `npm install --global @fullstack-ai-infra/digital-employee@0.3.0` |
-| npm（core） | `npm install @fullstack-ai-infra/digital-employee-core@0.3.0` |
-| GHCR | `docker pull ghcr.io/fullstack-ai-infra/digital-employee:0.3.0` |
-| GitHub Release | 从 [`v0.3.0`](https://github.com/fullstack-ai-infra/digital-employee/releases/tag/v0.3.0) 下载 root/core 包和校验文件 |
+| npm（CLI） | `npm install --global @fullstack-ai-infra/digital-employee@0.4.0` |
+| npm（core） | `npm install @fullstack-ai-infra/digital-employee-core@0.4.0` |
+| GHCR | `docker pull ghcr.io/fullstack-ai-infra/digital-employee:0.4.0` |
+| GitHub Release | 从 [`v0.4.0`](https://github.com/fullstack-ai-infra/digital-employee/releases/tag/v0.4.0) 下载 root/core 包和校验文件 |
 
-独立的 `@fullstack-ai-infra/digital-employee-core@0.3.0` npm 包已经公开。一次性 registry bootstrap 已完成，后续版本由 `release.yml` 通过 npm Trusted Publishing 发布。当前 `main` 已包含标签之后的改动，本身不代表一个已发布版本。不要覆盖或重新标记 `0.3.0` 或 `0.1.0`。
+独立的 `@fullstack-ai-infra/digital-employee-core@0.4.0` npm 包已经公开。一次性 registry bootstrap 已完成，后续版本由 `release.yml` 通过 npm Trusted Publishing 发布。当前 `main` 已包含标签之后的改动，本身不代表一个已发布版本。不要覆盖或重新标记 `0.4.0`、`0.3.0` 或 `0.1.0`。
 
 冻结的 `0.1.0` 兼容版本通过三个公开渠道分发：
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstack-ai-infra/digital-employee",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstack-ai-infra/digital-employee",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -1430,7 +1430,7 @@
     },
     "packages/core": {
       "name": "@fullstack-ai-infra/digital-employee-core",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstack-ai-infra/digital-employee",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "An Agent-native CLI and outer runtime for portable digital employees.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstack-ai-infra/digital-employee-core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Dependency-free package, Agent-host, and compatibility primitives for digital employees.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/92
- Supplementary dependencies: https://github.com/fullstack-ai-infra/digital-employee/issues/107
- Consumed revision: R2
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-003 / AC-003 | `package.json`, `packages/core/package.json`, `package-lock.json`, `CHANGELOG.md` | `npm run release:check -- --tag v0.4.0` PASS (1/1): stable semver, tag-to-version equality, core/root parity, lockfile parity, dated changelog heading; changelog dated `[0.4.0] - 2026-08-16` |
| REQ-003 / AC-003 | `README.md`, `README.zh-CN.md`, `INSTALL.md`, `AGENTS.md` | Stale 0.3.0-only/source-preview claims removed; `setup` and package-bound `deploy` presented as installed-package capabilities of 0.4.0; grep audit shows only historical/frozen-release references remain |
| REQ-001 / AC-001 | `README.md`, `README.zh-CN.md` | Release-status tables pin the same v0.4.0 across npm (CLI/core), GHCR, and GitHub Release channels; no retag policy for 0.4.0/0.3.0/0.1.0 recorded |

## File domains

- `package.json`, `packages/core/package.json`, `package-lock.json` — version bump 0.3.0 -> 0.4.0 (root, core, lockfile root/core entries; asynckit 0.4.0 untouched).
- `CHANGELOG.md` — dated `## [0.4.0] - 2026-08-16` heading over the accumulated unreleased entries; fresh empty `## [Unreleased]` on top.
- `README.md`, `README.zh-CN.md` — quickstart pins `@0.4.0`; setup/deploy sections no longer source-only; release-status section updated.
- `INSTALL.md`, `AGENTS.md` — published-versus-source boundary rewritten for 0.4.0; "Current-source previews (unreleased)" section removed.

## Scope and non-goals

Only the release preparation for v0.4.0: version metadata, changelog, and documentation truth. No runtime, CLI, connector, or workflow code changes. Non-goals honored: no v0.3.0 or v0.1.0 artifact mutation, no registry/release write, no live resource created by this PR (publishing happens from the tag-triggered Release workflow after merge). No dependencies changed.

## Validation

- Exact commands: `npm run release:check -- --tag v0.4.0`; manual `grep` audit over README/INSTALL/AGENTS for stale 0.3.0/preview claims
- Observed counts/results: release:check PASS (1/1); grep audit PASS (only historical frozen-release references remain)
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/actions/runs/31900497067

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-003 | release:check validates 0.4.0 parity (version, lockfile, changelog, tag) | `npm run release:check -- --tag v0.4.0` | Node 24, exact HEAD | PASS (1/1) | PASS (1/1) | PASS |
| V2 | AC-003 | no stale 0.3.0-only or source-preview claims in install/quickstart docs | grep audit on `README.md`, `README.zh-CN.md`, `INSTALL.md`, `AGENTS.md` | exact HEAD | no stale claims | only historical frozen-release references remain | PASS |
| V3 | REQ-002 / AC-002 | full `npm run check` suite green on this PR head | CI | GitHub Actions | all required checks pass | all 12 checks PASS (test 20/22/24, coverage, package-consumer, container, distribution-*, commit-metadata) | PASS |
| V4 | REQ-001 / AC-001 | npm/GHCR/GitHub Release publish v0.4.0 from the merged revision with immutable digests | Release workflow after tag `v0.4.0` | GitHub Actions | identical revision, checksums, GHCR digest recorded | pending tag | NOT VERIFIED: executes after merge and tag |
| V5 | REQ-002 / AC-002 | clean environment installs pinned 0.4.0 and reproduces help/setup/deploy entry points | Release workflow consumer jobs on tag | clean container | install succeeds, entry points present | pending tag | NOT VERIFIED: executes after merge and tag |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] No runtime, connector, or workflow behavior changes; version and documentation only.
- [x] No dependency changed; no lockfile dependency entries touched (asynckit 0.4.0 preserved).
- [x] Compatibility: the 0.4.0 artifact is the same verified CLI that passed required CI on the merged predecessors; install paths and command names unchanged.

## Known limitations

Release publishing itself is not exercised by this PR; AC-001/AC-002 evidence is produced by the tag-triggered Release workflow after merge. This PR cannot prove the future release run succeeds, only that the release preparation satisfies release:check.

## Risk and rollback

Version metadata and documentation only; revert is a single squash-commit revert. No release tag, npm version, or live resource is created by this PR, so nothing to deprecate or roll back at this stage. The tagged release keeps v0.3.0 and v0.1.0 artifacts untouched.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @Bindy-lbb
- Milestone or release packet: https://github.com/fullstack-ai-infra/digital-employee/issues/92
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
