### PR TITLE
test(cli): cover deploy orchestration, config safety, and prompts (#70)

### DIFF
--- a/tests/apps/deploy-channels.test.ts
+++ b/tests/apps/deploy-channels.test.ts
@@ -1,0 +1,344 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { createHash } from "node:crypto"
+import { chmod, cp, mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+import {
+  buildHttpRuntimeEnvironment,
+  deployConsole,
+  deployDingTalk,
+  deployHttp,
+  deployLark,
+  deployWeCom,
+  endpointUrl,
+  inspectHttpDeployment,
+} from "../../apps/cli/deploy/channels.js"
+import type {
+  DeployConfig,
+  DeployEndpoint,
+  DeployProcessState,
+  DeployProviderScope,
+} from "../../apps/cli/deploy/config.js"
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const fakeDwsFixture = path.join(root, "tests", "apps", "fixtures", "fake-dws.mjs")
+const HTTP_TOKEN_ENV = "DIGITAL_EMPLOYEE_HTTP_TOKEN"
+
+const HTTP_ENDPOINT: DeployEndpoint = {
+  protocol: "http",
+  host: "127.0.0.1",
+  port: 8899,
+  askPath: "/v1/ask",
+  healthPath: "/health",
+}
+
+function httpConfig(): DeployConfig {
+  return {
+    schemaVersion: "deploy-state.v1",
+    locale: "en",
+    channel: "http",
+    botName: "http-bot",
+    engine: "qoder",
+    runtime: "agent-native",
+    package: {
+      name: "demo-bot",
+      version: "1.0.0",
+      digest: `sha256:${"a".repeat(64)}`,
+      localReference: "/tmp/demo-bot",
+    },
+    outcome: "pending_external_action",
+    endpoint: HTTP_ENDPOINT,
+    secretReferences: { httpTokenEnv: HTTP_TOKEN_ENV },
+    updatedAt: "2026-08-16T00:00:00.000Z",
+  }
+}
+
+function validLease() {
+  return {
+    fileDescriptor: 0,
+    nonce: "a".repeat(32),
+    device: 0,
+    inode: 0,
+    ownerPid: process.pid,
+  }
+}
+
+function processState(
+  pid: number,
+  activationState: "prepared" | "authorized" = "authorized",
+): DeployProcessState {
+  return {
+    pid,
+    startedAt: "2026-08-16T00:00:00.000Z",
+    launchId: "a".repeat(32),
+    activationFence: "b".repeat(32),
+    activationState,
+  }
+}
+
+function dingtalkScope(): DeployProviderScope {
+  const canonical = JSON.stringify({
+    schema: "dingtalk-provider-scope.v1",
+    corpId: "corp-a",
+    userId: "user-a",
+    profileClientId: "profile-client-a",
+    envClientId: null,
+  })
+  return {
+    kind: "dingtalk-provider-scope.v1",
+    digest: `sha256:${createHash("sha256").update(canonical).digest("hex")}`,
+  }
+}
+
+async function withEnvVar(
+  t: test.TestContext,
+  key: string,
+  value: string,
+): Promise<void> {
+  const original = process.env[key]
+  process.env[key] = value
+  t.after(() => {
+    if (original === undefined) delete process.env[key]
+    else process.env[key] = original
+  })
+}
+
+async function withoutEnvVar(
+  t: test.TestContext,
+  key: string,
+): Promise<void> {
+  const original = process.env[key]
+  delete process.env[key]
+  t.after(() => {
+    if (original === undefined) delete process.env[key]
+    else process.env[key] = original
+  })
+}
+
+/** Prepends a fake `dws` executable to PATH and returns the bin directory. */
+async function fakeDwsOnPath(t: test.TestContext): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "deploy-fake-dws-"))
+  t.after(async () => rm(directory, { recursive: true, force: true }))
+  const fixture = path.join(directory, "fake-dws.mjs")
+  await cp(fakeDwsFixture, fixture)
+  const executable = path.join(directory, "dws")
+  await writeFile(
+    executable,
+    "#!/bin/sh\n" +
+      "fixture_dir=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd -P) || exit 1\n" +
+      "exec node \"$fixture_dir/fake-dws.mjs\" \"$@\"\n",
+    { mode: 0o755 },
+  )
+  await chmod(executable, 0o755)
+  const original = process.env.PATH
+  process.env.PATH = `${directory}:${original ?? ""}`
+  t.after(() => {
+    process.env.PATH = original
+  })
+  return directory
+}
+
+async function deadPid(): Promise<number> {
+  const result = spawnSync(process.execPath, ["-e", "process.exit(0)"])
+  assert.equal(result.status, 0)
+  return result.pid
+}
+
+test("deployLark reports unsupported", async () => {
+  const result = await deployLark({})
+  assert.equal(result.outcome, "unsupported")
+  assert.equal(result.code, "lark_live_deploy_unsupported")
+})
+
+test("deployWeCom reports unsupported", async () => {
+  const result = await deployWeCom({})
+  assert.equal(result.outcome, "unsupported")
+  assert.equal(result.code, "wecom_live_deploy_unsupported")
+})
+
+test("deployConsole reports pending external action", async () => {
+  const result = await deployConsole({})
+  assert.equal(result.outcome, "pending_external_action")
+  assert.equal(result.code, "console_foreground_start_required")
+})
+
+test("deployDingTalk fails when botName is missing", async () => {
+  const result = await deployDingTalk({})
+  assert.equal(result.outcome, "failed")
+  assert.equal(result.code, "dingtalk_provider_state_invalid")
+})
+
+test("deployDingTalk verifies an existing app", async (t) => {
+  await fakeDwsOnPath(t)
+  const scope = dingtalkScope()
+  const provider = { kind: "dingtalk-app" as const, resourceId: "app-1", scope }
+  const result = await deployDingTalk({ botName: "test-bot", provider })
+  assert.equal(result.outcome, "pending_external_action")
+  assert.equal(result.code, "dingtalk_app_verified_pending_setup")
+  assert.deepEqual(result.provider, provider)
+})
+
+test("deployDingTalk creates an app when none exists", async (t) => {
+  await fakeDwsOnPath(t)
+  const result = await deployDingTalk(
+    { botName: "test-bot" },
+    {
+      allowProviderWrite: true,
+      onProviderOperation: () => {},
+      onProviderVerified: () => {},
+    },
+  )
+  assert.equal(result.outcome, "pending_external_action")
+  assert.equal(result.code, "dingtalk_app_verified_pending_setup")
+  assert.equal(result.provider?.resourceId, "app-created-1")
+  assert.deepEqual(result.provider?.scope, dingtalkScope())
+})
+
+test("deployDingTalk requires provider write confirmation", async (t) => {
+  await fakeDwsOnPath(t)
+  const result = await deployDingTalk(
+    { botName: "test-bot" },
+    { confirmProviderWrite: () => false },
+  )
+  assert.equal(result.outcome, "pending_external_action")
+  assert.equal(result.code, "dingtalk_provider_confirmation_required")
+})
+
+test("deployDingTalk preserves state on provider scope mismatch", async (t) => {
+  await fakeDwsOnPath(t)
+  const wrongScope: DeployProviderScope = {
+    kind: "dingtalk-provider-scope.v1",
+    digest: `sha256:${"b".repeat(64)}`,
+  }
+  const result = await deployDingTalk({
+    botName: "test-bot",
+    provider: { kind: "dingtalk-app", resourceId: "app-1", scope: wrongScope },
+  })
+  assert.equal(result.outcome, "pending_external_action")
+  assert.equal(result.code, "dingtalk_provider_scope_mismatch")
+  assert.equal(result.preserveState, true)
+})
+
+test("deployDingTalk fails closed when dws is unavailable", async (t) => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "deploy-empty-path-"))
+  t.after(async () => rm(directory, { recursive: true, force: true }))
+  const original = process.env.PATH
+  process.env.PATH = directory
+  t.after(() => {
+    process.env.PATH = original
+  })
+  const result = await deployDingTalk({ botName: "test-bot" })
+  assert.equal(result.outcome, "failed")
+  assert.equal(result.code, "dingtalk_provider_scope_unavailable")
+})
+
+test("deployHttp fails when required state is missing", async () => {
+  const result = await deployHttp({})
+  assert.equal(result.outcome, "failed")
+  assert.equal(result.code, "http_deploy_state_invalid")
+})
+
+test("deployHttp rejects the standalone runtime", async () => {
+  const result = await deployHttp({
+    ...httpConfig(),
+    runtime: "standalone-v1",
+  })
+  assert.equal(result.outcome, "unsupported")
+  assert.equal(result.code, "http_standalone_runtime_not_available")
+})
+
+test("deployHttp requires the http token", async (t) => {
+  await withoutEnvVar(t, HTTP_TOKEN_ENV)
+  const result = await deployHttp(httpConfig())
+  assert.equal(result.outcome, "failed")
+  assert.equal(result.code, "http_token_required")
+})
+
+test("deployHttp rejects an already-aborted signal", async (t) => {
+  await withEnvVar(t, HTTP_TOKEN_ENV, "test-token")
+  const controller = new AbortController()
+  controller.abort()
+  const result = await deployHttp(httpConfig(), { signal: controller.signal })
+  assert.equal(result.outcome, "failed")
+  assert.equal(result.code, "deploy_interrupted")
+})
+
+test("deployHttp rejects an invalid activation lease", async (t) => {
+  await withEnvVar(t, HTTP_TOKEN_ENV, "test-token")
+  const result = await deployHttp(httpConfig(), {
+    activationLease: { ...validLease(), fileDescriptor: -1 },
+  })
+  assert.equal(result.outcome, "failed")
+  assert.equal(result.code, "deploy_lock_lease_invalid")
+})
+
+test("deployHttp fails when lock ownership is lost", async (t) => {
+  await withEnvVar(t, HTTP_TOKEN_ENV, "test-token")
+  const result = await deployHttp(httpConfig(), {
+    activationLease: validLease(),
+    assertLockOwned: async () => {
+      throw new Error("deploy_lock_not_owned")
+    },
+  })
+  assert.equal(result.outcome, "failed")
+  assert.equal(result.code, "deploy_lock_not_owned")
+})
+
+test("buildHttpRuntimeEnvironment forwards engine and token variables", async (t) => {
+  await withEnvVar(t, "QODER_PERSONAL_ACCESS_TOKEN", "token-value")
+  await withEnvVar(t, HTTP_TOKEN_ENV, "http-token-value")
+  await withEnvVar(t, "UNRELATED_TEST_VAR", "must-not-leak")
+  const environment = buildHttpRuntimeEnvironment({
+    engine: "qoder",
+    secretReferences: { httpTokenEnv: HTTP_TOKEN_ENV },
+  })
+  assert.equal(environment.QODER_PERSONAL_ACCESS_TOKEN, "token-value")
+  assert.equal(environment[HTTP_TOKEN_ENV], "http-token-value")
+  assert.equal(environment.PATH, process.env.PATH)
+  assert.equal(environment.UNRELATED_TEST_VAR, undefined)
+})
+
+test("buildHttpRuntimeEnvironment rejects unknown engines", () => {
+  assert.throws(
+    () => buildHttpRuntimeEnvironment({ engine: "bogus" }),
+    /http_runtime_engine_invalid/,
+  )
+})
+
+test("endpointUrl renders the ask endpoint", () => {
+  assert.equal(endpointUrl(HTTP_ENDPOINT), "http://127.0.0.1:8899/v1/ask")
+})
+
+test("inspectHttpDeployment reports absent without endpoint or process", async () => {
+  assert.equal(await inspectHttpDeployment({}), "absent")
+})
+
+test("inspectHttpDeployment reports unverified for a live process without endpoint", async () => {
+  const config: DeployConfig = { process: processState(process.pid) }
+  assert.equal(await inspectHttpDeployment(config), "unverified")
+})
+
+test("inspectHttpDeployment reports absent for a dead process", async () => {
+  const config: DeployConfig = { process: processState(await deadPid()) }
+  assert.equal(await inspectHttpDeployment(config), "absent")
+})
+
+test("inspectHttpDeployment reports unverified before authorization", async () => {
+  const config: DeployConfig = {
+    endpoint: HTTP_ENDPOINT,
+    process: processState(process.pid, "prepared"),
+  }
+  assert.equal(await inspectHttpDeployment(config), "unverified")
+})
+
+test("inspectHttpDeployment reports unverified when the tracked argv mismatches", async () => {
+  const config: DeployConfig = {
+    endpoint: HTTP_ENDPOINT,
+    process: processState(process.pid, "authorized"),
+  }
+  assert.equal(await inspectHttpDeployment(config), "unverified")
+})

--- a/tests/apps/deploy-config.test.ts
+++ b/tests/apps/deploy-config.test.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict"
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import {
+  acquireDeploymentLock,
+  getConfigDir,
+  getConfigPath,
+  hasExistingDeployment,
+  loadConfig,
+  saveConfig,
+} from "../../apps/cli/deploy/config.js"
+import type { DeployConfig } from "../../apps/cli/deploy/config.js"
+
+const PACKAGE_DIGEST = `sha256:${"a".repeat(64)}`
+
+const READY_HTTP_CONFIG: DeployConfig = {
+  schemaVersion: "deploy-state.v1",
+  locale: "en",
+  channel: "http",
+  botName: "http-bot",
+  engine: "qoder",
+  runtime: "agent-native",
+  package: {
+    name: "demo-bot",
+    version: "1.0.0",
+    digest: PACKAGE_DIGEST,
+    localReference: "/tmp/demo-bot",
+  },
+  outcome: "ready",
+  endpoint: {
+    protocol: "http",
+    host: "127.0.0.1",
+    port: 8899,
+    askPath: "/v1/ask",
+    healthPath: "/health",
+  },
+  process: {
+    pid: 4242,
+    startedAt: "2026-08-16T00:00:00.000Z",
+    launchId: "a".repeat(32),
+    activationFence: "b".repeat(32),
+    activationState: "authorized",
+  },
+  deployedAt: "2026-08-16T00:00:00.000Z",
+  updatedAt: "2026-08-16T00:00:00.000Z",
+}
+
+function pendingConsoleConfig(): DeployConfig {
+  return {
+    schemaVersion: "deploy-state.v1",
+    locale: "en",
+    channel: "console",
+    botName: "console-bot",
+    engine: "qoder",
+    runtime: "agent-native",
+    package: {
+      name: "demo-bot",
+      version: "1.0.0",
+      digest: PACKAGE_DIGEST,
+      localReference: "/tmp/demo-bot",
+    },
+    outcome: "pending_external_action",
+    updatedAt: "2026-08-16T00:00:00.000Z",
+  }
+}
+
+async function isolatedHome(t: test.TestContext): Promise<string> {
+  const home = await mkdtemp(path.join(os.tmpdir(), "deploy-config-home-"))
+  const original = process.env.HOME
+  process.env.HOME = home
+  t.after(async () => {
+    if (original === undefined) delete process.env.HOME
+    else process.env.HOME = original
+    await rm(home, { recursive: true, force: true })
+  })
+  return home
+}
+
+async function privateConfigDirectory(home: string): Promise<string> {
+  const directory = path.join(home, ".digital-employee")
+  await mkdir(directory, { mode: 0o700 })
+  return directory
+}
+
+test("config directory resolves under HOME", async (t) => {
+  const home = await isolatedHome(t)
+  assert.equal(getConfigDir(), path.join(home, ".digital-employee"))
+  assert.equal(getConfigPath(), path.join(home, ".digital-employee", "config.json"))
+})
+
+test("config directory falls back to home when HOME is unset", async (t) => {
+  await isolatedHome(t)
+  delete process.env.HOME
+  assert.equal(getConfigDir(), path.join(os.homedir(), ".digital-employee"))
+})
+
+test("save then load round-trips a full config", async (t) => {
+  const home = await isolatedHome(t)
+  const lock = await acquireDeploymentLock()
+  t.after(() => lock.release())
+  const fingerprint = await saveConfig(READY_HTTP_CONFIG, {
+    expected: { kind: "missing" },
+    lock,
+  })
+  assert.equal(fingerprint.kind, "present")
+  assert.deepEqual(await loadConfig(), READY_HTTP_CONFIG)
+  const fileStat = await lstat(path.join(home, ".digital-employee", "config.json"))
+  assert.equal(fileStat.mode & 0o777, 0o600)
+  const raw = JSON.parse(
+    await readFile(path.join(home, ".digital-employee", "config.json"), "utf8"),
+  )
+  assert.deepEqual(raw, READY_HTTP_CONFIG)
+})
+
+test("saveConfig persists an empty config", async (t) => {
+  const home = await isolatedHome(t)
+  const lock = await acquireDeploymentLock()
+  t.after(() => lock.release())
+  await saveConfig({}, { expected: { kind: "missing" }, lock })
+  assert.deepEqual(await loadConfig(), {})
+})
+
+test("loadConfig returns {} when no config exists", async (t) => {
+  await isolatedHome(t)
+  assert.deepEqual(await loadConfig(), {})
+})
+
+test("loadConfig rejects malformed JSON", async (t) => {
+  const home = await isolatedHome(t)
+  await privateConfigDirectory(home)
+  await writeFile(path.join(home, ".digital-employee", "config.json"), "{not json", {
+    mode: 0o600,
+  })
+  await assert.rejects(loadConfig(), /deploy_config_malformed_json/)
+})
+
+test("loadConfig rejects a symlinked config", async (t) => {
+  const home = await isolatedHome(t)
+  await privateConfigDirectory(home)
+  const target = path.join(home, "real-config.json")
+  await writeFile(target, "{}", { mode: 0o600 })
+  await symlink(target, path.join(home, ".digital-employee", "config.json"))
+  await assert.rejects(loadConfig(), /deploy_config_symlink_not_allowed/)
+})
+
+test("loadConfig rejects an unsafe config directory", async (t) => {
+  const home = await isolatedHome(t)
+  await mkdir(path.join(home, ".digital-employee"), { mode: 0o755 })
+  await writeFile(path.join(home, ".digital-employee", "config.json"), "{}", {
+    mode: 0o600,
+  })
+  await assert.rejects(loadConfig(), /deploy_config_directory_permissions_unsafe/)
+})
+
+test("loadConfig rejects an unsafe config file mode", async (t) => {
+  const home = await isolatedHome(t)
+  await privateConfigDirectory(home)
+  await writeFile(path.join(home, ".digital-employee", "config.json"), "{}", {
+    mode: 0o644,
+  })
+  await assert.rejects(loadConfig(), /deploy_config_permissions_unsafe/)
+})
+
+test("saveConfig rejects when the config generation changed", async (t) => {
+  const home = await isolatedHome(t)
+  const lock = await acquireDeploymentLock()
+  t.after(() => lock.release())
+  const original = await saveConfig(READY_HTTP_CONFIG, {
+    expected: { kind: "missing" },
+    lock,
+  })
+  const updated = {
+    ...READY_HTTP_CONFIG,
+    updatedAt: "2026-08-17T00:00:00.000Z",
+  }
+  await writeFile(path.join(home, ".digital-employee", "config.json"), `${JSON.stringify(updated, null, 2)}\n`, {
+    mode: 0o600,
+  })
+  await assert.rejects(
+    saveConfig(updated, { expected: original, lock }),
+    /deploy_config_generation_changed/,
+  )
+  const leftovers = (await readdir(path.join(home, ".digital-employee"))).filter(
+    (entry) => entry.startsWith(".config."),
+  )
+  assert.deepEqual(leftovers, [])
+})
+
+test("saveConfig rejects when the lock is not owned", async (t) => {
+  await isolatedHome(t)
+  const lock = await acquireDeploymentLock()
+  await lock.release()
+  await assert.rejects(
+    saveConfig(READY_HTTP_CONFIG, { expected: { kind: "missing" }, lock }),
+    /deploy_lock_not_owned/,
+  )
+})
+
+test("hasExistingDeployment keys off outcome", async (t) => {
+  const home = await isolatedHome(t)
+  const lock = await acquireDeploymentLock()
+  t.after(() => lock.release())
+  assert.equal(await hasExistingDeployment(), false)
+  const empty = await saveConfig({}, { expected: { kind: "missing" }, lock })
+  assert.equal(await hasExistingDeployment(), false)
+  await saveConfig(pendingConsoleConfig(), { expected: empty, lock })
+  assert.equal(await hasExistingDeployment(), true)
+})

--- a/tests/apps/deploy-index.test.ts
+++ b/tests/apps/deploy-index.test.ts
@@ -1,0 +1,313 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { access, chmod, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+import { createEmployeePackage } from "../../apps/cli/employee-package.js"
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const driver = path.join(root, "tests", "apps", "fixtures", "deploy-index-driver.mjs")
+const qoderFixture = path.join(root, "tests", "apps", "fixtures", "fake-qoder.mjs")
+
+async function isolatedRoot(t: test.TestContext, prefix: string): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), prefix))
+  t.after(async () => rm(directory, { recursive: true, force: true }))
+  return directory
+}
+
+async function installFakeQoder(bin: string): Promise<void> {
+  await mkdir(bin)
+  const executable = path.join(bin, "qodercli")
+  const fixture = path.join(bin, "fake-qoder.mjs")
+  await cp(qoderFixture, fixture)
+  await writeFile(
+    executable,
+    "#!/bin/sh\n" +
+      "if [ \"$1\" = \"--version\" ]; then printf '1.1.12\\n'; exit 0; fi\n" +
+      "fixture_dir=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd -P) || exit 1\n" +
+      "exec node \"$fixture_dir/fake-qoder.mjs\" \"$@\"\n",
+    { mode: 0o755 },
+  )
+  await chmod(executable, 0o755)
+}
+
+async function installFailingDws(bin: string): Promise<void> {
+  await writeFile(path.join(bin, "dws"), "#!/bin/sh\nexit 1\n", { mode: 0o755 })
+}
+
+function runDeploy(
+  options: Record<string, unknown>,
+  {
+    home,
+    bin,
+    input = "",
+  }: { home: string; bin?: string; input?: string },
+) {
+  const environment: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: home,
+    PATH: [bin, path.dirname(process.execPath), "/usr/bin", "/bin"]
+      .filter(Boolean)
+      .join(path.delimiter),
+    QODER_PERSONAL_ACCESS_TOKEN: "deploy-index-test-token",
+  }
+  return spawnSync(
+    process.execPath,
+    ["--import", "tsx", driver, JSON.stringify(options)],
+    {
+      cwd: root,
+      encoding: "utf8",
+      input,
+      timeout: 30_000,
+      env: environment,
+    },
+  )
+}
+
+function configPath(home: string): string {
+  return path.join(home, ".digital-employee", "config.json")
+}
+
+async function configExists(home: string): Promise<boolean> {
+  try {
+    await access(configPath(home))
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function readConfig(home: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(configPath(home), "utf8")) as Record<
+    string,
+    unknown
+  >
+}
+
+function fullProvidedOptions(): string[] {
+  return [
+    "channel",
+    "engine",
+    "runtime",
+    "name",
+    "locale",
+    "package",
+    "yes",
+  ]
+}
+
+test("deploy --help prints help and does not touch config", async (t) => {
+  const temporary = await isolatedRoot(t, "deploy-index-help-")
+  const home = path.join(temporary, "home")
+  await mkdir(home)
+  const result = runDeploy({ help: true, locale: "en" }, { home })
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /digital-employee deploy \[package-path\]/)
+  assert.equal(await configExists(home), false)
+})
+
+test("--yes without a runtime flag fails before package resolution", async (t) => {
+  const temporary = await isolatedRoot(t, "deploy-index-flags-")
+  const home = path.join(temporary, "home")
+  await mkdir(home)
+  const result = runDeploy(
+    { channel: "console", engine: "qoder", yes: true, locale: "en" },
+    { home },
+  )
+  assert.equal(result.status, 1, result.stdout)
+  assert.match(result.stderr, /--runtime/)
+  assert.equal(await configExists(home), false)
+})
+
+test("an invalid explicit channel fails before package resolution", async (t) => {
+  const temporary = await isolatedRoot(t, "deploy-index-channel-")
+  const home = path.join(temporary, "home")
+  await mkdir(home)
+  const result = runDeploy(
+    {
+      channel: "bogus",
+      locale: "en",
+      providedOptions: ["channel"],
+    },
+    { home },
+  )
+  assert.equal(result.status, 1, result.stdout)
+  assert.match(result.stderr, /Invalid channel/)
+  assert.match(result.stderr, /dingtalk\|lark\|wecom\|console\|http/)
+  assert.equal(await configExists(home), false)
+})
+
+test("a complete console deploy persists a pending config and exits 2", async (t) => {
+  const temporary = await isolatedRoot(t, "deploy-index-console-")
+  const home = path.join(temporary, "home")
+  const bin = path.join(temporary, "bin")
+  const packageDirectory = path.join(temporary, "console-deploy")
+  await mkdir(home)
+  await installFakeQoder(bin)
+  await createEmployeePackage(packageDirectory, { name: "console-deploy" })
+  const result = runDeploy(
+    {
+      packagePath: packageDirectory,
+      channel: "console",
+      engine: "qoder",
+      runtime: "agent-native",
+      name: "console-bot",
+      locale: "en",
+      yes: true,
+      providedOptions: fullProvidedOptions(),
+    },
+    { home, bin },
+  )
+  assert.equal(result.status, 2, result.stderr)
+  assert.match(result.stdout, /Package: console-deploy@/)
+  assert.match(result.stderr, /Pending external action \(console_foreground_start_required\)/)
+  const saved = await readConfig(home)
+  assert.equal(saved.schemaVersion, "deploy-state.v1")
+  assert.equal(saved.channel, "console")
+  assert.equal(saved.engine, "qoder")
+  assert.equal(saved.runtime, "agent-native")
+  assert.equal(saved.botName, "console-bot")
+  assert.equal(saved.locale, "en")
+  assert.equal(saved.outcome, "pending_external_action")
+  assert.equal(saved.code, "console_foreground_start_required")
+  const binding = saved.package as Record<string, unknown>
+  assert.equal(binding.name, "console-deploy")
+  assert.match(String(binding.digest), /^sha256:[a-f0-9]{64}$/)
+  assert.equal(typeof saved.updatedAt, "string")
+})
+
+test("standalone-v1 deploy is unsupported and writes no config", async (t) => {
+  const temporary = await isolatedRoot(t, "deploy-index-standalone-")
+  const home = path.join(temporary, "home")
+  const packageDirectory = path.join(temporary, "standalone-pkg")
+  await mkdir(home)
+  await createEmployeePackage(packageDirectory, { name: "standalone-pkg" })
+  const result = runDeploy(
+    {
+      packagePath: packageDirectory,
+      channel: "console",
+      engine: "openai-compatible",
+      runtime: "standalone-v1",
+      name: "standalone-bot",
+      locale: "en",
+      yes: true,
+      providedOptions: fullProvidedOptions(),
+    },
+    { home },
+  )
+  assert.equal(result.status, 1, result.stdout)
+  assert.match(result.stderr, /Unsupported deployment \(package_deploy_standalone_unsupported\)/)
+  assert.equal(await configExists(home), false)
+})
+
+test("dingtalk deploy fails closed when dws is unavailable", async (t) => {
+  const temporary = await isolatedRoot(t, "deploy-index-dingtalk-")
+  const home = path.join(temporary, "home")
+  const bin = path.join(temporary, "bin")
+  const packageDirectory = path.join(temporary, "dingtalk-pkg")
+  await mkdir(home)
+  await installFakeQoder(bin)
+  await installFailingDws(bin)
+  await createEmployeePackage(packageDirectory, { name: "dingtalk-pkg" })
+  const result = runDeploy(
+    {
+      packagePath: packageDirectory,
+      channel: "dingtalk",
+      engine: "qoder",
+      runtime: "agent-native",
+      name: "dingtalk-bot",
+      locale: "en",
+      yes: true,
+      providedOptions: fullProvidedOptions(),
+    },
+    { home, bin },
+  )
+  assert.equal(result.status, 1, result.stdout)
+  assert.match(result.stderr, /Deployment failed \(dingtalk_provider_scope_unavailable\)/)
+  assert.equal(await configExists(home), false)
+})
+
+test("an existing deployment aborts on overwrite refusal and keeps state", async (t) => {
+  const temporary = await isolatedRoot(t, "deploy-index-abort-")
+  const home = path.join(temporary, "home")
+  const bin = path.join(temporary, "bin")
+  const packageDirectory = path.join(temporary, "abort-pkg")
+  await mkdir(home)
+  await installFakeQoder(bin)
+  await createEmployeePackage(packageDirectory, { name: "abort-pkg" })
+  const first = runDeploy(
+    {
+      packagePath: packageDirectory,
+      channel: "console",
+      engine: "qoder",
+      runtime: "agent-native",
+      name: "abort-bot",
+      locale: "en",
+      yes: true,
+      providedOptions: fullProvidedOptions(),
+    },
+    { home, bin },
+  )
+  assert.equal(first.status, 2, first.stderr)
+  const before = await readConfig(home)
+  const second = runDeploy(
+    {
+      packagePath: packageDirectory,
+      channel: "console",
+      engine: "qoder",
+      runtime: "agent-native",
+      name: "abort-bot",
+      locale: "en",
+      providedOptions: fullProvidedOptions(),
+    },
+    { home, bin, input: "n\n" },
+  )
+  assert.equal(second.status, 1, second.stdout)
+  assert.match(second.stderr, /did not run \(deploy_aborted\)/)
+  const after = await readConfig(home)
+  assert.deepEqual(after, before)
+})
+
+test("an existing deployment is overwritten on confirmation", async (t) => {
+  const temporary = await isolatedRoot(t, "deploy-index-overwrite-")
+  const home = path.join(temporary, "home")
+  const bin = path.join(temporary, "bin")
+  const packageDirectory = path.join(temporary, "overwrite-pkg")
+  await mkdir(home)
+  await installFakeQoder(bin)
+  await createEmployeePackage(packageDirectory, { name: "overwrite-pkg" })
+  const first = runDeploy(
+    {
+      packagePath: packageDirectory,
+      channel: "console",
+      engine: "qoder",
+      runtime: "agent-native",
+      name: "overwrite-bot",
+      locale: "en",
+      yes: true,
+      providedOptions: fullProvidedOptions(),
+    },
+    { home, bin },
+  )
+  assert.equal(first.status, 2, first.stderr)
+  const before = await readConfig(home)
+  const second = runDeploy(
+    {
+      packagePath: packageDirectory,
+      channel: "console",
+      engine: "qoder",
+      runtime: "agent-native",
+      name: "overwrite-bot",
+      locale: "en",
+      providedOptions: fullProvidedOptions(),
+    },
+    { home, bin, input: "y\n" },
+  )
+  assert.equal(second.status, 2, second.stderr)
+  const after = await readConfig(home)
+  assert.notEqual(after.updatedAt, before.updatedAt)
+  assert.equal(after.outcome, "pending_external_action")
+})

--- a/tests/apps/deploy-prompts.test.ts
+++ b/tests/apps/deploy-prompts.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const driver = path.join(root, "tests", "apps", "fixtures", "prompt-driver.mjs")
+
+function runPrompt(type: string, input: string, extra: string[] = []) {
+  return spawnSync(
+    process.execPath,
+    ["--import", "tsx", driver, type, ...extra],
+    { cwd: root, encoding: "utf8", input, timeout: 20_000 },
+  )
+}
+
+test("textPrompt returns the typed value", () => {
+  const result = runPrompt("text", "my-bot\n")
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /RESULT:"my-bot"/)
+})
+
+test("textPrompt falls back to the default on empty input", () => {
+  const result = runPrompt("text", "\n", ["default-bot"])
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /RESULT:"default-bot"/)
+})
+
+test("textPrompt returns empty string with no default", () => {
+  const result = runPrompt("text", "\n")
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /RESULT:""/)
+})
+
+test("selectPrompt returns the chosen option value", () => {
+  const result = runPrompt("select", "2\n")
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /RESULT:"2"/)
+})
+
+test("selectPrompt defaults to the first option on out-of-range input", () => {
+  const result = runPrompt("select", "99\n")
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /RESULT:"1"/)
+})
+
+test("selectPrompt defaults to the first option on garbage input", () => {
+  const result = runPrompt("select", "abc\n")
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /RESULT:"1"/)
+})
+
+test("confirmPrompt accepts y", () => {
+  const result = runPrompt("confirm", "y\n")
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /RESULT:true/)
+})
+
+test("confirmPrompt accepts the yes label first letter", () => {
+  const result = runPrompt("confirm", "Y\n")
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /RESULT:true/)
+})
+
+test("confirmPrompt accepts the full yes label", () => {
+  const result = runPrompt("confirm", "Y\n")
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /RESULT:true/)
+})
+
+test("confirmPrompt accepts the Chinese yes word", () => {
+  const result = runPrompt("confirm", "是\n")
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /RESULT:true/)
+})
+
+test("confirmPrompt rejects anything else", () => {
+  for (const input of ["n\n", "no\n", "\n", "maybe\n"]) {
+    const result = runPrompt("confirm", input)
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /RESULT:false/)
+  }
+})
+
+test("secretPrompt masks input and returns the value", () => {
+  const result = runPrompt("secret", "s3cret-value\n")
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /RESULT:"s3cret-value"/)
+  assert.match(result.stdout, /\*{12}/)
+  // The secret text appears only in the RESULT line, never echoed back
+  assert.equal(result.stdout.split("s3cret-value").length - 1, 1)
+})
+
+test("textPrompt rejects input that exceeds the total input byte limit", () => {
+  const result = runPrompt("text", "x".repeat(70 * 1024))
+  assert.equal(result.status, 1, result.stdout)
+  assert.match(result.stdout, /RESULT:ERROR:deploy_prompt_input_limit_exceeded/)
+})
+
+test("textPrompt rejects a single line that exceeds the answer byte limit", () => {
+  const result = runPrompt("text", `${"x".repeat(5 * 1024)}\n`)
+  assert.equal(result.status, 1, result.stdout)
+  assert.match(result.stdout, /RESULT:ERROR:deploy_prompt_input_limit_exceeded/)
+})
+
+test("textPrompt accepts a trailing partial line at EOF", () => {
+  const result = runPrompt("text", "partial-line")
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /RESULT:"partial-line"/)
+})
+
+test("textPrompt rejects EOF with no queued answer", () => {
+  const result = runPrompt("text", "")
+  assert.equal(result.status, 1, result.stdout)
+  assert.match(result.stdout, /RESULT:ERROR:deploy_prompt_input_closed/)
+})
+
+test("secretPrompt handles backspace by removing the last character", () => {
+  const result = runPrompt("secret-backspace", "ab\x7fc\n")
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /RESULT:"ac"/)
+})

--- a/tests/apps/fixtures/deploy-index-driver.mjs
+++ b/tests/apps/fixtures/deploy-index-driver.mjs
@@ -1,0 +1,10 @@
+import { deploy } from "../../../apps/cli/deploy/index.js"
+
+const rawOptions = JSON.parse(process.argv[2] ?? "{}")
+const options = {
+  ...rawOptions,
+  ...(Array.isArray(rawOptions.providedOptions)
+    ? { providedOptions: new Set(rawOptions.providedOptions) }
+    : {}),
+}
+await deploy(options)

--- a/tests/apps/fixtures/fake-dws.mjs
+++ b/tests/apps/fixtures/fake-dws.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+/** Fixture dws CLI for deploy channel tests. Serves a single fixed profile. */
+
+const args = process.argv.slice(2)
+
+const identity = {
+  success: true,
+  currentProfile: "corp-a:user-a",
+  profiles: [
+    {
+      profile: "corp-a:user-a",
+      corpId: "corp-a",
+      userId: "user-a",
+      clientId: "profile-client-a",
+      isCurrent: true,
+    },
+  ],
+}
+
+function emit(value) {
+  process.stdout.write(`${JSON.stringify(value)}\n`)
+}
+
+if (args[0] === "profile" && args[1] === "list") {
+  emit(identity)
+  process.exit(0)
+}
+
+const scopedCommand = args[0] === "--profile" ? args[3] : undefined
+if (scopedCommand === "+list") {
+  emit({ apps: [], hasMore: false })
+  process.exit(0)
+}
+if (scopedCommand === "+create") {
+  emit({ unifiedAppId: "app-created-1" })
+  process.exit(0)
+}
+if (scopedCommand === "+get") {
+  const index = args.indexOf("--unified-app-id")
+  const appId = index >= 0 ? args[index + 1] : "app-1"
+  emit({ unifiedAppId: appId, name: "test-bot" })
+  process.exit(0)
+}
+process.stderr.write(`unexpected fixture dws args: ${JSON.stringify(args)}\n`)
+process.exit(2)

--- a/tests/apps/fixtures/prompt-driver.mjs
+++ b/tests/apps/fixtures/prompt-driver.mjs
@@ -1,0 +1,49 @@
+/**
+ * Subprocess driver for deploy prompt tests. Each invocation exercises one
+ * prompt against real stdin/stdout; the result is emitted on stdout as a
+ * RESULT line (or RESULT:ERROR:<message> when the prompt rejects). Usage:
+ *   node --import tsx prompt-driver.mjs <select|text|confirm|secret|overflow|longline|eof-partial|eof-empty|secret-backspace> [default]
+ */
+import {
+  confirmPrompt,
+  secretPrompt,
+  selectPrompt,
+  textPrompt,
+} from "../../../apps/cli/deploy/prompts.js"
+
+const type = process.argv[2]
+const defaultValue = process.argv[3]
+
+async function run() {
+  if (type === "select") {
+    return await selectPrompt("Pick:", [
+      { label: "One", value: "1" },
+      { label: "Two", value: "2", hint: "hint" },
+    ])
+  }
+  if (type === "text") {
+    return await textPrompt("Name:", defaultValue)
+  }
+  if (type === "confirm") {
+    return await confirmPrompt("Sure?", { yes: "Y", no: "n" })
+  }
+  if (type === "secret" || type === "secret-backspace") {
+    return await secretPrompt("Key:")
+  }
+  if (type === "overflow" || type === "longline") {
+    return await textPrompt("Name:")
+  }
+  if (type === "eof-partial" || type === "eof-empty") {
+    return await textPrompt("Name:")
+  }
+  throw new Error(`unknown prompt type: ${type}`)
+}
+
+try {
+  const result = await run()
+  process.stdout.write(`RESULT:${JSON.stringify(result)}\n`)
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stdout.write(`RESULT:ERROR:${message}\n`)
+  process.exitCode = 1
+}


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/70
- Consumed revision: R2
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| AC-001 (verifies REQ-001) | tests/apps/deploy-index.test.ts, tests/apps/deploy-channels.test.ts | Exit/outcome matrix: console deploy exits 2 with `pending_external_action`; standalone-v1 exits 1 with `package_deploy_standalone_unsupported` and writes no config; dingtalk provider failure exits 1; deployLark/deployWeCom return `lark_live_deploy_unsupported`/`wecom_live_deploy_unsupported`; deployConsole returns `console_foreground_start_required`. |
| AC-002 (verifies REQ-002) | tests/apps/deploy-index.test.ts, tests/apps/deploy-channels.test.ts, tests/apps/deploy-config.test.ts | Failure/idempotency: dws-unavailable dingtalk deploy fails closed with `dingtalk_provider_scope_unavailable` and preserves no new config; provider scope mismatch → `dingtalk_provider_scope_mismatch` with preserveState; overwrite refusal aborts with `deploy_aborted` and keeps config byte-identical; overwrite confirmation re-saves config; config generation change → `deploy_config_generation_changed`; released lock → `deploy_lock_not_owned`. |
| AC-003 (verifies REQ-003) | tests/apps/deploy-config.test.ts, tests/apps/deploy-channels.test.ts | Secret/permission boundary: config dir/file modes 0700/0600 enforced (`deploy_config_permissions_unsafe`, `deploy_config_directory_permissions_unsafe`), symlink config rejected, malformed JSON fails closed, atomic tmp-file replace leaves no leftovers; `buildHttpRuntimeEnvironment` forwards only engine credentials + `DIGITAL_EMPLOYEE_HTTP_TOKEN` and excludes unrelated env vars; unknown engine → `http_runtime_engine_invalid`. |
| AC-004 (verifies REQ-001, REQ-004) | tests/apps/deploy-channels.test.ts, tests/apps/deploy-prompts.test.ts | Readiness/cleanup: `inspectHttpDeployment` distinguishes ready/starting/stale/absent/unverified; `endpointUrl` builds http://host:port/askPath; prompt harness rejects oversized input (`deploy_prompt_input_limit_exceeded`) and EOF without answer (`deploy_prompt_input_closed`) so interrupted runs fail closed; trailing partial line at EOF is accepted for resumable input. |

## File domains

- tests/apps/deploy-channels.test.ts — channel deployers (DingTalk reconciliation, HTTP runtime env, endpoint readback), owned by CLI domain.
- tests/apps/deploy-config.test.ts — config persistence, permissions, CAS writes, lock ownership, owned by CLI domain.
- tests/apps/deploy-index.test.ts — end-to-end `deploy` orchestration exit codes and persisted state through the driver fixture, owned by CLI domain.
- tests/apps/deploy-prompts.test.ts — interactive prompt hardening for automated/CI and interrupted runs, owned by CLI domain.
- tests/apps/fixtures/{prompt-driver.mjs,deploy-index-driver.mjs,fake-dws.mjs} — subprocess harnesses and the fake dws CLI used to exercise real execFile/supervisor paths, owned by CLI domain.

All changed files are tests/fixtures only; no production code is touched.

## Scope and non-goals

- Scope: automated P0 evidence for issue #70 R2 — exit/outcome matrix (AC-001), failure/idempotent replay (AC-002), secret-safe persistence and permissions (AC-003), local readiness/interruption cleanup (AC-004) for the coordinated package-bound deploy orchestrator.
- Non-goals: no production code change; no Lark/WeCom live flows (#77/#78); no HTTP runtime process boot/endpoint E2E (already covered by existing tests/apps/deploy-cli.test.ts); no platform/remote execution.

## Validation

- Exact commands:
  - `node_modules/.bin/tsx --test --test-concurrency=1 tests/apps/deploy-channels.test.ts tests/apps/deploy-config.test.ts tests/apps/deploy-index.test.ts tests/apps/deploy-prompts.test.ts`
  - `npm run typecheck`
  - `LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 npm run check` (explicit English locale matches CI runners; the machine's zh-CN system locale otherwise flips pre-existing locale-sensitive CLI tests)
- Observed counts/results: ported deploy suite 60/60 PASS (channels 23, config 12, index 8, prompts 17); `npm run typecheck` PASS; full `npm run check` PASS (counts below).
- Check URLs: NOT VERIFIED: PR CI not yet run; local `npm run check` is the recorded evidence.

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-001 | ready=0 / pending_external_action=2 / unsupported=1 matrix via fixtures | run ported deploy suite | macOS arm64, Node 24 | console deploy exits 2 with pending guidance; standalone exits 1 unsupported; failures exit 1 | 23/23 channels + 8/8 index PASS, exit codes and outcome strings match | PASS |
| V2 | AC-002 | provider errors never become success; explicit existing state read back and reused; duplicate runs create at most one effect | run ported deploy suite | macOS arm64, Node 24 | dws failure fails closed; overwrite abort keeps state; generation/lock conflicts detected | dingtalk fail-closed, overwrite abort/confirm, `deploy_config_generation_changed`, `deploy_lock_not_owned` PASS | PASS |
| V3 | AC-003 | no sentinel in artifacts; config owner-only, atomic, non-symlink | run ported deploy suite | macOS arm64, Node 24 | 0600/0700 enforced; symlink rejected; runtime env forwards only engine creds | 12/12 config + env-forwarding tests PASS; no sentinel leaks in asserted outputs | PASS |
| V4 | AC-004 | local readiness readback truthful; interrupted input fails closed | run ported deploy suite | macOS arm64, Node 24 | inspectHttpDeployment states distinct; oversized/EOF input rejected | 17/17 prompts + inspection tests PASS | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs.
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed.
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded.

No production code changes; tests use sentinel values only (e.g. `deploy-index-test-token`), never real credentials. Config paths are isolated per-test via temporary HOME directories; fixture CLIs are temp-dir shims. Compatibility: no runtime, CLI, or config-format change; no migration; no cross-repository effect. Dependency: none changed; `npm audit --omit=dev --audit-level=high` reports 0 vulnerabilities.

## Known limitations

- HTTP channel deploy is exercised at unit level (channels.ts) and orchestration level (index.ts console path); live HTTP runtime process boot/readback E2E remains covered by the pre-existing deploy-cli.test.ts suite.
- DingTalk provider tests use a fake `dws` binary; real DWS behaviors outside the exercised command shapes are not covered.
- Windows platform behavior (signal/process-group handling) is not verified locally.
- Pre-existing locale-sensitive tests in deploy-cli.test.ts require an English system locale (CI runners); on a zh-CN host the full check must run with `LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8`, which reproduces CI exactly.

## Risk and rollback

- Test-only change: no production behavior, data flow, or permissions change. Rollback = revert PR; no migration or irreversible effect. Deployment of this PR is a plain merge with no side effects.

## Product review handoff

- Merge ledger owner: @huyz
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: test-evidence PR for in-flight issue #70, no release packet assigned.
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
