### PR TITLE
fix(qoder): tolerate late-init handshake and surface terminal_reason errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ printf '%s\n' '{"message":"What does the approved handbook say?"}' | \
   node ./dist/apps/cli/bin.js run ../team-answer --engine qoder --stdin
 ```
 
+Generate `QODER_PERSONAL_ACCESS_TOKEN` as a Personal Access Token in your
+Qoder account settings; it is a deployment service credential, not a personal
+CLI login. If the token is missing, invalid or expired, `run` fails closed
+with `qoder_service_token_not_configured` or `qoder_access_token_invalid`
+before any trusted output is produced.
+
 Select `claude-code`, `qwen-code` or `codebuddy` in the same commands after
 configuring that adapter's service API key. `--stdin`/`--input-file` keep task
 data out of the outer process arguments. Claude Code, Qwen Code and CodeBuddy

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,6 +48,8 @@ printf '%s\n' '{"message":"批准资料里怎么说？"}' | \
   node ./dist/apps/cli/bin.js run ../team-answer --engine qoder --stdin
 ```
 
+`QODER_PERSONAL_ACCESS_TOKEN` 需要在 Qoder 账号设置中生成 Personal Access Token，它是部署用的服务凭证，不是个人 CLI 登录态。Token 缺失、无效或过期时，`run` 会在产出任何可信输出前 fail closed，分别报 `qoder_service_token_not_configured` 或 `qoder_access_token_invalid`。
+
 Claude Code、Qwen Code 或 CodeBuddy 使用同样的 `validate/run` 命令，改为对应 `--engine` 并配置该 Adapter 的服务 API Key 即可。`--stdin`/`--input-file` 让任务数据不进入外层进程参数。Claude Code、Qwen Code 和 CodeBuddy 只接收由 manifest 显式选中、有上限的密封 UTF-8 资产投影，并在空白且隔离的工作目录、HOME 和配置目录中运行；输出被信任前必须确认模型可见 tools 与 MCP 均为空。Claude 还会确认 plugins、Skills 和 slash commands 为空；Qwen 会禁用 slash commands 并锁定不可调用的内建 Agent 目录；CodeBuddy 则会显式拒绝已验证版本的每一个内建工具，因为单独使用空 `--tools` 并不能真正清空工具。Qoder 使用最小只读文件投影，并确认精确的读取/搜索工具集以及空 MCP/Skill/plugin 集；回答文本会等进程与凭证清理成功后再整体按真实服务 Token 脱敏。工具值会在截断前脱敏，包含服务 Token 的工具标识或键会被拒绝，需要凭证或通用模式脱敏的 schema 结构化输出会 fail closed。
 
 四条链路仍是本机/单租户技术预览，不是已经可供市场租赁的在线员工服务；都会 fail-closed 拒绝 MCP、附件、会话恢复、写操作与审批回调。模型认证/推理控制面保持可达，员工 tool/MCP 数据面网络被禁止。当前只完成了一致性 fixture，没有使用真实模型权益验收。

--- a/apps/cli/qoder-agent-host.ts
+++ b/apps/cli/qoder-agent-host.ts
@@ -51,7 +51,15 @@ const QODER_PROTOCOL_MAJOR = 1
 // compatibility version when it enables SDK mode in qodercli 1.1.x.
 const QODER_SDK_TRANSPORT_VERSION = "1.0.16"
 const DEFAULT_TIMEOUT_MS = 240_000
+// Some qodercli 1.1.x builds only complete the init handshake after the first
+// user message. If no handshake response arrives within this window the adapter
+// submits the prompt anyway and keeps validating init strictly on arrival.
+const DEFAULT_HANDSHAKE_GRACE_MS = 5_000
 const TERMINATION_GRACE_MS = 2_000
+const QODER_TERMINAL_REASON_CODES: Record<string, string> = {
+  access_token_invalid: "qoder_access_token_invalid",
+  auth_payload_missing: "qoder_auth_payload_missing",
+}
 const CLEANUP_ATTEMPTS = 2
 const CLEANUP_ATTEMPT_TIMEOUT_MS = 2_000
 const MAX_PROMPT_BYTES = 256 * 1024
@@ -65,6 +73,15 @@ const MAX_PROJECTED_FILE_BYTES = 5 * 1024 * 1024
 const MAX_PROJECTED_TOTAL_BYTES = 20 * 1024 * 1024
 const MAX_EVENTS = 10_000
 const PORTABLE_EXACT_PATH = /^\.\/(?!.*\\)[^\u0000-\u001f\u007f*?[\]{}!]+$/
+
+function terminalReasonCode(
+  result: Record<string, unknown> | undefined,
+): string | undefined {
+  const reason = result?.terminal_reason
+  return typeof reason === "string"
+    ? QODER_TERMINAL_REASON_CODES[reason]
+    : undefined
+}
 
 type RunStopReason =
   | "aborted"
@@ -100,6 +117,7 @@ export interface QoderAgentHostAdapterOptions {
   versionExecutor?: VersionCommandExecutor
   temporaryRoot?: string
   timeoutMs?: number
+  handshakeGraceMs?: number
   now?: () => Date
   /** Lifecycle hooks are primarily useful to deterministic embedders/tests. */
   beforeSpawn?: () => Promise<void>
@@ -696,6 +714,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
   private readonly versionExecutor: VersionCommandExecutor
   private readonly temporaryRoot?: string
   private readonly timeoutMs: number
+  private readonly handshakeGraceMs: number
   private readonly now: () => Date
   private readonly beforeSpawn?: () => Promise<void>
   private readonly beforeProjectionOpen?: (sourcePath: string) => Promise<void>
@@ -710,6 +729,10 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
     this.versionExecutor = options.versionExecutor ?? executeVersionCommand
     this.temporaryRoot = options.temporaryRoot
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    this.handshakeGraceMs = Math.max(
+      0,
+      options.handshakeGraceMs ?? DEFAULT_HANDSHAKE_GRACE_MS,
+    )
     this.now = options.now ?? (() => new Date())
     this.beforeSpawn = options.beforeSpawn
     this.beforeProjectionOpen = options.beforeProjectionOpen
@@ -773,6 +796,13 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
         issue(
           "authentication_not_verified",
           "A service token is configured; model access is verified only by a run",
+          false,
+        ),
+      )
+      issues.push(
+        issue(
+          "qoder_handshake_verified_by_conformance_only",
+          "Capabilities are verified by the bundled conformance fixture; late-init 1.1.x builds are tolerated at runtime",
           false,
         ),
       )
@@ -863,6 +893,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
     let pendingAssistantText = ""
     let abortListener: (() => void) | undefined
     let deadlineTimer: NodeJS.Timeout | undefined
+    let handshakeGraceTimer: NodeJS.Timeout | undefined
     let terminalEvent:
       | Extract<AgentHostEvent, { type: "run.completed" | "run.failed" }>
       | undefined
@@ -1133,18 +1164,20 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
         stop("protocol")
       }
 
-      const maybeSubmitPrompt = () => {
-        if (
-          !initSeen ||
-          !initializeResponseSeen ||
-          promptSubmitted ||
-          active.reason
-        ) {
-          return
-        }
+      const submitPrompt = () => {
+        if (promptSubmitted || stdinError || active.reason) return
         promptSubmitted = true
         child.stdin.end(promptLine)
       }
+      const maybeSubmitPrompt = () => {
+        if (!initSeen || !initializeResponseSeen) return
+        submitPrompt()
+      }
+      handshakeGraceTimer = setTimeout(
+        submitPrompt,
+        Math.min(this.handshakeGraceMs, deadlineMs),
+      )
+      handshakeGraceTimer.unref()
       child.stdin.once("error", () => {
         stdinError = true
         protocolFailure("qoder_stdin_failed")
@@ -1273,7 +1306,14 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
           continue
         }
 
-        if (["assistant", "user", "stream_event", "result"].includes(event.type) && !initSeen) {
+        if (event.type === "result" && !initSeen) {
+          resultEvent = event
+          protocolFailure(
+            terminalReasonCode(event) ?? "qoder_result_before_init",
+          )
+          continue
+        }
+        if (["assistant", "user", "stream_event"].includes(event.type) && !initSeen) {
           protocolFailure("qoder_init_required")
           continue
         }
@@ -1434,6 +1474,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
       }
 
       const close = await closed
+      clearTimeout(handshakeGraceTimer)
       if (active.forceTimer) clearTimeout(active.forceTimer)
 
       let terminalCode: string | undefined
@@ -1453,7 +1494,8 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
       else if (close.code !== 0) {
         terminalCode = "qoder_process_failed"
         retryable = true
-      } else if (!initSeen) terminalCode = "qoder_init_missing"
+      } else if (eventCount === 0) terminalCode = "qoder_no_response"
+      else if (!initSeen) terminalCode = "qoder_init_missing"
       else if (!initializeResponseSeen) {
         terminalCode = "qoder_initialize_response_missing"
       } else if (!promptSubmitted) terminalCode = "qoder_prompt_not_submitted"
@@ -1465,7 +1507,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
         terminalCode =
           resultEvent.subtype === "error_max_turns"
             ? "qoder_max_turns_exceeded"
-            : "qoder_execution_failed"
+            : terminalReasonCode(resultEvent) ?? "qoder_execution_failed"
       } else if (toolNames.size !== completedTools.size) {
         terminalCode = "qoder_tool_result_missing"
       }
@@ -1511,6 +1553,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
     } finally {
       let cleanupSucceeded = true
       if (deadlineTimer) clearTimeout(deadlineTimer)
+      if (handshakeGraceTimer) clearTimeout(handshakeGraceTimer)
       if (abortListener) request.signal?.removeEventListener("abort", abortListener)
       if (active.forceTimer) clearTimeout(active.forceTimer)
       if (active.child) {

--- a/tests/apps/fixtures/fake-qoder.mjs
+++ b/tests/apps/fixtures/fake-qoder.mjs
@@ -308,6 +308,7 @@ async function executeRun() {
 
 const lines = createInterface({ input: process.stdin, crlfDelay: Infinity })
 let initialized = false
+let deferredInitPending = false
 for await (const line of lines) {
   if (!line.trim()) continue
   inputLines.push(line)
@@ -319,12 +320,35 @@ for await (const line of lines) {
   }
 
   if (!initialized) {
+    if (deferredInitPending) {
+      if (message.type !== "user") process.exit(2)
+      emit(init)
+      initialized = true
+      await executeRun()
+      continue
+    }
     if (
       message.type !== "control_request" ||
       message.request?.type !== "initialize" ||
       typeof message.request_id !== "string"
     ) {
       process.exit(2)
+    }
+    if (mode === "auth-invalid" || mode === "auth-payload-missing") {
+      emit({
+        type: "result",
+        session_id: sessionId,
+        subtype: "error_during_execution",
+        is_error: true,
+        terminal_reason:
+          mode === "auth-invalid"
+            ? "access_token_invalid"
+            : "auth_payload_missing",
+      })
+      process.exit(0)
+    }
+    if (mode === "silent-exit") {
+      process.exit(0)
     }
     if (mode === "malformed") {
       process.stdout.write("not-json\n")
@@ -374,6 +398,10 @@ for await (const line of lines) {
         },
       },
     })
+    if (mode === "deferred-init") {
+      deferredInitPending = true
+      continue
+    }
     emit(init)
     initialized = true
     if (

--- a/tests/apps/qoder-agent-host.test.ts
+++ b/tests/apps/qoder-agent-host.test.ts
@@ -133,6 +133,11 @@ test("Qoder probe reports only the fixture-verified stateless capabilities", asy
   assert.equal(probe.capabilities.structured_output, "supported")
   assert.equal(probe.capabilities.mcp, "unsupported")
   assert.equal(probe.capabilities.usage_events, "unknown")
+  const disclosure = probe.issues.find(
+    (entry) => entry.code === "qoder_handshake_verified_by_conformance_only",
+  )
+  assert.equal(typeof disclosure?.message, "string")
+  assert.equal(disclosure?.blocking, false)
 })
 
 test("Qoder probe accepts only stable three-segment 1.1.x versions", async () => {
@@ -542,6 +547,9 @@ for (const [mode, expectedCode] of [
   ["schema-extra-field", "qoder_output_schema_mismatch"],
   ["stdout-oversize", "qoder_stdout_limit_exceeded"],
   ["stderr-oversize", "qoder_stderr_limit_exceeded"],
+  ["auth-invalid", "qoder_access_token_invalid"],
+  ["auth-payload-missing", "qoder_auth_payload_missing"],
+  ["silent-exit", "qoder_no_response"],
 ] as const) {
   test(`Qoder ${mode} fixture fails closed with one terminal event`, async () => {
     const parent = await mkdtemp(path.join(os.tmpdir(), `qoder-${mode}-`))
@@ -612,6 +620,28 @@ for (const [mode, expectedCode] of [
     )
   })
 }
+
+test("Qoder completes a late-init handshake after the grace window submits the prompt", async () => {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "qoder-deferred-init-"))
+  const request = await employeeRequest(parent, "run-deferred-init")
+  const events = await collect(
+    adapter(parent, "deferred-init", undefined, 30_000, {
+      handshakeGraceMs: 100,
+    }).run(request),
+  )
+
+  assert.deepEqual(
+    events.map((event) => event.type),
+    [
+      "run.started",
+      "tool.started",
+      "tool.completed",
+      "assistant.delta",
+      "run.completed",
+    ],
+  )
+  assert.equal(events.at(-1)?.type, "run.completed")
+})
 
 test("Qoder releases credentials and the run reservation before its terminal event", async () => {
   const parent = await mkdtemp(path.join(os.tmpdir(), "qoder-terminal-cleanup-"))


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/91
- Consumed revision: R3
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-002 / AC-002 | `apps/cli/qoder-agent-host.ts`, `tests/apps/fixtures/fake-qoder.mjs`, `tests/apps/qoder-agent-host.test.ts` | Fail-closed terminal codes are observable: `auth-invalid`, `auth-payload-missing`, and `silent-exit` fixtures map to `qoder_access_token_invalid`, `qoder_auth_payload_missing`, and `qoder_no_response`; deferred-init fixture completes the run through the bounded grace window. Qoder adapter suite PASS (49/49). |
| REQ-003 / AC-003 | `apps/cli/qoder-agent-host.ts` (probe), `README.md`, `README.zh-CN.md` | `doctor` now discloses that capability evidence comes from the bundled conformance fixture via non-blocking `qoder_handshake_verified_by_conformance_only`, and README documents PAT acquisition plus invalid-token failure codes; probe assertion PASS (1/1). |

## File domains

- `apps/cli/qoder-agent-host.ts` — bounded handshake grace window with `submitPrompt`/`maybeSubmitPrompt`, `terminal_reason` mapping (`qoder_access_token_invalid`, `qoder_auth_payload_missing`) before and after init, `qoder_no_response` for zero-event exits, non-blocking probe disclosure; init validation stays strict (fail-closed preserved).
- `tests/apps/fixtures/fake-qoder.mjs` — new fixture modes `auth-invalid`, `auth-payload-missing`, `silent-exit`, `deferred-init` under the existing fixture contract.
- `tests/apps/qoder-agent-host.test.ts` — matrix additions for the three terminal codes, late-init grace-window completion test, probe disclosure assertion.
- `README.md`, `README.zh-CN.md` — Qoder PAT acquisition guidance (service credential from Qoder account settings, not CLI login) and the exact fail-closed codes for missing/invalid tokens.

## Scope and non-goals

Scope: make the Qoder adapter honest and live-usable against qodercli 1.1.x late-init builds without weakening the fail-closed contract. Non-goals honored: no MCP, attachment, session-resume, write, or approval-callback surface added; no other adapter changed; no live-model entitlement validation (consistency fixtures only); no protocol version bump.

## Validation

- Exact commands: `npm run check`; `npx tsx --test tests/apps/qoder-agent-host.test.ts`
- Observed counts/results: full local check PASS (1/1); Qoder adapter tests PASS (49/49)
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/actions/runs/32090798779

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-002 | invalid service credentials fail closed with exact terminal codes instead of a deadlock or misleading code | `npx tsx --test tests/apps/qoder-agent-host.test.ts` over `auth-invalid`, `auth-payload-missing`, `silent-exit` fixtures | Node 24, local HEAD | one terminal `run.failed` event with the exact code, no credential leak | PASS (3/3) | PASS |
| V2 | AC-002 | late-init 1.1.x host still completes a run after the bounded grace window | same command over `deferred-init` fixture with `handshakeGraceMs: 100` | Node 24, local HEAD | exact event sequence `run.started -> tool.started -> tool.completed -> assistant.delta -> run.completed` | PASS (1/1) | PASS |
| V3 | AC-003 | doctor discloses conformance-only capability evidence without blocking | same command, probe assertion | Node 24, local HEAD | `qoder_handshake_verified_by_conformance_only` present, `blocking === false` | PASS (1/1) | PASS |
| V4 | REQ-001 / AC-001 | full `npm run check` green on PR head | CI | GitHub Actions | all required checks SUCCESS | this run failed on an unrelated pre-existing deploy test flake in the coverage lane and on the PR trace body; re-run follows this body edit | NOT VERIFIED: pending CI re-run after this body edit |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Fail-closed posture preserved: init is still strictly validated on arrival; the grace window only submits the prompt, it never downgrades protocol validation; credential scrubbing order is unchanged.
- [x] Compatibility: only the Qoder adapter and its fixtures/tests/README text change; Claude Code, Qwen Code, CodeBuddy, and Codex paths untouched; no dependency changed.
- [x] Pre-push L3 deep security review: 0 findings.

## Known limitations

The grace window is a bounded runtime tolerance (default 5s, clamped to the run deadline), not a protocol guarantee; hosts that never complete init still fail closed at result validation. Capability evidence for `doctor` remains the bundled conformance fixture, now disclosed honestly. No real-model entitlement validation was performed.

## Risk and rollback

Single squash commit; revert is a one-commit revert. Hosts that complete the handshake immediately see no behavior change because `maybeSubmitPrompt` submits on the same condition as before; the grace timer is cleared in every terminal path and is clamped to `min(handshakeGraceMs, deadlineMs)` so it can never extend a run.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @Bindy-lbb
- Milestone or release packet: https://github.com/fullstack-ai-infra/digital-employee/issues/91
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
