### PR TITLE
feat(i18n): pin JSON-only locale discovery on the built CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ All notable changes to this project will be documented in this file.
   sanitized fixture, and `docs/agent-hosts.md` drops the stale 0.146.0
   wording in favor of the 0.148.0/0.147.0 research records.
 
+### Fixed
+
+- Deploy i18n malformed-catalog handling is now observable and pinned by
+  built-CLI tests (#79). A catalog that fails JSON parsing or has a
+  non-object root falls back to canonical English with a single `[i18n]`
+  stderr warning instead of silently or unsafely loading. New
+  `tests/apps/deploy-i18n-discovery.test.ts` proves on the built CLI that a
+  JSON-only synthetic locale is discovered and rendered without any
+  TypeScript registration, that malformed catalogs fall back to English, and
+  that an explicitly unsupported `--locale` exits nonzero;
+  `locales/README.md` documents the exact built-CLI verification commands.
+
 ## [0.4.0] - 2026-08-16
 
 ### Added

--- a/apps/cli/deploy/i18n.ts
+++ b/apps/cli/deploy/i18n.ts
@@ -151,6 +151,12 @@ export function setLocale(locale: SupportedLocale): void {
   try {
     parsed = JSON.parse(raw) as Record<string, unknown>
   } catch {
+    parsed = null as unknown as Record<string, unknown>
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    process.stderr.write(
+      `[i18n] failed to parse ${locale}.json; falling back to English\n`,
+    )
     messages = { ...fallbackMessages }
     currentLocale = "en"
     return

--- a/locales/README.md
+++ b/locales/README.md
@@ -35,5 +35,27 @@ validation errors are logged to stderr as warnings — they don't block loading
 since missing keys fall back to English. Add `"locale.display_name"` and all
 keys present in `en.json` to keep validation clean.
 
+A catalog that cannot be parsed as JSON, or whose root is not a JSON object,
+is treated as malformed: the CLI writes a single `[i18n] failed to parse
+{locale}.json` warning to stderr and serves canonical English instead. It
+never crashes and never serves a half-loaded catalog. An explicitly requested
+unsupported `--locale` is rejected as invalid input (nonzero exit).
+
 To validate all locale files at once during CI, use `npm run check` which
 exercises the test suite including the AC-002 validation tests.
+
+## Verify against the built CLI
+
+After adding a catalog, prove discovery and rendering against the built CLI
+(no TypeScript changes required):
+
+```bash
+npm run build --silent
+node ./dist/apps/cli/bin.js deploy --help --locale {locale-code}
+```
+
+The new locale code must appear in the supported locale list and the help
+text must render from your catalog. Built-CLI discovery, malformed-catalog
+fallback, and fail-closed `--locale` handling are pinned by
+`tests/apps/deploy-i18n-discovery.test.ts`, which runs on Node 20, 22, and 24
+in CI.

--- a/tests/apps/deploy-i18n-discovery.test.ts
+++ b/tests/apps/deploy-i18n-discovery.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import { cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const dist = path.join(root, "dist")
+const builtCli = path.join(dist, "apps", "cli", "bin.js")
+
+function cliEnvironment(home: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = { ...process.env }
+  delete environment.LANG
+  delete environment.LC_ALL
+  return {
+    ...environment,
+    HOME: home,
+    PATH: [path.dirname(process.execPath), "/usr/bin", "/bin"].join(path.delimiter),
+    ...extra,
+  }
+}
+
+function runBin(
+  entry: string,
+  args: string[],
+  environment: NodeJS.ProcessEnv,
+  cwd: string,
+) {
+  return spawnSync(process.execPath, [entry, ...args], {
+    cwd,
+    env: environment,
+    encoding: "utf8",
+    input: "",
+    timeout: 20_000,
+    maxBuffer: 1024 * 1024,
+  })
+}
+
+/**
+ * Copy the built dist/ tree into a temporary install-shaped layout so a
+ * synthetic locale can be dropped into dist/locales without touching the
+ * repository. This mirrors the shipped package: locales are discovered
+ * relative to the built tree, not registered in TypeScript.
+ */
+async function copiedBuiltCli(
+  t: test.TestContext,
+  label: string,
+): Promise<{ bin: string; localesDir: string; home: string }> {
+  assert.ok(existsSync(builtCli), "built CLI missing: run `npm run build` before this suite")
+  const temporary = await mkdtemp(path.join(os.tmpdir(), `i18n-discovery-${label}-`))
+  t.after(async () => rm(temporary, { recursive: true, force: true }))
+  const copiedDist = path.join(temporary, "dist")
+  await cp(dist, copiedDist, { recursive: true })
+  await symlink(path.join(root, "node_modules"), path.join(copiedDist, "node_modules"), "dir")
+  const home = path.join(temporary, "home")
+  await mkdir(home)
+  return {
+    bin: path.join(copiedDist, "apps", "cli", "bin.js"),
+    localesDir: path.join(copiedDist, "locales"),
+    home,
+  }
+}
+
+test("AC-001: a JSON-only synthetic locale is discovered and rendered by the built CLI", async (t) => {
+  const { bin, localesDir, home } = await copiedBuiltCli(t, "synthetic")
+  const reference = JSON.parse(
+    await readFile(path.join(localesDir, "en.json"), "utf8"),
+  ) as Record<string, string>
+  const synthetic: Record<string, string> = { "locale.display_name": "Synthetic Fixture" }
+  for (const [key, value] of Object.entries(reference)) {
+    if (key === "locale.display_name") continue
+    synthetic[key] = `XX·${value}`
+  }
+  await writeFile(
+    path.join(localesDir, "xx-XX.json"),
+    `${JSON.stringify(synthetic, null, 2)}\n`,
+    "utf8",
+  )
+  const result = runBin(bin, ["deploy", "--help", "--locale", "xx-XX"], cliEnvironment(home), home)
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(result.stderr, "")
+  assert.match(result.stdout, /xx-XX/, "discovered locale must appear in the supported list")
+  assert.match(result.stdout, /XX·/, "deploy help must render from the synthetic catalog")
+  assert.match(result.stdout, /Synthetic Fixture|xx-XX/)
+})
+
+test("AC-002: a malformed catalog falls back to English with an observable warning", async (t) => {
+  const { bin, localesDir, home } = await copiedBuiltCli(t, "malformed")
+  await writeFile(path.join(localesDir, "yy.json"), "{ not valid json", "utf8")
+  const result = runBin(
+    bin,
+    ["deploy", "--help"],
+    cliEnvironment(home, { LANG: "yy_YY.UTF-8" }),
+    home,
+  )
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stderr, /\[i18n\] failed to parse yy\.json/)
+  assert.match(result.stdout, /digital-employee deploy \[package-path\]/)
+  assert.doesNotMatch(result.stdout, /XX·/)
+})
+
+test("AC-002: a non-object catalog root falls back to English without crashing", async (t) => {
+  const { bin, localesDir, home } = await copiedBuiltCli(t, "non-object")
+  await writeFile(path.join(localesDir, "zz.json"), "null", "utf8")
+  const result = runBin(
+    bin,
+    ["deploy", "--help"],
+    cliEnvironment(home, { LANG: "zz_ZZ.UTF-8" }),
+    home,
+  )
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stderr, /\[i18n\] failed to parse zz\.json/)
+  assert.match(result.stdout, /digital-employee deploy \[package-path\]/)
+})
+
+test("AC-002: an explicitly unsupported --locale stays fail-closed with a nonzero exit", async (t) => {
+  const { bin, home } = await copiedBuiltCli(t, "unsupported")
+  const result = runBin(bin, ["deploy", "--help", "--locale", "qq-QQ"], cliEnvironment(home), home)
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /locale/)
+})


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/79
- Consumed revision: R2
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 (JSON-only locale extension discoverable by the built CLI without TypeScript registration) | `tests/apps/deploy-i18n-discovery.test.ts` | Built-CLI test copies dist/ to an install-shaped temp tree, drops one synthetic `xx-XX.json` catalog derived from `en.json`, runs `deploy --help --locale xx-XX`, asserts exit 0, empty stderr, the locale in the supported list, and synthetic values rendered; no locale-registration TypeScript exists in the diff. |
| REQ-002 / AC-002 (deterministic fallback and validation) | `apps/cli/deploy/i18n.ts`, `tests/apps/deploy-i18n-discovery.test.ts` | Malformed JSON and non-object catalog roots now fall back to canonical English with one observable `[i18n]` stderr warning; an explicitly unsupported `--locale` exits nonzero. Built-CLI tests pin all three branches; existing `deploy-i18n.test.ts` suite passes 22/22. |
| REQ-003 / AC-003 (contribution and release contract) | `locales/README.md`, `CHANGELOG.md` | README documents malformed-catalog semantics and the exact built-CLI verification commands; the new suite runs on the Node 20/22/24 CI matrix. |

## File domains

- `apps/cli/deploy/i18n.ts` — `setLocale` now writes a single `[i18n] failed to parse {locale}.json` stderr warning and falls back to English when a catalog fails JSON parsing or its root is not a plain object; no discovery, fallback-key, or interpolation logic changed.
- `tests/apps/deploy-i18n-discovery.test.ts` — new built-CLI suite: synthetic-locale discovery/rendering (AC-001), malformed and non-object catalog fallback (AC-002), fail-closed explicit `--locale` rejection (AC-002).
- `locales/README.md` — malformed-catalog behavior and the exact `npm run build` + `deploy --help --locale` verification commands.
- `CHANGELOG.md` — Unreleased Fixed entry.

## Scope and non-goals

Scope: close the remaining #79 R2 evidence gaps — real built-CLI proof of JSON-only discovery, observable malformed-catalog fallback, and documented verification commands. Non-goals honored: no new locales claimed, no TypeScript registration added, no fallback weakened, no `--locale` error semantics changed (still owned by the #86 fail-closed path), no document translation sweep.

## Validation

- Exact commands: `npm run build --silent`, `npx tsx --test tests/apps/deploy-i18n-discovery.test.ts`, `npx tsx --test tests/apps/deploy-i18n.test.ts`, `npm run typecheck`, `node ./scripts/requirement-governance-check.js`, `node ./scripts/security-check.js`
- Observed counts/results: discovery suite PASS 4/4; existing i18n suite PASS 22/22; typecheck PASS 1/1; governance PASS 1/1; security PASS 1/1
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/pull/132/checks

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-001 | A JSON-only synthetic locale is discovered and rendered by the built CLI with zero TypeScript registration | Run `npx tsx --test tests/apps/deploy-i18n-discovery.test.ts` and inspect the synthetic test | macOS arm64, Node 24, built dist | exit 0, empty stderr, `xx-XX` listed and `XX·` values rendered | matches | PASS |
| V2 | AC-002 | Malformed and non-object catalogs fall back to English with an observable warning | same suite, malformed/non-object tests | same | exit 0, `[i18n] failed to parse` on stderr, English help rendered | matches | PASS |
| V3 | AC-002 | An explicitly unsupported `--locale` stays fail closed | same suite, unsupported test | same | nonzero exit, locale input error on stderr | matches | PASS |
| V4 | AC-003 | Documented built-CLI commands reproduce discovery for a contributor | Run `npm run build --silent` then `node ./dist/apps/cli/bin.js deploy --help --locale zh-CN` | same | localized help renders, no undocumented steps | matches | PASS |

## Security and compatibility

- No credentials, personal identifiers, or private paths are introduced; tests use isolated temp HOMEs and synthetic fixtures only.
- Fail-closed posture preserved: unsupported explicit locales still exit nonzero; malformed catalogs never serve half-loaded values.
- Compatibility: deploy i18n runtime behavior changes only for catalogs that were already broken (previously silent fallback, now warned); shipped `en`/`zh-CN`/`ja` catalogs are untouched and still pass validation.

## Known limitations

- The synthetic-locale proof runs on the built dist tree, not a published npm tarball; the package-consumer CI job separately verifies tarball contents include `dist/locales/*`.
- Windows behavior is not separately exercised here; the repo remains POSIX-focused for runnable paths.

## Risk and rollback

- Risk: low. One stderr warning added for catalogs that previously failed silently; discovery/fallback logic otherwise unchanged, and all existing i18n tests pass.
- Rollback: revert the squashed commit; the CLI returns to silent malformed-catalog fallback and the new suite/README section disappear with it.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @Bindy-lbb
- Milestone or release packet: https://github.com/fullstack-ai-infra/digital-employee/issues/79
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
