### PR TITLE
chore(host): re-audit Codex CLI 0.148.0 for the default-deny contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Codex default-deny research is re-audited against stable Codex CLI 0.148.0
+  (release `rust-v0.148.0`, tag commit `3ba0f71`): the offline Responses
+  fixture still observes model-visible `apply_patch` after every expressible
+  tool reduction, four candidate removal surfaces are rejected by
+  `--strict-config` as unknown fields, and upstream closed the `apply_patch`
+  disable request as NOT_PLANNED (openai/codex#8161). The verdict stays
+  NO-GO / probe-only; the audit script and tests now pin 0.148.0 with a new
+  sanitized fixture, and `docs/agent-hosts.md` drops the stale 0.146.0
+  wording in favor of the 0.148.0/0.147.0 research records.
+
 ## [0.4.0] - 2026-08-16
 
 ### Added

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -1,6 +1,6 @@
 # Agent Host 状态与接入策略
 
-- 状态日期：2026-08-14
+- 状态日期：2026-08-19
 - 适用范围：当前源码树中的 `employee-package.v1alpha1`、`agent-host.v1`
 - 相关文档：[架构说明](architecture.md)、[员工包规范](employee-package.md)、[ADR 0001](decisions/0001-agent-host-boundary.md)
 
@@ -8,7 +8,7 @@
 
 `digital-employee` 不实现另一套通用 Agent loop。模型推理、上下文窗口、原生工具循环和宿主会话由 Agent Host 负责；本项目负责员工包、Host Adapter、能力协商、策略、标准事件，以及后续的通道、队列、审计和人工接力。
 
-当前源码中有四条版本锁定的 **runnable** 路径：Qoder CLI 1.1.x、Claude Code `>=2.1.214 <2.2.0`、Qwen Code `0.17.1` 和 CodeBuddy Code `2.106.4`。它们都是 one-shot、无状态、POSIX 本机/单租户技术预览；Qoder 只获得最小只读文件投影，另外三个是不暴露原生工具的 context-only Adapter。四条路径都不支持 MCP、附件、会话恢复、写工具或审批回调，也都没有使用真实模型权益验收。Windows 因尚无经过验证的 Job Object 进程树清理而 fail closed。Codex 仍是 **probe-only**：Codex CLI 0.146.0 无法可靠移除所有模型可见的内建工具，其中包括 `apply_patch`。
+当前源码中有四条版本锁定的 **runnable** 路径：Qoder CLI 1.1.x、Claude Code `>=2.1.214 <2.2.0`、Qwen Code `0.17.1` 和 CodeBuddy Code `2.106.4`。它们都是 one-shot、无状态、POSIX 本机/单租户技术预览；Qoder 只获得最小只读文件投影，另外三个是不暴露原生工具的 context-only Adapter。四条路径都不支持 MCP、附件、会话恢复、写工具或审批回调，也都没有使用真实模型权益验收。Windows 因尚无经过验证的 Job Object 进程树清理而 fail closed。Codex 仍是 **probe-only**：Codex CLI 0.148.0 无法可靠移除所有模型可见的内建工具，其中包括 `apply_patch`，详见 [0.148.0 复审](research/codex-cli-0.148.0-default-deny-audit.md)。
 
 官方产品文档只能证明某个宿主值得适配，不能把 `documented` 提升为本仓库的 `supported`。只有版本锁定、Adapter 实现和仓库内 Adapter 专用确定性 fixture 全部通过后，一项能力才能参与运行前兼容性判断。
 
@@ -61,7 +61,7 @@ v2 的全部 50 个向量；这些 fixture 不启动真实 Agent Host，也不�
 | --- | --- | --- | --- |
 | Qoder CLI 1.1.x | `runnable`；内置、版本锁定、只读 one-shot Adapter | 当前实现与测试见 [`qoder-agent-host.ts`](../apps/cli/qoder-agent-host.ts) 和 [验证账本](verification.md) | 最小只读文件投影，运行时校验精确的读/搜索工具集；`structured_output` 由 Adapter 严格终态校验，Schema 限 16 KiB 且必须同步；无效、超限或异步 Schema 在运行工作区投影、受限 `--version` 探针和模型进程前即拒绝；仍不是多租户在线服务 |
 | Claude Code `>=2.1.214 <2.2.0` | `runnable`；内置、版本锁定、context-only one-shot Adapter | 官方提供 [`claude -p` 与 `--bare`](https://code.claude.com/docs/en/headless)、JSON/stream-json、[权限](https://code.claude.com/docs/en/permissions)、[沙箱](https://code.claude.com/docs/en/sandboxing)、[MCP](https://code.claude.com/docs/en/mcp)、[Skills](https://code.claude.com/docs/en/skills) 和 [Agent SDK](https://code.claude.com/docs/en/agent-sdk/typescript) | `--bare --tools "" --strict-mcp-config --disable-slash-commands --no-session-persistence`，资产经 stdin 内联；只支持显式 `ANTHROPIC_API_KEY` |
-| Codex CLI | `probe-only`；仅检查本机命令和版本 | 官方提供 [`codex exec`](https://learn.chatgpt.com/docs/non-interactive-mode)、[JSONL 与输出 Schema](https://learn.chatgpt.com/docs/developer-commands?surface=cli#cli-codex-exec)、[MCP](https://learn.chatgpt.com/docs/extend/mcp)、[Skills](https://learn.chatgpt.com/docs/build-skills)；[App Server](https://learn.chatgpt.com/docs/app-server) 另有事件与 `turn/interrupt` | 已审计 0.146.0；即使禁用 shell/unified exec，`apply_patch` 等模型可见内建工具仍无法可靠全部移除，所以 `tool_allowlist` 保持 `unknown` |
+| Codex CLI | `probe-only`；仅检查本机命令和版本 | 官方提供 [`codex exec`](https://learn.chatgpt.com/docs/non-interactive-mode)、[JSONL 与输出 Schema](https://learn.chatgpt.com/docs/developer-commands?surface=cli#cli-codex-exec)、[MCP](https://learn.chatgpt.com/docs/extend/mcp)、[Skills](https://learn.chatgpt.com/docs/build-skills)；[App Server](https://learn.chatgpt.com/docs/app-server) 另有事件与 `turn/interrupt` | 已审计 0.148.0（[复审记录](research/codex-cli-0.148.0-default-deny-audit.md)，前次 0.147.0 记录见 [research](research/codex-cli-0.147.0-default-deny-audit.md)）；即使禁用 shell/unified exec，`apply_patch` 等模型可见内建工具仍无法可靠全部移除，候选移除配置也未被 `--strict-config` 接受，上游禁用 `apply_patch` 的请求已按 NOT_PLANNED 关闭（[openai/codex#8161](https://github.com/openai/codex/issues/8161)），所以 `tool_allowlist` 保持 `unknown` |
 | Qwen Code `0.17.1` | `runnable`；内置、精确版本锁定、context-only one-shot Adapter | 官方提供 [headless JSON/stream-json](https://qwenlm.github.io/qwen-code-docs/en/users/features/headless/)、[权限与沙箱](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/)、[MCP](https://qwenlm.github.io/qwen-code-docs/en/users/features/mcp/)、[Skills](https://qwenlm.github.io/qwen-code-docs/en/users/features/skills) 和 [TypeScript SDK](https://github.com/QwenLM/qwen-code/blob/main/packages/sdk-typescript/README.md) | 密封 UTF-8 资产经 stdin 内联，工具/MCP/slash-command 集为空；锁定 0.17.1 的不可调用内建 Agent 目录；要求显式 `OPENAI_API_KEY` 与 `OPENAI_MODEL`，可选 `OPENAI_BASE_URL` |
 | CodeBuddy Code `2.106.4` | `runnable`；内置、精确版本锁定、context-only one-shot Adapter | 官方提供 [headless JSON/双向 JSONL](https://www.workbuddy.ai/docs/cli/headless)、[权限与沙箱](https://www.workbuddy.ai/docs/cli/settings)、[MCP](https://www.workbuddy.ai/docs/cli/mcp)、[Skills](https://www.workbuddy.ai/docs/cli/skills)、[Python SDK](https://www.workbuddy.ai/docs/cli/sdk-python) 和 [Beta HTTP API](https://www.workbuddy.ai/docs/cli/http-api) | 密封 UTF-8 资产经 stdin 内联；空 `--tools` 不足以清空 2.106.4，Adapter 额外逐项 deny 该版本全部内建工具并校验最终工具/MCP 集为空；要求显式 `CODEBUDDY_API_KEY` 与 `CODEBUDDY_MODEL` |
 | QwenWork（千问办公） | 不在 Host registry | 官方定位是[办公工作台](https://qwenwork.cn/docs)，提供[定时任务](https://qwenwork.cn/docs/desktop/scheduled-tasks)、[IM 渠道](https://qwenwork.cn/docs/desktop/im-channels)和 [Skills](https://qwenwork.cn/docs/features/skills) | Workbench / Channel，不是当前 Agent Host；官方文档尚未给出本项目所需的稳定 headless 事件与取消契约 |

--- a/docs/research/codex-cli-0.148.0-default-deny-audit.md
+++ b/docs/research/codex-cli-0.148.0-default-deny-audit.md
@@ -1,0 +1,136 @@
+# Codex CLI 0.148.0 default-deny re-audit
+
+## Decision
+
+**NO-GO. Codex CLI 0.148.0 remains probe-only.** A deterministic local
+Responses fixture observed `apply_patch` in the model-visible `tools` request
+even after user config, shell, unified execution, Apps, plugins, Skill search,
+multi-agent, image, and workspace-dependency surfaces were disabled. A
+disabled web search, request-user-input, and update-plan surface did not
+remove `apply_patch`. A read-only sandbox or Prompt instruction cannot
+substitute for removing a disallowed tool.
+
+In addition, four candidate removal surfaces that this project had not yet
+probed were rejected by `--strict-config` as unrecognized fields on 0.148.0:
+`tools.apply_patch.enabled`, `--disable apply_patch`,
+`features.apply_patch`, and `tools.apply_patch="disabled"`. No config path
+exists in the audited release to express an apply-patch tool removal.
+
+Upstream intent is corroborating evidence, not a substitute for the dynamic
+probe: the request to allow disabling the built-in `apply_patch` tool was
+closed as not planned
+([openai/codex#8161](https://github.com/openai/codex/issues/8161),
+2026-02-23), and the broader request to disable built-in tools for MCP-only
+execution remains open without an enforcement surface
+([openai/codex#6049](https://github.com/openai/codex/issues/6049)).
+
+No runnable Adapter, registry entry, or support claim is introduced by this
+research result.
+
+## Fixed target and public sources
+
+- Official release: [`rust-v0.148.0`](https://github.com/openai/codex/releases/tag/rust-v0.148.0),
+  published as a non-prerelease on 2026-08-18.
+- Tag commit: [`3ba0f711642a888aec92a611a3f3b2211157ff89`](https://github.com/openai/codex/commit/3ba0f711642a888aec92a611a3f3b2211157ff89).
+- npm package: `@openai/codex@0.148.0`, Apache-2.0, integrity
+  `sha512-bh5kH9+BMrFaHGmLeoSansPdfRksvr4UXzjQInns/KRO7r8VJ+6AAW+SqUsE8XcG3+OW/mI4EEy8Gpo9UDXGvQ==`.
+- GitHub release archive `codex-aarch64-apple-darwin.tar.gz` SHA-256, as
+  published in the release asset metadata:
+  `758916aa38efa7ad076a050830fcbef1a7ed6f41efae9c1cceaeef63e428fc2b`.
+- Audited npm-package-extracted, signed darwin-arm64 executable SHA-256:
+  `b0308517b20543012fa2171aa3d46ce455a7456c4eb2a552ab9468ba4eeb1e50`.
+
+The archive digest and executable digest identify different byte sequences;
+the dynamic probe below executed the npm-package-extracted signed executable.
+
+The pinned source still registers `apply_patch` whenever an execution
+environment is present and the selected model declares an apply-patch tool
+type; the registration condition has no separate allowlist check:
+[`spec_plan.rs`](https://github.com/openai/codex/blob/3ba0f711642a888aec92a611a3f3b2211157ff89/codex-rs/core/src/tools/spec_plan.rs#L1101-L1105).
+The model-visible custom-tool definition is explicit in
+[`apply_patch_spec.rs`](https://github.com/openai/codex/blob/3ba0f711642a888aec92a611a3f3b2211157ff89/codex-rs/core/src/tools/handlers/apply_patch_spec.rs#L9-L25).
+Those source observations are E2 support for, not a replacement for, the E3
+dynamic inventory below.
+
+## Safety boundary
+
+The probe creates fresh temporary HOME, `CODEX_HOME`, XDG config/cache, temp,
+and workspace directories; passes a minimal environment allowlist with a
+non-secret placeholder; uses `--ignore-user-config` and `--ephemeral`; disables
+analytics; and points the only model provider at an HTTP fixture bound to
+`127.0.0.1`. The fixture accepts exactly `POST /v1/responses`, returns static
+Responses events, and performs no model inference. The prompt asks for no tool
+call, no tool output or model payload is saved, and the record contains no
+headers, credentials, prompts, private paths, or account state.
+
+No real provider was configured, and the expected loopback request was
+observed. External-network behavior and remote-write behavior were not
+independently measured and remain `NOT_VERIFIED`. The probe did not use a
+personal login, entitlement, paid model, or remote MCP server.
+
+## Reproduction
+
+Set `CODEX_BIN` to the official 0.148.0 binary from the pinned npm package,
+then run:
+
+```bash
+node scripts/audit-codex-host.js --codex-bin "$CODEX_BIN"
+```
+
+The script refuses any version other than 0.148.0. Its bounded `codex exec`
+invocation uses:
+
+```text
+--strict-config --ephemeral --ignore-user-config --skip-git-repo-check
+--sandbox read-only --json --model gpt-5.2
+--disable shell_tool --disable unified_exec --disable apps
+--disable plugins --disable skill_search --disable multi_agent
+--disable view_image --disable workspace_dependencies
+analytics.enabled=false
+web_search="disabled"
+tools.experimental_request_user_input.enabled=false
+tools.update_plan.enabled=false
+```
+
+Observed sanitized record:
+[`tests/fixtures/agent-hosts/codex-cli-0.148.0-no-go.json`](../../tests/fixtures/agent-hosts/codex-cli-0.148.0-no-go.json).
+
+The model-visible tools were exactly:
+
+```json
+["apply_patch"]
+```
+
+The CLI exited 0 and emitted `thread.started`, `turn.started`, and
+`turn.completed`. This is E3 evidence for the tool inventory and the stable
+NO-GO blocker. It is not proof of adversarial event validation or cleanup.
+
+## Qualification vector ledger
+
+| #30 / R2 vector | Result | Evidence and boundary |
+| --- | --- | --- |
+| Model-visible tool removal | **FAIL (E3)** | After every expressible tool reduction above, the dynamic request inventory still contains disallowed `apply_patch`. Candidate removal surfaces (`tools.apply_patch.enabled`, `--disable apply_patch`, `features.apply_patch`, `tools.apply_patch="disabled"`) are not accepted by `--strict-config` on this release. |
+| Pinned source registration path | **FAIL-supporting (E2)** | Exact-tag source registers `apply_patch` from model metadata whenever an environment exists, with no allowlist check. |
+| Native event validation | OBSERVED, NOT QUALIFIED | Three lifecycle event types were observed; malformed, duplicate, and post-terminal cases were not exercised. |
+| Single terminal outcome | NOT VERIFIED | One nominal static response is not an adversarial terminal-outcome test. |
+| Deadline / cancellation | NOT VERIFIED | No App Server `turn/interrupt` or deadline race was executed. |
+| Process-tree cleanup | NOT VERIFIED | No child/grandchild fixture was launched through a Codex Adapter. |
+| Credential boundary | NOT VERIFIED | The probe uses no real credential, but did not test rejection or leak paths. |
+| Filesystem enforcement | NOT VERIFIED | `--sandbox read-only` was configured; no hostile write was executed. Tool visibility already fails admission. |
+| Network enforcement | NOT VERIFIED | Only loopback transport was used; no adversarial external-network attempt was executed. |
+| MCP isolation | NOT VERIFIED | No MCP server was configured or exercised. |
+| Skill / plugin isolation | NOT VERIFIED | Features were disabled, but no hostile Skill or plugin fixture was exercised. |
+| Output Schema behavior | NOT VERIFIED | No schema success/failure fixture was executed. |
+
+## Three independent axes
+
+| Axis | Result | Reason |
+| --- | --- | --- |
+| `implemented` | `false` | No Codex `agent-host.v1` Adapter is introduced. |
+| `fixture-conformant` | `false` | Mandatory default-deny tool enforcement fails at the dynamic inventory step. |
+| `live-qualified` | `false` | Live provider/authentication/model use was intentionally prohibited. |
+
+The next re-audit trigger is a stable upstream interface that can enforce an
+explicit model-visible built-in tool allowlist (including removal of
+`apply_patch`) for a normal execution environment. Until then, issue #34
+remains research-only and Codex remains probe-only.

--- a/scripts/audit-codex-host.js
+++ b/scripts/audit-codex-host.js
@@ -8,7 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-export const AUDITED_CODEX_VERSION = "0.147.0";
+export const AUDITED_CODEX_VERSION = "0.148.0";
 export const AUDIT_SCHEMA = "codex-host-research-record.v1";
 export const MAX_LOOPBACK_REQUEST_BYTES = 4 * 1024 * 1024;
 

--- a/tests/fixtures/agent-hosts/codex-cli-0.148.0-no-go.json
+++ b/tests/fixtures/agent-hosts/codex-cli-0.148.0-no-go.json
@@ -1,0 +1,38 @@
+{
+  "schema": "codex-host-research-record.v1",
+  "auditedHost": "codex-cli",
+  "auditedVersion": "0.148.0",
+  "policy": "digital-employee-default-deny.v1",
+  "transport": "loopback-responses-fixture",
+  "realProviderConfigured": false,
+  "loopbackRequestObserved": true,
+  "modelVisibleTools": [
+    "apply_patch"
+  ],
+  "eventTypes": [
+    "thread.started",
+    "turn.completed",
+    "turn.started"
+  ],
+  "processExitCode": 0,
+  "axes": {
+    "implemented": false,
+    "fixtureConformant": false,
+    "liveQualified": false
+  },
+  "vectors": {
+    "modelVisibleToolRemoval": "FAIL_E3",
+    "nativeEventValidation": "OBSERVED_NOT_QUALIFIED",
+    "singleTerminalOutcome": "NOT_VERIFIED",
+    "deadlineAndCancel": "NOT_VERIFIED",
+    "processTreeCleanup": "NOT_VERIFIED",
+    "credentialBoundary": "NOT_VERIFIED",
+    "filesystemEnforcement": "NOT_VERIFIED",
+    "networkEnforcement": "NOT_VERIFIED",
+    "mcpIsolation": "NOT_VERIFIED",
+    "skillPluginIsolation": "NOT_VERIFIED",
+    "outputSchema": "NOT_VERIFIED"
+  },
+  "verdict": "NO_GO",
+  "blocker": "model_visible_disallowed_tool:apply_patch"
+}

--- a/tests/scripts/audit-codex-host.test.ts
+++ b/tests/scripts/audit-codex-host.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../../scripts/audit-codex-host.js";
 
 const expectedFixture = new URL(
-  "../fixtures/agent-hosts/codex-cli-0.147.0-no-go.json",
+  "../fixtures/agent-hosts/codex-cli-0.148.0-no-go.json",
   import.meta.url
 );
 
@@ -115,7 +115,7 @@ test("the probe refuses a binary outside the audited version", async () => {
   try {
     await writeFile(binary, fakeCodexSource("0.146.0"), { mode: 0o755 });
     await chmod(binary, 0o755);
-    await assert.rejects(auditCodex(binary), /expected codex-cli 0\.147\.0/);
+    await assert.rejects(auditCodex(binary), /expected codex-cli 0\.148\.0/);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/34
- Consumed revision: R2
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 (the bounded Codex re-audit obligation carried by Issue #34 at revision R2; REQ-001 = re-audit the current stable Codex CLI against the default-deny policy and record reproducible evidence; AC-001 = record audited version, exact commands, observed model-visible tool set, and the three axes independently, keeping Codex probe-only while any mandatory boundary is unavailable) | `scripts/audit-codex-host.js`, `tests/scripts/audit-codex-host.test.ts`, `tests/fixtures/agent-hosts/codex-cli-0.148.0-no-go.json`, `docs/research/codex-cli-0.148.0-default-deny-audit.md`, `docs/agent-hosts.md`, `CHANGELOG.md` | Offline loopback Responses fixture re-run against the official signed 0.148.0 darwin-arm64 binary: model-visible tools exactly `["apply_patch"]`, verdict NO_GO; reproduced record byte-identical to the checked-in fixture; audit suite PASS (10/10). |

## File domains

- `scripts/audit-codex-host.js` — version pin bumped 0.147.0 → 0.148.0; no probe logic change.
- `tests/scripts/audit-codex-host.test.ts` — fixture URL and version-refusal regex follow the new pin.
- `tests/fixtures/agent-hosts/codex-cli-0.148.0-no-go.json` — new sanitized NO-GO record; the 0.147.0 fixture is kept as historical evidence.
- `docs/research/codex-cli-0.148.0-default-deny-audit.md` — full re-audit record: release/tag/npm-integrity/archive/executable digests, E2 source pointers at tag commit 3ba0f71 (spec_plan.rs L1101-L1105 unconditional apply_patch registration), four candidate removal surfaces rejected by `--strict-config`, upstream NOT_PLANNED evidence (openai/codex#8161), vector ledger, and unchanged re-audit trigger.
- `docs/agent-hosts.md` — stale 0.146.0 wording replaced by the 0.148.0 conclusion with links to both research records; status date bumped.
- `CHANGELOG.md` — Unreleased entry.

## Scope and non-goals

Scope: refresh the Codex default-deny research evidence to the current stable release (0.148.0). Non-goals honored: no runnable Adapter, no registry entry, no support claim, no probe behavior change, no dependency change. Issue #34 stays open; this PR records one bounded go/no-go result for the R2 trigger.

## Validation

- Exact commands: `npx tsx --test tests/scripts/audit-codex-host.test.ts`, `node ./scripts/audit-codex-host.js --codex-bin "$CODEX_BIN"` with the npm-package-extracted signed 0.148.0 binary, `node ./scripts/requirement-governance-check.js`, `node ./scripts/security-check.js`
- Observed counts/results: audit suite PASS 10/10; real-binary reproduction matches the checked-in fixture PASS 1/1 (verdict NO_GO); governance check PASS 1/1; security check PASS 1/1
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/pull/131/checks

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-001 | 0.148.0 dynamic inventory still exposes model-visible apply_patch under every expressible tool reduction | Run `node ./scripts/audit-codex-host.js --codex-bin "$CODEX_BIN"` against the signed 0.148.0 binary over the loopback fixture | macOS arm64, Node 24, @openai/codex@0.148.0 | modelVisibleTools `["apply_patch"]`, verdict NO_GO | matches | PASS |
| V2 | AC-001 | The checked-in sanitized fixture reproduces the real probe byte-for-byte | Deep-equal the live record against `tests/fixtures/agent-hosts/codex-cli-0.148.0-no-go.json` | same as V1 | byte-identical, sanitized | matches fixture: true | PASS |
| V3 | REQ-001 | The audit suite pins the new version and refuses other versions | Run `npx tsx --test tests/scripts/audit-codex-host.test.ts` | Node 24 | 10/10 PASS | 10/10 | PASS |

## Security and compatibility

- No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included; the record is sanitized by construction and the reproducibility test asserts it.
- Fail-closed posture preserved: probe-only status unchanged; no runtime code path changes.
- Compatibility: audit script/tests/docs/fixture/changelog only; no package API change; the 0.147.0 fixture remains as frozen history.

## Known limitations

- This is research evidence, not Host qualification: filesystem/network enforcement, cancellation, process-tree cleanup, MCP/Skill isolation, and output Schema behavior remain NOT VERIFIED in the 0.148.0 ledger.
- The audit ran on darwin-arm64 only; other platforms are out of scope for this re-audit.
- Upstream openai/codex#8161 is NOT_PLANNED and #6049 is open, so the blocker is expected to persist until upstream adds an enforceable model-visible tool allowlist.

## Risk and rollback

- Risk: low. Research docs, a version pin constant, a fixture, and the changelog only; no runtime behavior changes. If the pin bump conflicts with another in-flight audit, revert is safe because the 0.147.0 record and fixture remain in the tree.
- Rollback: revert the squashed commit; `docs/agent-hosts.md` falls back to the 0.147.0 wording and the audit script pins 0.147.0 again.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @Bindy-lbb
- Milestone or release packet: https://github.com/fullstack-ai-infra/digital-employee/issues/34
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
