### PR TITLE
fix(cli): tolerate transient HTTP readback probe failures during final deploy verification

### DIFF
--- a/apps/cli/deploy/index.ts
+++ b/apps/cli/deploy/index.ts
@@ -2,6 +2,7 @@
 
 import path from "node:path"
 import { realpath } from "node:fs/promises"
+import { setTimeout as delay } from "node:timers/promises"
 
 import {
   computeEmployeePackageDirectoryDigest,
@@ -291,15 +292,36 @@ function writeBinding(binding: DeployPackageBinding, runtime: DeployRuntime): vo
   )
 }
 
-async function hasExactHttpReadback(
+// Bounded window that tolerates a transient observation failure (for
+// example a loaded CI runner delaying one /health probe) without masking a
+// runtime that never becomes ready: fail-closed verdicts are unchanged.
+const HTTP_FINAL_READBACK_WINDOW_MS = 3_000
+const HTTP_FINAL_READBACK_DELAY_MS = 150
+
+export async function hasExactHttpReadback(
   config: DeployConfig,
   binding: DeployPackageBinding,
+  signal?: AbortSignal,
 ): Promise<boolean> {
   try {
+    if (
+      config.package?.localReference !== binding.localReference ||
+      config.package.digest !== binding.digest
+    ) {
+      return false
+    }
+    const deadline = Date.now() + HTTP_FINAL_READBACK_WINDOW_MS
+    let ready = false
+    while (!signal?.aborted && Date.now() < deadline) {
+      if (await readbackHttpDeployment(config)) {
+        ready = true
+        break
+      }
+      await delay(HTTP_FINAL_READBACK_DELAY_MS, undefined, { signal })
+        .catch(() => undefined)
+    }
     return (
-      config.package?.localReference === binding.localReference &&
-      config.package.digest === binding.digest &&
-      await readbackHttpDeployment(config) &&
+      ready &&
       await computeEmployeePackageDirectoryDigest(config.package.localReference) ===
         config.package.digest
     )
@@ -749,7 +771,11 @@ async function deployImpl(options: DeployOptions = {}): Promise<void> {
       let promoted = false
       try {
         await lock.assertOwned()
-        const prePublicationReadback = await hasExactHttpReadback(existing, binding)
+        const prePublicationReadback = await hasExactHttpReadback(
+          existing,
+          binding,
+          controller.signal,
+        )
         await lock.assertOwned()
         if (controller.signal.aborted) {
           failCode("deploy.error_interrupted", "deploy_interrupted")
@@ -778,6 +804,7 @@ async function deployImpl(options: DeployOptions = {}): Promise<void> {
         const postPublicationReadback = await hasExactHttpReadback(
           fresh.config,
           binding,
+          controller.signal,
         )
         await lock.assertOwned()
         if (controller.signal.aborted || !postPublicationReadback) {
@@ -1024,7 +1051,11 @@ async function deployImpl(options: DeployOptions = {}): Promise<void> {
         const prePublication = await loadExactConfigGeneration(stateGeneration, lock)
         const prePublicationReadback = controller.signal.aborted
           ? false
-          : await hasExactHttpReadback(prePublication.config, binding)
+          : await hasExactHttpReadback(
+              prePublication.config,
+              binding,
+              controller.signal,
+            )
         await lock.assertOwned()
         if (controller.signal.aborted) {
           failureCode = "deploy_interrupted"
@@ -1059,7 +1090,11 @@ async function deployImpl(options: DeployOptions = {}): Promise<void> {
           const published = await loadExactConfigGeneration(stateGeneration, lock)
           const postPublicationReadback = controller.signal.aborted
             ? false
-            : await hasExactHttpReadback(published.config, binding)
+            : await hasExactHttpReadback(
+                published.config,
+                binding,
+                controller.signal,
+              )
           await lock.assertOwned()
           if (controller.signal.aborted) {
             failureCode = "deploy_interrupted"
@@ -1086,7 +1121,11 @@ async function deployImpl(options: DeployOptions = {}): Promise<void> {
           const released = await loadExactConfigGeneration(stateGeneration, lock)
           const postReleaseReadback = controller.signal.aborted
             ? false
-            : await hasExactHttpReadback(released.config, binding)
+            : await hasExactHttpReadback(
+                released.config,
+                binding,
+                controller.signal,
+              )
           await lock.assertOwned()
           if (controller.signal.aborted) {
             failureCode = "deploy_interrupted"

--- a/tests/apps/deploy-readback.test.ts
+++ b/tests/apps/deploy-readback.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { once } from "node:events"
+import test from "node:test"
+
+import { hasExactHttpReadback } from "../../apps/cli/deploy/index.js"
+import type {
+  DeployConfig,
+  DeployPackageBinding,
+} from "../../apps/cli/deploy/config.js"
+
+const MATCHING_DIGEST = `sha256:${"a".repeat(64)}`
+
+function httpConfig(pid: number): DeployConfig {
+  return {
+    channel: "http",
+    engine: "qoder",
+    runtime: "agent-native",
+    package: {
+      name: "readback-bot",
+      version: "1.0.0",
+      digest: MATCHING_DIGEST,
+      localReference: "/tmp/readback-bot",
+    },
+    endpoint: {
+      protocol: "http",
+      host: "127.0.0.1",
+      port: 8899,
+      askPath: "/v1/ask",
+      healthPath: "/health",
+    },
+    process: {
+      pid,
+      startedAt: new Date().toISOString(),
+      launchId: "c".repeat(32),
+      activationFence: "d".repeat(32),
+      activationState: "authorized",
+    },
+  }
+}
+
+const binding: DeployPackageBinding = {
+  name: "readback-bot",
+  version: "1.0.0",
+  digest: MATCHING_DIGEST,
+  localReference: "/tmp/readback-bot",
+}
+
+test("hasExactHttpReadback rejects a mismatched package binding immediately", async () => {
+  const mismatched: DeployPackageBinding = {
+    ...binding,
+    localReference: "/tmp/other-package",
+  }
+  assert.equal(await hasExactHttpReadback(httpConfig(process.pid), mismatched), false)
+})
+
+test("hasExactHttpReadback stays fail-closed for a process with a mismatched argv", async () => {
+  // The test runner's own process is alive but its argv never matches the
+  // tracked runtime invocation, so every attempt observes "unverified".
+  assert.equal(await hasExactHttpReadback(httpConfig(process.pid), binding), false)
+})
+
+test("hasExactHttpReadback stays fail-closed for a dead process", async () => {
+  const child = spawn(process.execPath, ["-e", "process.exit(0)"])
+  await once(child, "exit")
+  assert.equal(await hasExactHttpReadback(httpConfig(child.pid!), binding), false)
+})
+
+test("hasExactHttpReadback aborts the bounded window on signal", async () => {
+  const controller = new AbortController()
+  controller.abort()
+  assert.equal(
+    await hasExactHttpReadback(httpConfig(process.pid), binding, controller.signal),
+    false,
+  )
+})


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/89
- Consumed revision: R1
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-002 / AC-002 | `apps/cli/deploy/index.ts` (final HTTP deployment readback gates) | `tests/apps/deploy-readback.test.ts` (4/4 fail-closed unit tests); full `npm run check` gate passes 1408/0 |
| REQ-003 / AC-003 | `apps/cli/deploy/index.ts` (fail-closed semantics, unchanged failure codes) | Mutation test `package mutation during the post-persistence HTTP gate` PASS; `readbackHttpDeployment` single-probe contract unchanged |

## File domains

- Deploy CLI verification path: `apps/cli/deploy/index.ts` — bounded retry window in `hasExactHttpReadback` (3s / 150ms) with AbortSignal propagation to all five final verification call sites.
- Deploy CLI tests: `tests/apps/deploy-readback.test.ts` — new unit tests for binding mismatch, unverified/absent runtime, and pre-aborted signal fail-closed paths.
- Product runtime, config schema, channels, and other domains: unchanged.

## Scope and non-goals

Add a bounded retry window to the final HTTP deployment readback so a single transient `/health` probe failure on a loaded CI runner cannot turn a valid deployment into `http_final_readback_failed`. Propagate the deploy controller AbortSignal so interruption still wins immediately, and keep fail-closed verdicts unchanged: a runtime that never becomes ready still fails the deploy.

Non-goals: no change to `readbackHttpDeployment` single-probe semantics (lock-contention tests depend on it); no change to readiness polling loop timing, failure codes, or the config state machine.

## Validation

- Exact commands: `npm run typecheck`; `npx tsx --test tests/apps/deploy-readback.test.ts`; `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 npm run check`; `npx tsx --test --test-concurrency=1 --test-name-pattern="paused deploy fencing" tests/apps/deploy-cli.test.ts`; `npx tsx --test --test-concurrency=1 --test-name-pattern="post-persistence HTTP gate" tests/apps/deploy-cli.test.ts`
- Observed counts/results: PASS, 4/4 new unit tests; PASS, 1408/0 full check; PASS, 3/3 key deploy-cli tests in isolation; governance:check and security:check PASS
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/pull/127/checks

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-002 / AC-002 | Typecheck passes | `npm run typecheck` | macOS arm64, Node 24 | exit 0 | exit 0 | PASS |
| V2 | REQ-002 / AC-002 | New fail-closed unit tests pass | `npx tsx --test tests/apps/deploy-readback.test.ts` | macOS arm64, Node 24 | 4/4 pass | 4/4 pass | PASS |
| V3 | REQ-002 / AC-002 | Full repository gate passes | `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 npm run check` | macOS arm64, Node 24 | all pass | 1408 pass / 0 fail; governance and security checks pass | PASS |
| V4 | REQ-002 / AC-002 | Previously flaky paused-fencing deploy test passes | `npx tsx --test --test-concurrency=1 --test-name-pattern="paused deploy fencing" tests/apps/deploy-cli.test.ts` | macOS arm64, Node 24 | pass | pass | PASS |
| V5 | REQ-003 / AC-003 | Mutation fail-closed test still rejects mutated package | `npx tsx --test --test-concurrency=1 --test-name-pattern="post-persistence HTTP gate" tests/apps/deploy-cli.test.ts` | macOS arm64, Node 24 | `http_final_readback_failed` preserved, no Ready, cleanup verified | pass | PASS |

## Security and compatibility

No new secrets, network surfaces, or persisted data; the retry only repeats an existing authenticated loopback probe with the existing token. No API, schema, or state shape changes. Bounded worst-case latency per failing probe: 3s total per gate, aborted immediately on controller cancellation.

## Known limitations

The 3s window covers transient probe timeouts but does not extend readiness polling itself; a runtime that needs longer than the existing readiness window still fails closed. Full-suite watchdog and interactive tests show local-machine timing/locale sensitivity unrelated to this change (all pass under English locale and in isolation).

## Risk and rollback

Low risk: additive retry around an existing fail-closed check; failure codes and state machine unchanged. Rollback: revert the single commit; no migration or data impact.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: this PR is part of Issue #89's CI restoration maintenance, not a separate milestone packet
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
