### PR TITLE
fix(qoder): forbid prose around the schema-bound JSON output

### DIFF
--- a/apps/cli/qoder-agent-host.ts
+++ b/apps/cli/qoder-agent-host.ts
@@ -1034,7 +1034,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
         "</employee-task>",
         ...(outputSchema !== undefined
           ? [
-              "Return exactly one JSON value and no code fence. It must match this JSON Schema:",
+              "Return exactly one JSON value with no prose or code fence. It must match this JSON Schema:",
               outputSchema.json,
             ]
           : []),


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/91
- Consumed revision: R3
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-002 / AC-002 | `apps/cli/qoder-agent-host.ts` | The schema-bound output instruction now requires exactly one JSON value with no prose or code fence, matching the Claude and Qwen adapters; live-verified against qodercli 1.1.24 on the escalation path (exit 0) and Qoder adapter suite PASS (49/49). |

## File domains

- `apps/cli/qoder-agent-host.ts` — one-line output instruction wording: "Return exactly one JSON value with no prose or code fence." replaces "...and no code fence.", aligning with `claude-agent-host.ts` and `qwen-agent-host.ts`. No protocol, validation, or error-code change.

## Scope and non-goals

Scope: stop the model from prepending free-form prose before the schema-bound JSON output on escalation paths, which previously failed with `qoder_output_not_json` despite a valid answer. Non-goals honored: no protocol change; no relaxation of output parsing (fail-closed preserved); no other adapter touched; no fixtures or tests changed.

## Validation

- Exact commands: `npx tsx --test tests/apps/qoder-agent-host.test.ts`; `node dist/apps/cli/bin.js run cases/team-qa --question "how do I book a flight" --json`
- Observed counts/results: Qoder adapter tests PASS (49/49); live escalation rerun PASS (1/1), exit 0 with schema-valid JSON
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/actions/runs/32099678800

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-002 | schema-bound runs where the model escalates still emit exactly one JSON value | `node dist/apps/cli/bin.js run cases/team-qa --question "how do I book a flight" --json` | Node 24, qodercli 1.1.24, real PAT | exit 0, schema-valid JSON, no `qoder_output_not_json` | PASS (1/1) | PASS |
| V2 | AC-002 | adapter behavior unchanged for all fixture-covered paths | `npx tsx --test tests/apps/qoder-agent-host.test.ts` | Node 24, local HEAD | 49 tests PASS | PASS (49/49) | PASS |
| V3 | REQ-001 / AC-001 | full `npm run check` green on PR head | CI | GitHub Actions | all required checks SUCCESS | pending this PR's CI run | NOT VERIFIED: pending CI |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Fail-closed posture preserved: output parsing and schema validation are unchanged; only the instruction wording is tightened.
- [x] Compatibility: only one line in the Qoder adapter changes; Claude Code, Qwen Code, CodeBuddy, and Codex paths untouched; no dependency changed.
- [x] Pre-push L3 deep security review: 0 findings.

## Known limitations

Prompt instructions are best-effort model guidance, not a protocol guarantee; a host that still emits prose around the JSON fails closed with `qoder_output_not_json` as before. No new automated fixture covers prose-around-JSON because the existing parse path already fails closed.

## Risk and rollback

Single-line change in a single squash commit; revert is a one-commit revert. In-scope answers are unaffected; the only behavior change is stricter instruction wording, identical to the two sibling adapters already in production.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @Bindy-lbb
- Milestone or release packet: https://github.com/fullstack-ai-infra/digital-employee/issues/91
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
