### PR TITLE
feat(adapters): share one synchronous Schema preflight guard across runnable Adapters (#113 AC-002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Claude, Qwen, CodeBuddy and Qoder now share one synchronous output-Schema
+  preflight guard (`apps/cli/output-schema-guard.ts`, #113): invalid,
+  oversized (>16 KiB), `$async:true` and otherwise unsupported Schemas are
+  rejected before any version probe, projection or model process, and each
+  run prepares exactly one Schema snapshot that projection and terminal
+  validation both consume — the stream layer never recompiles or re-accepts
+  a Schema. Claude, Qwen and CodeBuddy preflight previously probed first,
+  and Qwen/CodeBuddy recompiled Ajv at the terminal; both behaviors are
+  gone. New deterministic regressions prove the shared guard unit contract
+  and that each of the three adapters fails closed with its typed code,
+  zero version-probe calls and no model spawn for invalid/`$async`/oversized
+  Schemas; Schema-absent requests keep the existing unstructured behavior.
 - Codex default-deny research is re-audited against stable Codex CLI 0.148.0
   (release `rust-v0.148.0`, tag commit `3ba0f71`): the offline Responses
   fixture still observes model-visible `apply_patch` after every expressible

--- a/apps/cli/claude-agent-host.ts
+++ b/apps/cli/claude-agent-host.ts
@@ -5,7 +5,6 @@ import os from "node:os"
 import path from "node:path"
 import { createInterface } from "node:readline"
 import type { Readable, Writable } from "node:stream"
-import { Ajv2020 } from "ajv/dist/2020.js"
 
 import {
   AGENT_HOST_PROTOCOL_VERSION,
@@ -37,6 +36,7 @@ import {
   readInlineAgentAssets,
 } from "./inline-agent-projection.js"
 import type { InlineAgentAsset } from "./inline-agent-projection.js"
+import { prepareOutputSchemaSnapshot } from "./output-schema-guard.js"
 
 const CLAUDE_HOST_ID = "claude-code"
 const CLAUDE_DISPLAY_NAME = "Claude Code"
@@ -48,7 +48,6 @@ const CLEANUP_ATTEMPTS = 2
 const CLEANUP_ATTEMPT_TIMEOUT_MS = 2_000
 const MAX_PROMPT_BYTES = 256 * 1024
 const MAX_INSTRUCTIONS_BYTES = 128 * 1024
-const MAX_SCHEMA_BYTES = 16 * 1024
 const MAX_STDIN_BYTES = 512 * 1024
 const MAX_STDOUT_BYTES = 4 * 1024 * 1024
 const MAX_STDERR_BYTES = 256 * 1024
@@ -108,6 +107,7 @@ interface PreparedRun {
 interface PreparedOutputSchema {
   json: string
   value: SafeValue
+  validate: (candidate: unknown) => boolean
 }
 
 export interface ClaudeAgentHostAdapterOptions {
@@ -208,29 +208,11 @@ function validateIdentifier(value: string, code: string): void {
 function serializeAndValidateSchema(
   schema: SafeValue | undefined,
 ): PreparedOutputSchema | undefined {
-  if (schema === undefined) return undefined
-  let serialized: string | undefined
-  try {
-    serialized = JSON.stringify(schema)
-    if (!serialized || byteLength(serialized) > MAX_SCHEMA_BYTES) {
-      throw new ClaudeAdapterError("claude_output_schema_too_large")
-    }
-    const ajv = new Ajv2020({
-      allErrors: true,
-      allowUnionTypes: true,
-      strict: false,
-      validateSchema: true,
-    })
-    const value = JSON.parse(serialized) as SafeValue
-    const validate = ajv.compile(value as object)
-    if ("$async" in validate && validate.$async === true) {
-      throw new ClaudeAdapterError("claude_output_schema_invalid")
-    }
-    return { json: serialized, value }
-  } catch (error) {
-    if (error instanceof ClaudeAdapterError) throw error
-    throw new ClaudeAdapterError("claude_output_schema_invalid")
-  }
+  return prepareOutputSchemaSnapshot(schema, {
+    tooLarge: () => new ClaudeAdapterError("claude_output_schema_too_large"),
+    invalid: () => new ClaudeAdapterError("claude_output_schema_invalid"),
+    isGuardError: (error) => error instanceof ClaudeAdapterError,
+  })
 }
 
 function validateRequestShape(
@@ -627,6 +609,31 @@ export class ClaudeAgentHostAdapter implements AgentHostAdapter {
   }
 
   async preflight(request: AgentHostRunRequest): Promise<AgentHostProbeResult> {
+    try {
+      serializeAndValidateSchema(request.outputSchema)
+    } catch (error) {
+      const code =
+        error instanceof ClaudeAdapterError
+          ? error.code
+          : "claude_policy_projection_failed"
+      return {
+        protocolVersion: AGENT_HOST_PROTOCOL_VERSION,
+        hostId: CLAUDE_HOST_ID,
+        displayName: CLAUDE_DISPLAY_NAME,
+        status: "not_ready",
+        available: false,
+        adapterStatus: "runnable",
+        capabilities: capabilities(),
+        capabilitySource: "conformance_test",
+        issues: [
+          issue(
+            code,
+            "Claude Code cannot safely validate this output Schema",
+          ),
+        ],
+      }
+    }
+
     const probe = await this.probe(request.signal)
     const issues = [...probe.issues]
     try {
@@ -688,6 +695,9 @@ export class ClaudeAgentHostAdapter implements AgentHostAdapter {
 
       const beforePrepareError = stoppedRunError(active)
       if (beforePrepareError) throw beforePrepareError
+      // The shared Schema guard fails closed before any probe, projection or
+      // model process; prepareRun re-checks deterministically below.
+      serializeAndValidateSchema(request.outputSchema)
       const probe = await this.probe(request.signal)
       const afterProbeError = stoppedRunError(active)
       if (afterProbeError) throw afterProbeError
@@ -909,7 +919,7 @@ export class ClaudeAgentHostAdapter implements AgentHostAdapter {
 
       let completion
       try {
-        completion = normalizer.finish(prepared.outputSchema?.value)
+        completion = normalizer.finish(prepared.outputSchema?.validate)
       } catch (error) {
         if (error instanceof ClaudeStreamProtocolError) {
           throw new ClaudeAdapterError(error.code, error.retryable)

--- a/apps/cli/claude-stream-agent-host.ts
+++ b/apps/cli/claude-stream-agent-host.ts
@@ -1,5 +1,3 @@
-import { Ajv2020 } from "ajv/dist/2020.js"
-
 import { redactText } from "../../packages/core/src/contracts.js"
 import type {
   AgentHostEvent,
@@ -114,26 +112,13 @@ function normalizeOutputValue(
 
 function validateStructuredOutput(
   value: unknown,
-  schema: SafeValue,
+  validate: (candidate: unknown) => boolean,
 ): SafeValue {
   const normalized = normalizeOutputValue(value)
-  try {
-    const ajv = new Ajv2020({
-      allErrors: true,
-      allowUnionTypes: true,
-      strict: false,
-      validateSchema: true,
-    })
-    const validate = ajv.compile(schema as object)
-    if ("$async" in validate && validate.$async === true) {
-      throw new ClaudeStreamProtocolError("claude_output_schema_invalid")
-    }
-    if (validate(normalized) !== true) {
-      throw new ClaudeStreamProtocolError("claude_output_schema_mismatch")
-    }
-  } catch (error) {
-    if (error instanceof ClaudeStreamProtocolError) throw error
-    throw new ClaudeStreamProtocolError("claude_output_schema_invalid")
+  // The validator is the Adapter's one prepared synchronous Schema
+  // snapshot; the stream layer never recompiles or re-accepts a Schema.
+  if (!validate(normalized)) {
+    throw new ClaudeStreamProtocolError("claude_output_schema_mismatch")
   }
   return normalized
 }
@@ -412,7 +397,9 @@ export class ClaudeZeroToolStreamNormalizer {
     throw new ClaudeStreamProtocolError("claude_stream_unknown_event")
   }
 
-  finish(outputSchema: SafeValue | undefined): ClaudeStreamCompletion {
+  finish(
+    outputValidator: ((candidate: unknown) => boolean) | undefined,
+  ): ClaudeStreamCompletion {
     if (!this.initSeen) {
       throw new ClaudeStreamProtocolError("claude_init_missing")
     }
@@ -424,7 +411,7 @@ export class ClaudeZeroToolStreamNormalizer {
     }
 
     let output: SafeValue
-    if (outputSchema !== undefined) {
+    if (outputValidator !== undefined) {
       if (typeof this.result.result !== "string") {
         throw new ClaudeStreamProtocolError("claude_result_text_missing")
       }
@@ -434,7 +421,7 @@ export class ClaudeZeroToolStreamNormalizer {
       } catch {
         throw new ClaudeStreamProtocolError("claude_output_not_json")
       }
-      output = validateStructuredOutput(parsed, outputSchema)
+      output = validateStructuredOutput(parsed, outputValidator)
     } else {
       if (typeof this.result.result !== "string") {
         throw new ClaudeStreamProtocolError("claude_result_text_missing")

--- a/apps/cli/codebuddy-agent-host.ts
+++ b/apps/cli/codebuddy-agent-host.ts
@@ -17,7 +17,6 @@ import os from "node:os"
 import path from "node:path"
 import { createInterface } from "node:readline"
 import type { Readable, Writable } from "node:stream"
-import { Ajv2020 } from "ajv/dist/2020.js"
 
 import {
   AGENT_HOST_PROTOCOL_VERSION,
@@ -44,6 +43,7 @@ import {
   readInlineAgentAssets,
 } from "./inline-agent-projection.js"
 import type { InlineAgentAsset } from "./inline-agent-projection.js"
+import { prepareOutputSchemaSnapshot } from "./output-schema-guard.js"
 
 const CODEBUDDY_HOST_ID = "codebuddy"
 const CODEBUDDY_DISPLAY_NAME = "CodeBuddy Code"
@@ -54,7 +54,6 @@ const CLEANUP_ATTEMPTS = 2
 const CLEANUP_ATTEMPT_TIMEOUT_MS = 2_000
 const MAX_PROMPT_BYTES = 256 * 1024
 const MAX_INSTRUCTIONS_BYTES = 128 * 1024
-const MAX_SCHEMA_BYTES = 16 * 1024
 const MAX_STDIN_BYTES = 512 * 1024
 const MAX_STDOUT_BYTES = 4 * 1024 * 1024
 const MAX_STDERR_BYTES = 256 * 1024
@@ -148,6 +147,7 @@ interface PreparedRun {
 interface PreparedOutputSchema {
   json: string
   value: SafeValue
+  validate: (candidate: unknown) => boolean
 }
 
 interface ValidatedConfiguration {
@@ -269,29 +269,11 @@ function validateIdentifier(value: string, code: string): void {
 function serializeAndValidateSchema(
   schema: SafeValue | undefined,
 ): PreparedOutputSchema | undefined {
-  if (schema === undefined) return undefined
-  let serialized: string | undefined
-  try {
-    serialized = JSON.stringify(schema)
-    if (!serialized || byteLength(serialized) > MAX_SCHEMA_BYTES) {
-      throw new CodeBuddyAdapterError("codebuddy_output_schema_too_large")
-    }
-    const ajv = new Ajv2020({
-      allErrors: true,
-      allowUnionTypes: true,
-      strict: false,
-      validateSchema: true,
-    })
-    const value = JSON.parse(serialized) as SafeValue
-    const validate = ajv.compile(value as object)
-    if ("$async" in validate && validate.$async === true) {
-      throw new CodeBuddyAdapterError("codebuddy_output_schema_invalid")
-    }
-    return { json: serialized, value }
-  } catch (error) {
-    if (error instanceof CodeBuddyAdapterError) throw error
-    throw new CodeBuddyAdapterError("codebuddy_output_schema_invalid")
-  }
+  return prepareOutputSchemaSnapshot(schema, {
+    tooLarge: () => new CodeBuddyAdapterError("codebuddy_output_schema_too_large"),
+    invalid: () => new CodeBuddyAdapterError("codebuddy_output_schema_invalid"),
+    isGuardError: (error) => error instanceof CodeBuddyAdapterError,
+  })
 }
 
 function validateRequestShape(
@@ -805,8 +787,11 @@ function scrubOutput(
   return value
 }
 
-function parseAndValidateOutput(text: string, schema: SafeValue | undefined): SafeValue {
-  if (schema === undefined) return redactText(text)
+function parseAndValidateOutput(
+  text: string,
+  validate: ((candidate: unknown) => boolean) | undefined,
+): SafeValue {
+  if (validate === undefined) return redactText(text)
   let parsed: unknown
   try {
     parsed = JSON.parse(text)
@@ -814,23 +799,10 @@ function parseAndValidateOutput(text: string, schema: SafeValue | undefined): Sa
     throw new CodeBuddyProtocolError("codebuddy_output_not_json")
   }
   const normalized = normalizeOutputValue(parsed)
-  try {
-    const ajv = new Ajv2020({
-      allErrors: true,
-      allowUnionTypes: true,
-      strict: false,
-      validateSchema: true,
-    })
-    const validate = ajv.compile(schema as object)
-    if ("$async" in validate && validate.$async === true) {
-      throw new CodeBuddyProtocolError("codebuddy_output_schema_invalid")
-    }
-    if (validate(normalized) !== true) {
-      throw new CodeBuddyProtocolError("codebuddy_output_schema_mismatch")
-    }
-  } catch (error) {
-    if (error instanceof CodeBuddyProtocolError) throw error
-    throw new CodeBuddyProtocolError("codebuddy_output_schema_invalid")
+  // The validator is the Adapter's one prepared synchronous Schema
+  // snapshot; the stream layer never recompiles or re-accepts a Schema.
+  if (!validate(normalized)) {
+    throw new CodeBuddyProtocolError("codebuddy_output_schema_mismatch")
   }
   return normalized
 }
@@ -1143,7 +1115,9 @@ class CodeBuddyStreamNormalizer {
     throw new CodeBuddyProtocolError("codebuddy_stream_unknown_event")
   }
 
-  finish(outputSchema: SafeValue | undefined): {
+  finish(
+    outputValidator: ((candidate: unknown) => boolean) | undefined,
+  ): {
     output: SafeValue
     usage: Extract<AgentHostEvent, { type: "usage" }>
   } {
@@ -1167,7 +1141,7 @@ class CodeBuddyStreamNormalizer {
     }
     const output = parseAndValidateOutput(
       this.result.result,
-      outputSchema,
+      outputValidator,
     )
     const usage = record(this.result.usage)
     const inputTokens = usage?.input_tokens
@@ -1304,6 +1278,28 @@ export class CodeBuddyAgentHostAdapter implements AgentHostAdapter {
   }
 
   async preflight(request: AgentHostRunRequest): Promise<AgentHostProbeResult> {
+    try {
+      serializeAndValidateSchema(request.outputSchema)
+    } catch (error) {
+      const code =
+        error instanceof CodeBuddyAdapterError
+          ? error.code
+          : "codebuddy_policy_projection_failed"
+      return {
+        protocolVersion: AGENT_HOST_PROTOCOL_VERSION,
+        hostId: CODEBUDDY_HOST_ID,
+        displayName: CODEBUDDY_DISPLAY_NAME,
+        status: "not_ready",
+        available: false,
+        adapterStatus: "runnable",
+        capabilities: capabilities(),
+        capabilitySource: "conformance_test",
+        issues: [
+          issue(code, "CodeBuddy Code cannot safely validate this output Schema"),
+        ],
+      }
+    }
+
     const probe = await this.probe(request.signal)
     const issues = [...probe.issues]
     try {
@@ -1363,6 +1359,9 @@ export class CodeBuddyAgentHostAdapter implements AgentHostAdapter {
 
       const beforeProbeError = stoppedRunError(active)
       if (beforeProbeError) throw beforeProbeError
+      // The shared Schema guard fails closed before any probe, projection or
+      // model process; prepareRun re-checks deterministically below.
+      serializeAndValidateSchema(request.outputSchema)
       const executableBefore = await inspectExecutable(
         this.command,
         this.environment,
@@ -1614,7 +1613,7 @@ export class CodeBuddyAgentHostAdapter implements AgentHostAdapter {
       }
       let completion
       try {
-        completion = normalizer.finish(prepared.outputSchema?.value)
+        completion = normalizer.finish(prepared.outputSchema?.validate)
       } catch (error) {
         if (error instanceof CodeBuddyProtocolError) {
           throw new CodeBuddyAdapterError(error.code, error.retryable)

--- a/apps/cli/output-schema-guard.ts
+++ b/apps/cli/output-schema-guard.ts
@@ -1,0 +1,64 @@
+import { Ajv2020 } from "ajv/dist/2020.js"
+
+import type { SafeValue } from "../../packages/core/src/contracts.js"
+
+export const SHARED_MAX_OUTPUT_SCHEMA_BYTES = 16 * 1024
+
+/**
+ * One bounded, immutable Schema snapshot shared by every built-in Adapter.
+ * The compiled validator is the single synchronous terminal check: projection
+ * and terminal validation must both consume this snapshot, never recompile.
+ */
+export interface PreparedOutputSchemaSnapshot {
+  json: string
+  value: SafeValue
+  validate: (candidate: unknown) => boolean
+}
+
+export interface OutputSchemaGuardErrors {
+  tooLarge: () => Error
+  invalid: () => Error
+  isGuardError: (error: unknown) => boolean
+}
+
+/**
+ * Prepares the run output Schema before probe, projection, or any model
+ * process. Asynchronous Schemas are the canonical hazard: an accepted
+ * `$async` validator would let a Promise masquerade as a synchronous
+ * terminal guarantee, so every compile failure fails closed.
+ */
+export function prepareOutputSchemaSnapshot(
+  schema: SafeValue | undefined,
+  errors: OutputSchemaGuardErrors,
+  maxBytes = SHARED_MAX_OUTPUT_SCHEMA_BYTES,
+): PreparedOutputSchemaSnapshot | undefined {
+  if (schema === undefined) return undefined
+  try {
+    const json = JSON.stringify(schema)
+    if (typeof json !== "string" || json.length === 0) {
+      throw errors.invalid()
+    }
+    if (Buffer.byteLength(json, "utf8") > maxBytes) {
+      throw errors.tooLarge()
+    }
+    const ajv = new Ajv2020({
+      allErrors: true,
+      allowUnionTypes: true,
+      strict: false,
+      validateSchema: true,
+    })
+    const value = JSON.parse(json) as SafeValue
+    const compiled = ajv.compile(value as object)
+    if ("$async" in compiled && compiled.$async === true) {
+      throw errors.invalid()
+    }
+    return {
+      json,
+      value,
+      validate: (candidate: unknown) => compiled(candidate) === true,
+    }
+  } catch (error) {
+    if (errors.isGuardError(error)) throw error
+    throw errors.invalid()
+  }
+}

--- a/apps/cli/qoder-agent-host.ts
+++ b/apps/cli/qoder-agent-host.ts
@@ -17,7 +17,6 @@ import os from "node:os"
 import path from "node:path"
 import { createInterface } from "node:readline"
 import type { Readable, Writable } from "node:stream"
-import { Ajv2020 } from "ajv/dist/2020.js"
 
 import {
   AGENT_HOST_PROTOCOL_VERSION,
@@ -41,6 +40,7 @@ import {
   signalAgentHostProcessTree,
   waitForAgentHostProcessTreeExit,
 } from "./agent-host-process-tree.js"
+import { prepareOutputSchemaSnapshot } from "./output-schema-guard.js"
 
 const QODER_HOST_ID = "qoder"
 const QODER_DISPLAY_NAME = "Qoder CLI"
@@ -64,7 +64,6 @@ const CLEANUP_ATTEMPTS = 2
 const CLEANUP_ATTEMPT_TIMEOUT_MS = 2_000
 const MAX_PROMPT_BYTES = 256 * 1024
 const MAX_INSTRUCTIONS_BYTES = 128 * 1024
-const MAX_SCHEMA_BYTES = 16 * 1024
 const MAX_STDOUT_BYTES = 4 * 1024 * 1024
 const MAX_STDERR_BYTES = 256 * 1024
 const MAX_LINE_BYTES = 1024 * 1024
@@ -300,30 +299,11 @@ interface PreparedOutputSchema {
 function prepareOutputSchema(
   schema: SafeValue | undefined,
 ): PreparedOutputSchema | undefined {
-  if (schema === undefined) return undefined
-  try {
-    const json = JSON.stringify(schema)
-    if (typeof json !== "string") {
-      throw new QoderAdapterError("qoder_output_schema_invalid")
-    }
-    if (byteLength(json) > MAX_SCHEMA_BYTES) {
-      throw new QoderAdapterError("qoder_output_schema_too_large")
-    }
-    const ajv = new Ajv2020({
-      allErrors: true,
-      allowUnionTypes: true,
-      strict: false,
-      validateSchema: true,
-    })
-    const validate = ajv.compile(JSON.parse(json))
-    if ("$async" in validate && validate.$async === true) {
-      throw new QoderAdapterError("qoder_output_schema_invalid")
-    }
-    return { json, validate: (value) => validate(value) === true }
-  } catch (error) {
-    if (error instanceof QoderAdapterError) throw error
-    throw new QoderAdapterError("qoder_output_schema_invalid")
-  }
+  return prepareOutputSchemaSnapshot(schema, {
+    tooLarge: () => new QoderAdapterError("qoder_output_schema_too_large"),
+    invalid: () => new QoderAdapterError("qoder_output_schema_invalid"),
+    isGuardError: (error) => error instanceof QoderAdapterError,
+  })
 }
 
 function validateRequestShape(

--- a/apps/cli/qwen-agent-host.ts
+++ b/apps/cli/qwen-agent-host.ts
@@ -6,7 +6,6 @@ import os from "node:os"
 import path from "node:path"
 import { createInterface } from "node:readline"
 import type { Readable, Writable } from "node:stream"
-import { Ajv2020 } from "ajv/dist/2020.js"
 
 import {
   AGENT_HOST_PROTOCOL_VERSION,
@@ -33,6 +32,7 @@ import {
   readInlineAgentAssets,
 } from "./inline-agent-projection.js"
 import type { InlineAgentAsset } from "./inline-agent-projection.js"
+import { prepareOutputSchemaSnapshot } from "./output-schema-guard.js"
 
 const QWEN_HOST_ID = "qwen-code"
 const QWEN_DISPLAY_NAME = "Qwen Code"
@@ -44,7 +44,6 @@ const CLEANUP_ATTEMPTS = 2
 const CLEANUP_ATTEMPT_TIMEOUT_MS = 2_000
 const MAX_PROMPT_BYTES = 256 * 1024
 const MAX_INSTRUCTIONS_BYTES = 128 * 1024
-const MAX_SCHEMA_BYTES = 16 * 1024
 const MAX_STDIN_BYTES = 512 * 1024
 const MAX_STDOUT_BYTES = 4 * 1024 * 1024
 const MAX_STDERR_BYTES = 256 * 1024
@@ -120,6 +119,7 @@ interface PreparedRun {
 interface PreparedOutputSchema {
   json: string
   value: SafeValue
+  validate: (candidate: unknown) => boolean
 }
 
 interface QwenStreamNormalizerOptions {
@@ -286,28 +286,11 @@ function validatedBaseUrl(environment: NodeJS.ProcessEnv): string | undefined {
 function serializeAndValidateSchema(
   schema: SafeValue | undefined,
 ): PreparedOutputSchema | undefined {
-  if (schema === undefined) return undefined
-  try {
-    const serialized = JSON.stringify(schema)
-    if (!serialized || byteLength(serialized) > MAX_SCHEMA_BYTES) {
-      throw new QwenAdapterError("qwen_output_schema_too_large")
-    }
-    const ajv = new Ajv2020({
-      allErrors: true,
-      allowUnionTypes: true,
-      strict: false,
-      validateSchema: true,
-    })
-    const value = JSON.parse(serialized) as SafeValue
-    const validate = ajv.compile(value as object)
-    if ("$async" in validate && validate.$async === true) {
-      throw new QwenAdapterError("qwen_output_schema_invalid")
-    }
-    return { json: serialized, value }
-  } catch (error) {
-    if (error instanceof QwenAdapterError) throw error
-    throw new QwenAdapterError("qwen_output_schema_invalid")
-  }
+  return prepareOutputSchemaSnapshot(schema, {
+    tooLarge: () => new QwenAdapterError("qwen_output_schema_too_large"),
+    invalid: () => new QwenAdapterError("qwen_output_schema_invalid"),
+    isGuardError: (error) => error instanceof QwenAdapterError,
+  })
 }
 
 function validateRequestShape(
@@ -635,25 +618,15 @@ function normalizeOutputValue(
   return output
 }
 
-function validateStructuredOutput(value: unknown, schema: SafeValue): SafeValue {
+function validateStructuredOutput(
+  value: unknown,
+  validate: (candidate: unknown) => boolean,
+): SafeValue {
   const normalized = normalizeOutputValue(value)
-  try {
-    const ajv = new Ajv2020({
-      allErrors: true,
-      allowUnionTypes: true,
-      strict: false,
-      validateSchema: true,
-    })
-    const validate = ajv.compile(schema as object)
-    if ("$async" in validate && validate.$async === true) {
-      throw new QwenStreamProtocolError("qwen_output_schema_invalid")
-    }
-    if (validate(normalized) !== true) {
-      throw new QwenStreamProtocolError("qwen_output_schema_mismatch")
-    }
-  } catch (error) {
-    if (error instanceof QwenStreamProtocolError) throw error
-    throw new QwenStreamProtocolError("qwen_output_schema_invalid")
+  // The validator is the Adapter's one prepared synchronous Schema
+  // snapshot; the stream layer never recompiles or re-accepts a Schema.
+  if (!validate(normalized)) {
+    throw new QwenStreamProtocolError("qwen_output_schema_mismatch")
   }
   return normalized
 }
@@ -901,7 +874,9 @@ class QwenZeroToolStreamNormalizer {
     throw new QwenStreamProtocolError("qwen_stream_unknown_event")
   }
 
-  finish(outputSchema: SafeValue | undefined): QwenStreamCompletion {
+  finish(
+    outputValidator: ((candidate: unknown) => boolean) | undefined,
+  ): QwenStreamCompletion {
     if (!this.initSeen) {
       throw new QwenStreamProtocolError("qwen_init_missing")
     }
@@ -926,9 +901,9 @@ class QwenZeroToolStreamNormalizer {
       throw new QwenStreamProtocolError("qwen_output_not_json")
     }
     const output =
-      outputSchema === undefined
+      outputValidator === undefined
         ? normalizeOutputValue(parsed)
-        : validateStructuredOutput(parsed, outputSchema)
+        : validateStructuredOutput(parsed, outputValidator)
 
     const usage = record(this.result.usage)
     const inputTokens = usage?.input_tokens
@@ -1085,6 +1060,28 @@ export class QwenAgentHostAdapter implements AgentHostAdapter {
   }
 
   async preflight(request: AgentHostRunRequest): Promise<AgentHostProbeResult> {
+    try {
+      serializeAndValidateSchema(request.outputSchema)
+    } catch (error) {
+      const code =
+        error instanceof QwenAdapterError
+          ? error.code
+          : "qwen_policy_projection_failed"
+      return {
+        protocolVersion: AGENT_HOST_PROTOCOL_VERSION,
+        hostId: QWEN_HOST_ID,
+        displayName: QWEN_DISPLAY_NAME,
+        status: "not_ready",
+        available: false,
+        adapterStatus: "runnable",
+        capabilities: capabilities(),
+        capabilitySource: "conformance_test",
+        issues: [
+          issue(code, "Qwen Code cannot safely validate this output Schema"),
+        ],
+      }
+    }
+
     const probe = await this.probe(request.signal)
     const issues = [...probe.issues]
     try {
@@ -1147,6 +1144,9 @@ export class QwenAgentHostAdapter implements AgentHostAdapter {
 
       const beforePrepareError = stoppedRunError(active)
       if (beforePrepareError) throw beforePrepareError
+      // The shared Schema guard fails closed before any probe, projection or
+      // model process; prepareRun re-checks deterministically below.
+      serializeAndValidateSchema(request.outputSchema)
       const probe = await this.probe(request.signal)
       const afterProbeError = stoppedRunError(active)
       if (afterProbeError) throw afterProbeError
@@ -1350,7 +1350,7 @@ export class QwenAgentHostAdapter implements AgentHostAdapter {
 
       let completion: QwenStreamCompletion
       try {
-        completion = normalizer.finish(prepared.outputSchema?.value)
+        completion = normalizer.finish(prepared.outputSchema?.validate)
       } catch (error) {
         if (error instanceof QwenStreamProtocolError) {
           throw new QwenAdapterError(error.code, error.retryable)

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -16,7 +16,7 @@
 
 当前 `capabilitySource: conformance_test` 指仓库内针对特定 Adapter 和锁定 Host 版本的确定性子进程 fixture。它不是可供第三方 Adapter 复用的认证 harness，也不是厂商认证或真实模型额度验证。Qoder 的 capability 声明来自 Adapter 专用确定性 fixture；本轮没有生成通用 qualification record，`liveQualified` 为 false。
 
-`structured_output` 统一表示 **Adapter 保证终态有效**，而不是 Host 原生约束生成：有 `outputSchema` 时，`run.completed` 必须携带原值通过调用方同步 Schema 的终态 JSON；修复、强制转换、默认值、删字段或脱敏都不得制造一个合格值，校验后的安全检查若需要改写 schema-bound 值也必须 fail closed。无效 JSON、异步 Schema、Schema 不匹配、取消、超时或清理失败同样必须 fail closed。事件流本身是 JSON 不构成该能力。Qoder 额外把 Schema 限制在 16 KiB，并在受限版本探针或任何投影、模型进程前完成编译。
+`structured_output` 统一表示 **Adapter 保证终态有效**，而不是 Host 原生约束生成：有 `outputSchema` 时，`run.completed` 必须携带原值通过调用方同步 Schema 的终态 JSON；修复、强制转换、默认值、删字段或脱敏都不得制造一个合格值，校验后的安全检查若需要改写 schema-bound 值也必须 fail closed。无效 JSON、异步 Schema、Schema 不匹配、取消、超时或清理失败同样必须 fail closed。事件流本身是 JSON 不构成该能力。四个 runnable Adapter（Qoder、Claude、Qwen、CodeBuddy）共用同一个前置守卫 `output-schema-guard.ts`：Schema 限 16 KiB、必须同步，`$async:true` 与任何非法 Schema 在受限版本探针、投影或模型进程之前即被拒绝；每次运行只编译一份 prepared Schema 快照，投影与终态校验复用同一快照，终态阶段不再重新编译或重新接受 Schema。
 
 ## 名词边界
 

--- a/tests/apps/claude-agent-host.test.ts
+++ b/tests/apps/claude-agent-host.test.ts
@@ -443,6 +443,52 @@ test("Claude validates synchronous JSON Schema locally before launching", async 
   }
 })
 
+test("Claude preflight rejects invalid, $async and oversized Schemas before any probe or spawn", async () => {
+  for (const [name, outputSchema, code] of [
+    [
+      "invalid",
+      { type: "definitely-not-a-json-schema-type" },
+      "claude_output_schema_invalid",
+    ],
+    [
+      "async",
+      { $async: true, type: "object" },
+      "claude_output_schema_invalid",
+    ],
+    [
+      "oversized",
+      {
+        type: "object",
+        properties: { filler: { description: "x".repeat(20_000) } },
+      },
+      "claude_output_schema_too_large",
+    ],
+  ] as const) {
+    const parent = await mkdtemp(path.join(os.tmpdir(), `claude-guard-${name}-`))
+    const launchLog = path.join(parent, "launch.jsonl")
+    const request = await employeeRequest(parent, `run-guard-${name}`)
+    request.outputSchema = outputSchema as SafeValue
+    const versionCalls: Array<{ command: string; args: string[] }> = []
+    const host = adapter(parent, "success", undefined, 10_000, {
+      fixtureArgs: ["--launch-log", launchLog],
+      versionExecutor: async (command, args) => {
+        versionCalls.push({ command, args })
+        return fixtureVersionExecutor()
+      },
+    })
+
+    const preflight = await host.preflight(request)
+    assert.equal(preflight.status, "not_ready")
+    assert.equal(preflight.available, false)
+    assert.deepEqual(
+      preflight.issues.map((entry) => entry.code),
+      [code],
+    )
+    assert.deepEqual(versionCalls, [])
+    await assert.rejects(access(launchLog))
+  }
+})
+
 test("Claude keeps the prepared Schema when the request mutates before spawn", async () => {
   const parent = await mkdtemp(path.join(os.tmpdir(), "claude-late-schema-"))
   const request = await employeeRequest(parent, "run-late-schema")

--- a/tests/apps/codebuddy-agent-host.test.ts
+++ b/tests/apps/codebuddy-agent-host.test.ts
@@ -537,6 +537,54 @@ test("CodeBuddy validates synchronous JSON Schema locally before launching", asy
   }
 })
 
+test("CodeBuddy preflight rejects invalid, $async and oversized Schemas before any probe or spawn", async () => {
+  for (const [name, outputSchema, code] of [
+    [
+      "invalid",
+      { type: "definitely-not-a-json-schema-type" },
+      "codebuddy_output_schema_invalid",
+    ],
+    [
+      "async",
+      { $async: true, type: "object" },
+      "codebuddy_output_schema_invalid",
+    ],
+    [
+      "oversized",
+      {
+        type: "object",
+        properties: { filler: { description: "x".repeat(20_000) } },
+      },
+      "codebuddy_output_schema_too_large",
+    ],
+  ] as const) {
+    const parent = await mkdtemp(
+      path.join(os.tmpdir(), `codebuddy-guard-${name}-`),
+    )
+    const launchLog = path.join(parent, "launch.jsonl")
+    const request = await employeeRequest(parent, `run-guard-${name}`)
+    request.outputSchema = outputSchema as SafeValue
+    const versionCalls: Array<{ command: string; args: string[] }> = []
+    const host = adapter(parent, "success", undefined, 10_000, {
+      fixtureArgs: ["--launch-log", launchLog],
+      versionExecutor: async (command, args) => {
+        versionCalls.push({ command, args })
+        return fixtureVersionExecutor()
+      },
+    })
+
+    const preflight = await host.preflight(request)
+    assert.equal(preflight.status, "not_ready")
+    assert.equal(preflight.available, false)
+    assert.deepEqual(
+      preflight.issues.map((entry) => entry.code),
+      [code],
+    )
+    assert.deepEqual(versionCalls, [])
+    await assert.rejects(access(launchLog))
+  }
+})
+
 test("CodeBuddy keeps the prepared Schema when the request mutates before spawn", async () => {
   const parent = await mkdtemp(path.join(os.tmpdir(), "codebuddy-late-schema-"))
   const request = await employeeRequest(parent, "run-late-schema")

--- a/tests/apps/output-schema-guard.test.ts
+++ b/tests/apps/output-schema-guard.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  SHARED_MAX_OUTPUT_SCHEMA_BYTES,
+  prepareOutputSchemaSnapshot,
+} from "../../apps/cli/output-schema-guard.js"
+import type { SafeValue } from "../../packages/core/index.js"
+
+class GuardError extends Error {
+  constructor(readonly code: string) {
+    super(code)
+    this.name = "GuardError"
+  }
+}
+
+const errors = {
+  tooLarge: () => new GuardError("schema_too_large"),
+  invalid: () => new GuardError("schema_invalid"),
+  isGuardError: (error: unknown) => error instanceof GuardError,
+}
+
+function guardError(fn: () => unknown): string {
+  try {
+    fn()
+  } catch (error) {
+    assert.ok(error instanceof GuardError)
+    return error.code
+  }
+  assert.fail("expected the guard to throw")
+}
+
+test("the shared guard passes undefined through unchanged", () => {
+  assert.equal(prepareOutputSchemaSnapshot(undefined, errors), undefined)
+})
+
+test("the shared guard prepares one synchronous snapshot per Schema", () => {
+  const schema: SafeValue = {
+    type: "object",
+    properties: { answer: { type: "string" } },
+    required: ["answer"],
+    additionalProperties: false,
+  }
+  const snapshot = prepareOutputSchemaSnapshot(schema, errors)
+  assert.ok(snapshot)
+  assert.deepEqual(JSON.parse(snapshot.json), schema)
+  assert.deepEqual(snapshot.value, schema)
+  assert.equal(snapshot.validate({ answer: "ok" }), true)
+  assert.equal(snapshot.validate({ answer: 7 }), false)
+  assert.equal(snapshot.validate({}), false)
+  assert.equal(snapshot.validate({ answer: "ok", extra: 1 }), false)
+})
+
+test("the shared guard rejects $async and invalid Schemas before compile output", () => {
+  assert.equal(
+    guardError(() =>
+      prepareOutputSchemaSnapshot({ $async: true, type: "object" }, errors),
+    ),
+    "schema_invalid",
+  )
+  assert.equal(
+    guardError(() =>
+      prepareOutputSchemaSnapshot(
+        { type: "definitely-not-a-json-schema-type" },
+        errors,
+      ),
+    ),
+    "schema_invalid",
+  )
+  assert.equal(
+    guardError(() => prepareOutputSchemaSnapshot("not an object" as SafeValue, errors)),
+    "schema_invalid",
+  )
+})
+
+test("the shared guard enforces the byte cap with a typed too-large error", () => {
+  assert.equal(SHARED_MAX_OUTPUT_SCHEMA_BYTES, 16 * 1024)
+  const oversized: SafeValue = {
+    type: "object",
+    properties: { filler: { description: "x".repeat(SHARED_MAX_OUTPUT_SCHEMA_BYTES) } },
+  }
+  assert.equal(
+    guardError(() => prepareOutputSchemaSnapshot(oversized, errors)),
+    "schema_too_large",
+  )
+})
+
+test("the shared guard snapshot survives hostile mutation of the source Schema", () => {
+  const schema: {
+    type: string
+    properties: { answer: { type: string } }
+    required?: string[]
+    additionalProperties: boolean
+  } = {
+    type: "object",
+    properties: { answer: { type: "string" } },
+    required: ["answer"],
+    additionalProperties: false,
+  }
+  const snapshot = prepareOutputSchemaSnapshot(schema as SafeValue, errors)
+  assert.ok(snapshot)
+  schema.type = "boolean"
+  schema.properties.answer.type = "number"
+  delete schema.required
+  assert.equal(snapshot.validate({ answer: "ok" }), true)
+  assert.equal(snapshot.validate({ answer: 7 }), false)
+  assert.deepEqual(JSON.parse(snapshot.json), {
+    type: "object",
+    properties: { answer: { type: "string" } },
+    required: ["answer"],
+    additionalProperties: false,
+  })
+})
+
+test("the shared guard fails closed on non-serializable Schemas", () => {
+  assert.equal(
+    guardError(() =>
+      prepareOutputSchemaSnapshot(BigInt(1) as unknown as SafeValue, errors),
+    ),
+    "schema_invalid",
+  )
+})

--- a/tests/apps/qwen-agent-host.test.ts
+++ b/tests/apps/qwen-agent-host.test.ts
@@ -546,6 +546,53 @@ test("Qwen validates synchronous JSON Schema locally before launching", async ()
   }
 })
 
+test("Qwen preflight rejects invalid, $async and oversized Schemas before any probe or spawn", async () => {
+  for (const [name, outputSchema, code] of [
+    [
+      "invalid",
+      { type: "definitely-not-a-json-schema-type" },
+      "qwen_output_schema_invalid",
+    ],
+    [
+      "async",
+      { $async: true, type: "object" },
+      "qwen_output_schema_invalid",
+    ],
+    [
+      "oversized",
+      {
+        type: "object",
+        properties: { filler: { description: "x".repeat(20_000) } },
+      },
+      "qwen_output_schema_too_large",
+    ],
+  ] as const) {
+    const parent = await mkdtemp(path.join(os.tmpdir(), `qwen-guard-${name}-`))
+    const launchLog = path.join(parent, "launch.jsonl")
+    const request = await employeeRequest(parent, `run-guard-${name}`)
+    request.outputSchema = outputSchema as SafeValue
+    const versionCalls: Array<{ command: string; args: string[] }> = []
+    const host = adapter(parent, "success", undefined, 10_000, {
+      fixtureArgs: ["--launch-log", launchLog],
+      versionExecutor: async (command, args) => {
+        versionCalls.push({ command, args })
+        return fixtureVersionExecutor()
+      },
+    })
+
+    const preflight = await host.preflight(request)
+    assert.equal(preflight.status, "not_ready")
+    assert.equal(preflight.available, false)
+    assert.deepEqual(
+      preflight.issues.map((entry) => entry.code),
+      [code],
+    )
+    assert.deepEqual(versionCalls, [])
+    await assert.rejects(access(launchLog))
+    await rm(parent, { recursive: true, force: true })
+  }
+})
+
 test("Qwen keeps the prepared Schema when the request mutates before spawn", async () => {
   const parent = await mkdtemp(path.join(os.tmpdir(), "qwen-late-schema-"))
   const request = await employeeRequest(parent, "run-late-schema")


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/113
- Consumed revision: R2
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-002 / AC-002 | `apps/cli/output-schema-guard.ts` | New shared synchronous Schema preflight guard: 16 KiB cap, `$async:true` and invalid Schema rejection, one prepared snapshot per run; six deterministic unit tests |
| REQ-002 / AC-002 | `apps/cli/claude-agent-host.ts`, `apps/cli/claude-stream-agent-host.ts` | Guard runs before probe/projection/model process in preflight and run; terminal validation consumes the prepared validator and never recompiles |
| REQ-002 / AC-002 | `apps/cli/qwen-agent-host.ts`, `apps/cli/codebuddy-agent-host.ts`, `apps/cli/qoder-agent-host.ts` | Same consolidation; Qwen/CodeBuddy terminal Ajv recompiles removed; Qoder keeps guard-first preflight via the shared module |
| REQ-002 / AC-002 | `tests/apps/output-schema-guard.test.ts`, `tests/apps/claude-agent-host.test.ts`, `tests/apps/qwen-agent-host.test.ts`, `tests/apps/codebuddy-agent-host.test.ts` | Shared guard unit contract plus per-adapter preflight no-probe/no-spawn regressions for invalid/`$async`/oversized Schemas; existing terminal suites stay green |
| REQ-002 / AC-002 | `docs/agent-hosts.md`, `CHANGELOG.md` | Shared guard contract documented for all four runnable Adapters; changelog entry |

## File domains

- Shared guard: new `apps/cli/output-schema-guard.ts` — one Ajv 2020 synchronous compile per run with a JSON snapshot round-trip, bounded 16 KiB bytes, `$async:true` rejection, and adapter-supplied typed error factories.
- Claude, Qwen, CodeBuddy, Qoder Adapters: duplicate private Schema guards replaced by the shared module; Claude/Qwen/CodeBuddy preflight and run paths now fail closed before any version probe, projection or model process; stream normalizers receive the prepared validator instead of a raw Schema and never recompile.
- Deploy, channel, provider, marketplace, employee-package, eval and stdio Adapter boundaries: unchanged.
- No dependency changed.

## Scope and non-goals

Issue #113 R2 REQ-002 requires Claude, Qwen, and CodeBuddy to reject
`$async:true` and any other unsupported Schema before Host execution, with all
four runnable Adapters using one prepared Schema snapshot for projection and
terminal validation. This PR delivers exactly that shared preflight guard and
its deterministic regressions. Schema-absent requests keep the existing
unstructured behavior; unverified versions stay fail closed via the existing
version gates. This does not change capability declarations, the qualification
kit, or AC-001/AC-004, and adds no live model or paid call.

## Validation

- Exact commands: `npm run check`; `npx tsx --test tests/apps/output-schema-guard.test.ts`; `npx tsx --test --test-concurrency=1 tests/apps/claude-agent-host.test.ts tests/apps/qwen-agent-host.test.ts tests/apps/codebuddy-agent-host.test.ts tests/apps/qoder-agent-host.test.ts`; `git diff --check`
- Observed counts/results: full check typecheck, build, governance, and security PASS; test body 1423/1431 PASS under `LANG=en_US.UTF-8` (three interactive deploy-cli tests pin English prompt strings), with the 8 failures confined to two load-sensitive deploy-cli DingTalk pagination families (20-second built-CLI deadline, `1 !== 2`) that pass 41/41 on isolated re-run while every failure signature shifts between runs; this diff touches no deploy, DingTalk, or provider code; shared guard 6/6 PASS; five adapter suites 173/173 PASS including the three new preflight no-probe/no-spawn regressions; diff check PASS
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/actions/runs/32330241561

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-002 / AC-002 | Invalid, oversized, `$async:true` and unsupported Schemas fail preflight before any probe, projection or model process | Run the three per-adapter preflight regression tests | macOS, Node.js 24, exact commit, offline fixtures | `not_ready` with the Adapter's typed code, 0/0 version-probe calls, no launch log | All three tests PASS; typed codes observed, versionCalls 0/0, launch log absent | PASS |
| V2 | REQ-002 / AC-002 | One prepared Schema snapshot serves both projection and terminal validation | Run the shared guard unit tests and existing terminal suites | macOS, offline fixtures | Guard compiles once; terminal validators consume the snapshot; mutation of the source Schema does not change verdicts | 6/6 guard tests PASS; 173/173 adapter tests PASS including prepared-Schema-mutation tests | PASS |
| V3 | REQ-002 / AC-002 | Schema-absent requests keep unstructured behavior | Run the existing unstructured terminal suites | macOS, offline fixtures | Unstructured terminals still complete and redact | Existing suites PASS unchanged | PASS |
| V4 | REQ-002 / AC-002 | Repository behavior remains compatible | `npm run check` | macOS, Node.js 24, exact commit, English locale for prompt-pinning tests | All tests and security gates pass | Typecheck, build, governance, and security PASS; 1423/1431 tests PASS with the 8 failures confined to load-sensitive deploy-cli DingTalk families proven flaky by a 41/41 isolated re-run and untouched by this diff | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Invalid Schemas never spawn a host or model process; rejection happens in bounded in-process validation.
- [x] Terminal validation uses the one prepared synchronous validator; no Schema is re-accepted at the stream layer.
- [x] Existing typed error codes for all four Adapters are preserved.
- [x] No dependency changed.
- [x] Full repository and security gates pass.

The consolidation removes three private duplicate guards and two terminal
Ajv recompiles, shrinking the surface where an asynchronous or oversized
Schema could slip past one Adapter but not another.

## Known limitations

This PR delivers AC-002 only. AC-001 capability declarations and AC-004's
later versioned release proving generic downstream selection remain separate
work; Issue #113 stays open for those gates. Fixture conformance is not
live-provider or model-entitlement proof. Regex-pattern ReDoS for untrusted
marketplace Schemas remains the separate pre-multitenant hardening decision
recorded on the Issue.

## Risk and rollback

The main risk is the preflight reorder changing observable issue ordering for
requests that fail both Schema and host checks; the typed Schema issue now
wins deterministically. Revert this single commit to restore the prior
per-Adapter guards; all error codes are unchanged. No persistent product
data, remote provider resource, channel state, or credential migration is
involved.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @Bindy-lbb
- Milestone or release packet: N/A: this is Adapter preflight hardening and remains behind Issue #113's recorded gates
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
