### PR TITLE
fix(qoder): repair unescaped quotes in schema-bound model JSON output

### DIFF
--- a/apps/cli/qoder-agent-host.ts
+++ b/apps/cli/qoder-agent-host.ts
@@ -567,6 +567,58 @@ function normalizeOutputValue(
   return output
 }
 
+function repairUnescapedQuotes(text: string): string {
+  let repaired = ""
+  let inString = false
+  let escaped = false
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index]
+    if (!inString) {
+      if (char === '"') inString = true
+      repaired += char
+      continue
+    }
+    if (escaped) {
+      escaped = false
+      repaired += char
+      continue
+    }
+    if (char === "\\") {
+      escaped = true
+      repaired += char
+      continue
+    }
+    if (char !== '"') {
+      repaired += char
+      continue
+    }
+    let lookahead = index + 1
+    while (
+      lookahead < text.length &&
+      (text[lookahead] === " " ||
+        text[lookahead] === "\t" ||
+        text[lookahead] === "\n" ||
+        text[lookahead] === "\r")
+    ) {
+      lookahead += 1
+    }
+    const next = text[lookahead]
+    if (
+      next === "," ||
+      next === "}" ||
+      next === "]" ||
+      next === ":" ||
+      next === undefined
+    ) {
+      inString = false
+      repaired += char
+    } else {
+      repaired += '\\"'
+    }
+  }
+  return repaired
+}
+
 function parseAndValidateOutput(
   text: string,
   schema: PreparedOutputSchema | undefined,
@@ -576,7 +628,11 @@ function parseAndValidateOutput(
   try {
     parsed = JSON.parse(text)
   } catch {
-    throw new QoderAdapterError("qoder_output_not_json")
+    try {
+      parsed = JSON.parse(repairUnescapedQuotes(text))
+    } catch {
+      throw new QoderAdapterError("qoder_output_not_json")
+    }
   }
   const normalized = normalizeOutputValue(parsed)
   if (!schema.validate(normalized)) {
@@ -1034,7 +1090,7 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
         "</employee-task>",
         ...(outputSchema !== undefined
           ? [
-              "Return exactly one JSON value with no prose or code fence. It must match this JSON Schema:",
+              "Return exactly one JSON value with no prose or code fence. Escape double quotes and backslashes inside string values. It must match this JSON Schema:",
               outputSchema.json,
             ]
           : []),

--- a/tests/apps/fixtures/fake-qoder.mjs
+++ b/tests/apps/fixtures/fake-qoder.mjs
@@ -299,7 +299,9 @@ async function executeRun() {
               ? "{not-json}"
               : mode === "unstructured-prose"
                 ? "plain fixture answer"
-                : output,
+                : mode === "unescaped-quotes"
+                  ? output.replace("fixture answer", 'fixture "quoted" answer')
+                  : output,
   }
   emit(result)
   if (mode === "duplicate-result") emit(result)

--- a/tests/apps/qoder-agent-host.test.ts
+++ b/tests/apps/qoder-agent-host.test.ts
@@ -571,6 +571,25 @@ for (const [mode, expectedCode] of [
   })
 }
 
+test("Qoder repairs unescaped quotes inside model JSON strings", async () => {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "qoder-quote-repair-"))
+  const request = await employeeRequest(parent, "run-unescaped-quotes")
+  const events = await collect(
+    adapter(parent, "unescaped-quotes").run(request),
+  )
+  const terminal = events.at(-1)
+
+  assert.equal(terminal?.type, "run.completed")
+  assert.equal(
+    terminal?.type === "run.completed" &&
+      typeof terminal.output === "object" &&
+      terminal.output !== null &&
+      !Array.isArray(terminal.output) &&
+      terminal.output.answer,
+    'fixture "quoted" answer',
+  )
+})
+
 test("Qoder treats a false JSON Schema as present and fails closed", async () => {
   const parent = await mkdtemp(path.join(os.tmpdir(), "qoder-false-schema-"))
   const request = await employeeRequest(parent, "run-false-schema")


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/91
- Consumed revision: R3
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-002 / AC-002 | `apps/cli/qoder-agent-host.ts`, `tests/apps/fixtures/fake-qoder.mjs`, `tests/apps/qoder-agent-host.test.ts` | Schema-bound runs whose model output contains unescaped double quotes inside string values now complete instead of failing as `qoder_output_not_json`; new `unescaped-quotes` fixture asserts the repaired answer, Qoder adapter suite PASS (50/50), and a live qodercli 1.1.24 rerun of the previously failing question exits 0. |

## File domains

- `apps/cli/qoder-agent-host.ts` — conservative `repairUnescapedQuotes` fallback inside `parseAndValidateOutput`: only quotes that cannot be string terminators (next structural character is not `,` `}` `]` `:` or end of input) are escaped; schema validation and all fail-closed codes unchanged. Task prompt additionally instructs the model to escape double quotes and backslashes inside string values.
- `tests/apps/fixtures/fake-qoder.mjs` — new `unescaped-quotes` fixture mode emitting an answer with raw unescaped quotes under the existing fixture contract.
- `tests/apps/qoder-agent-host.test.ts` — success-path test asserting the run completes with the repaired answer.

## Scope and non-goals

Scope: make schema-bound Qoder runs survive the common model defect of unescaped double quotes inside JSON string values, without weakening validation. Non-goals honored: no other repair heuristics (prose, fences, truncation still fail closed exactly as before); no protocol change; no other adapter touched; no dependency changed.

## Validation

- Exact commands: `npm run check`; `npx tsx --test tests/apps/qoder-agent-host.test.ts`; `node dist/apps/cli/bin.js run cases/team-qa --engine qoder --question "值班制度是怎样的？" --json`
- Observed counts/results: full local check PASS (1/1); Qoder adapter tests PASS (50/50); live rerun of the previously failing question PASS (1/1), exit 0 with schema-valid JSON
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/actions/runs/32111137076

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-002 | model output with unescaped quotes inside string values completes the run with the repaired value | `npx tsx --test tests/apps/qoder-agent-host.test.ts` over the `unescaped-quotes` fixture | Node 24, local HEAD | `run.completed` with answer `fixture "quoted" answer` | PASS (1/1) | PASS |
| V2 | AC-002 | all existing failure modes still fail closed unchanged | same command over the full fail-closed matrix (`invalid-output`, `prose-output`, `truncated-output`, `malformed-output`, schema mismatches, terminal codes) | Node 24, local HEAD | 50 tests PASS, no behavior change for existing codes | PASS (50/50) | PASS |
| V3 | AC-002 | the live question that previously failed now completes | `node dist/apps/cli/bin.js run cases/team-qa --engine qoder --question "值班制度是怎样的？" --json` | Node 24, qodercli 1.1.24, real PAT | exit 0, schema-valid JSON answer with citations | PASS (1/1) | PASS |
| V4 | REQ-001 / AC-001 | full `npm run check` green on PR head | CI | GitHub Actions | all required checks SUCCESS | local `npm run check` PASS (1/1); CI pending this PR's run | NOT VERIFIED: pending CI |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Fail-closed posture preserved: the repair only escapes quotes that cannot be string terminators, the repaired text must still `JSON.parse`, and schema validation runs unchanged on the result; prose, fences, truncation, and malformed output still fail closed with the same codes.
- [x] Compatibility: only the Qoder adapter plus its fixtures/tests change; Claude Code, Qwen Code, CodeBuddy, and Codex paths untouched; no dependency changed.
- [x] Pre-push L3 deep security review: 0 findings.

## Known limitations

The repair targets one specific defect class (unescaped double quotes inside string values). Other malformed outputs remain fail-closed by design. The repair is a bounded tolerance, not a protocol guarantee; the added prompt instruction reduces but cannot eliminate the defect.

## Risk and rollback

Single squash commit; revert is a one-commit revert. Outputs that already parse take the original path with zero behavior change; the repair path is only reached where the run previously failed, so it can only convert failures into schema-validated successes.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @Bindy-lbb
- Milestone or release packet: https://github.com/fullstack-ai-infra/digital-employee/issues/91
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
