### PR TITLE
docs(knowledge): commit asset convention, quality bar, and doc-consistency rule (#143)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,6 +36,7 @@
 - [ ] Compatibility, migration, and cross-repository effects are stated below.
 - [ ] New dependencies and licenses were reviewed, or no dependency changed.
 - [ ] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded.
+- [ ] Behavior changes carry a matching docs delta, or this body records the explicit no-doc-needed reason (CONTRIBUTING.md, "Documentation consistency").
 
 <!-- Security findings, compatibility range, migration requirements, and evidence visibility. -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,22 @@ and must never become a runtime dependency.
 Create a focused branch, add tests for user-visible behavior, and open a pull
 request against `main`. Keep generated data and credentials out of commits.
 
+## Documentation consistency
+
+Docs are the public contract for shipped behavior. A pull request that changes
+shipped behavior — commands, protocols, schemas, support matrices, deploy or
+release policy — must carry the matching `docs/` (or README/INSTALL) delta in
+the same change. If a behavior-changing pull request legitimately needs no doc
+delta, the PR body must state the explicit no-doc-needed reason; the PR
+template checklist carries the flag, and reviewers treat a missing delta with
+no recorded reason as a blocking finding.
+
+A doc that contradicts shipped behavior is drift: repair it with the smallest
+truthful edit the in-repo evidence supports, and never invent verification
+results to close a gap. Context and knowledge assets additionally follow the
+last-verified-date and review-cadence convention in
+[docs/knowledge/knowledge-source-quality-bar.md](docs/knowledge/knowledge-source-quality-bar.md).
+
 ## Product direction and issue routing
 
 Read the [product strategy](docs/strategy.md) for the stable scope boundary and

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ repository is not a hosted marketplace or a second Agent loop.
 - [Architecture](docs/architecture.md)
 - [Strategy](docs/strategy.md) and [roadmap](docs/roadmap.md)
 - [Verification](docs/verification.md) and [release process](docs/releasing.md)
+- [Knowledge asset convention](docs/knowledge/asset-convention.md) and [knowledge source quality bar](docs/knowledge/knowledge-source-quality-bar.md)
 - [Security policy](SECURITY.md)
 
 ## Community and support

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,7 +206,7 @@ identity checks apply before launch as well as during execution. The final
 result must pass the employee output Schema. These fixtures are not a reusable
 third-party certification harness; live model entitlement has not been tested.
 
-Codex remains probe-only. Codex CLI 0.146.0 cannot reliably remove every
+Codex remains probe-only. Codex CLI 0.148.0 cannot reliably remove every
 model-visible built-in tool: disabling shell and unified execution still leaves
 paths such as `apply_patch`. Consequently it cannot claim the required
 default-deny `tool_allowlist`, even with a read-only filesystem policy.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -42,8 +42,8 @@ compatibility runtime.
 
 Run the source-built `deploy --help --locale en`, `zh-CN`, or `ja` for the
 complete current value and option list. Help exits 0 without a prompt, config
-write, provider call, or process start. These source changes are newer than the
-tagged `0.3.0` release.
+write, provider call, or process start. Package-bound deploy first shipped in
+the tagged `0.4.0` release.
 
 ## Outcomes and channel truth
 

--- a/docs/employee-package.md
+++ b/docs/employee-package.md
@@ -117,6 +117,18 @@ authorized external system rather than be published in the package. Every
 local file made available to a run must also be listed explicitly in `assets`;
 policy globs grant a maximum scope but never discover package files.
 
+## Knowledge source quality bar
+
+Any knowledge a package declares — in-package `knowledge/` material or an
+external source reached through a connector or MCP capability — must meet the
+[knowledge source quality bar](knowledge/knowledge-source-quality-bar.md):
+explicit read-only scope, named provenance and approval status, and a freshness
+story (a pinned revision, or a last-verified date under the shared review
+cadence). Shared assets that live outside the package follow the
+[knowledge asset convention](knowledge/asset-convention.md), including its
+public-safe boundary: credentials, tenant or account identifiers, internal
+URLs, and generated private indexes are never package content.
+
 ## Built-in recipes
 
 The checked-in recipe packages live under `examples/recipes/` and are copied

--- a/docs/employee-package.md
+++ b/docs/employee-package.md
@@ -23,8 +23,8 @@ node ./dist/apps/cli/bin.js eval ../team-answer
 node ./dist/apps/cli/bin.js doctor
 ```
 
-After an Agent-native `0.2.0` or later release is actually published, the
-equivalent global commands will be:
+With the published `0.4.0` npm package installed globally, the equivalent
+commands are:
 
 ```bash
 digital-employee init ./team-answer --recipe minimal-answer.v1 --author your-team
@@ -244,7 +244,7 @@ The runnable version gates are Qoder CLI 1.1.x, Claude Code
 `>=2.1.214 <2.2.0`, Qwen Code exactly `0.17.1` and CodeBuddy Code exactly
 `2.106.4`; unverified versions fail closed. Codex exposes only an installation
 probe and documentation-derived capability data. Its `tool_allowlist` remains
-`unknown` because Codex CLI 0.146.0 cannot reliably remove every model-visible
+`unknown` because Codex CLI 0.148.0 cannot reliably remove every model-visible
 built-in tool, notably `apply_patch`; a package requiring the default-deny tool
 boundary is rejected even when the filesystem policy is read-only.
 

--- a/docs/knowledge/asset-convention.md
+++ b/docs/knowledge/asset-convention.md
@@ -1,0 +1,68 @@
+# Knowledge asset convention
+
+Last verified: 2026-08-22
+
+This convention defines where shared knowledge lives, how assets are named and
+kept fresh, and where the public-safe boundary sits. It applies to every
+knowledge asset a packaged employee, a recipe, or this repository's docs rely
+on. The quality bar a packaged employee must meet when it declares such an
+asset as a knowledge source is defined in
+[knowledge-source-quality-bar.md](knowledge-source-quality-bar.md).
+
+## Where shared knowledge lives
+
+| Location | What belongs there | What never belongs there |
+| --- | --- | --- |
+| In-package `knowledge/` | Small, approved, public-safe reference material shipped with one employee package and explicitly listed in `employee.json` `assets` | Large corpora, private data, credentials, account identifiers, generated indexes |
+| This repository (`docs/`, `examples/`, `recipes/`, `fixtures/`) | Public product contracts, the verification ledger, approved public fixtures and recipe samples | Anything internal-only; see the boundary below |
+| DWS drive (网盘) and DWS doc | Team-shared documents read at runtime through the explicitly approved, read-only DWS connector | Inline copies pasted into packages or issues; the package holds an approved locator, not the content |
+| `mem` / `doc` services | Scoped durable memory and version-pinned documents read through the operator-granted path described in [real-local-e2e.md](../real-local-e2e.md) | Operator grants inside the package; service URLs outside the loopback harness |
+| Internal knowledge bases | Internal-only material referenced from internal deployments | Any reference in public docs, packages, commit messages, or PR bodies |
+
+A packaged employee never mounts an internal system directly. It declares an
+abstract source or MCP capability; the operator-owned deployment binds the
+concrete locator and credential names.
+
+## Naming
+
+- Public files and directories use lowercase letters, digits and single
+  hyphens — the same portable subset as the employee name in
+  [employee-package.md](../employee-package.md) — at most 64 characters.
+- Dated snapshots and audits carry an ISO date suffix, for example
+  `codex-cli-0.148.0-default-deny-audit.md`; superseded revisions stay in
+  place and are named as their own dated revision rather than rewritten.
+- Locators that leave the repository (drive/doc nodes, service workspaces) are
+  recorded as capability or grant names, never as raw URLs or identifiers in
+  public artifacts.
+
+## Freshness
+
+- Every curated knowledge asset carries a last-verified date, either in the
+  asset itself (a `Last verified:` or `Last reviewed:` line, as in
+  [../verification.md](../verification.md)) or in the index that lists it.
+- The review cadence and the stale-asset rule are defined once in
+  [knowledge-source-quality-bar.md](knowledge-source-quality-bar.md) and apply
+  here unchanged.
+- A behavior-changing pull request that touches an asset resets that asset's
+  date in the same change; see the doc-consistency rule in
+  [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Public-safe vs internal boundary
+
+Public artifacts (this repository, packages, issues, PRs, ledgers) may contain
+only public-safe commands, sanitized output, public URLs and capability names.
+The following stay internal and are never committed, pasted, or screenshotted
+into public records:
+
+- credentials, tokens, cookies, and credential-bearing URLs;
+- tenant, organization, user, profile, document, or chat identifiers, and any
+  internal hostname or URL;
+- chat exports, personal data, and generated private knowledge indexes;
+- screenshots and recordings — share them through the private channel only and
+  reference them from public records by a text description.
+
+Redact by keeping the shape and dropping the value: `sk-...`, not a partial
+real key. The evidence discipline in
+[requirement-governance.md](../requirement-governance.md#security-visibility-and-corrections)
+and the repository security scan (`npm run security:check`) enforce the same
+boundary mechanically; this convention is the human-readable statement of it.

--- a/docs/knowledge/knowledge-source-quality-bar.md
+++ b/docs/knowledge/knowledge-source-quality-bar.md
@@ -1,0 +1,100 @@
+# Knowledge source quality bar
+
+Last verified: 2026-08-22
+
+This is the minimum bar a packaged employee must meet before it may declare a
+knowledge source — whether that source ships inside the package as
+`knowledge/` material or is reached at runtime through an approved connector
+or MCP capability. Where shared knowledge lives and how assets are named is
+defined in [asset-convention.md](asset-convention.md); this document defines
+scope, provenance, freshness, and the staleness-tracking cadence.
+
+## Scope
+
+- Every source is explicit. In-package material is listed file-by-file in
+  `employee.json` `assets`; policy globs grant a maximum scope and never
+  discover package files. External sources are declared as an MCP capability
+  or connector configuration with environment-variable secret names only.
+- Declared scope is read-only and maximal, never a floor: a run may narrow the
+  declared scope (operator grant, deployment policy) but never widen it.
+- Sources outside the package are bound by the operator-owned deployment, not
+  by the package. The package carries locators and capability names, never
+  endpoints with embedded credentials, tenant identifiers, or raw URLs.
+
+## Provenance
+
+- Each declared source names its origin: the owning system or author, its
+  approval status, and the trust boundary the read crosses. Approved fixture
+  material states this in the asset itself (see the recipe `knowledge/README.md`
+  files); external sources state it in the operator grant and connector
+  configuration.
+- Generated or private indexes, chat exports, and personal data are not
+  package content and cannot become a declared source by being copied into
+  `knowledge/`.
+- Answers grounded in an approved source cite that source; the package's Skill
+  or contract must say so, as the built-in `minimal-answer.v1` recipe does.
+
+## Freshness
+
+- Where the backing system supports revisions, the read pins one: the #42
+  real-local path reads documents with client-side ETag revision pinning and
+  rejects a wrong revision (`real_local_revision_mismatch`), and the component
+  matrix is the sole version authority for the services themselves.
+- Where no revision exists, the source or its index entry carries a
+  last-verified date, and the deployment treats reads past the review cadence
+  below as stale until re-verified.
+- A declared source never silently serves a degraded snapshot as current: the
+  Git source contract, for example, revalidates any last-known-good generation
+  and reports `degraded` instead of presenting it as fresh.
+
+## Alignment with the mem/doc read-path contract (#42)
+
+The real-local read path is the reference implementation for external
+knowledge reads, and any declared mem/doc source inherits its contract:
+
+- every read is gated twice — by the operator-owned `capability-grant.v1`
+  file materialized **outside** the package (a grant found inside the package
+  is rejected as a self-grant) and by the service's own grants or ownership;
+- service URLs are loopback-only in the harness, and denial, revocation, and
+  absence map to the frozen `real_local_*` code namespace rather than prose;
+- revoked, unlisted, and absent documents are indistinguishable — no
+  enumeration — and evidence is emitted with an empty secret scan;
+- fixture-backed declarations stay `synthetic-conformance`; only the pinned
+  real-service path earns `real-local-e2e`, and a packaged employee's claims
+  are capped by the evidence class its source path actually earned.
+
+## Alignment with the retention RFC (#104)
+
+Retention and deletion policy is set by the operator or platform that hosts
+the data, per [SECURITY.md](../../SECURITY.md) — not by the employee package.
+Accordingly:
+
+- a package declares no retention behavior and never implies that declaring a
+  source grants retention, export, or deletion rights over it;
+- connector contributions document the retention behavior of their boundary
+  (see [../connectors/README.md](../connectors/README.md));
+- the retention RFC tracked in
+  [#104](https://github.com/fullstack-ai-infra/digital-employee/issues/104)
+  owns the runtime retention semantics. When that RFC lands, declared sources
+  must not contradict it, and any retention metadata it introduces is adopted
+  here rather than redefined. This bar deliberately does not pre-implement the
+  RFC's runtime behavior.
+
+## Staleness tracking and review cadence
+
+Matching the verification-ledger habit (`Last reviewed:` in
+[../verification.md](../verification.md)):
+
+1. Every context asset — verification ledger rows, host/version matrices,
+   research audits, recipe knowledge files, and this directory's conventions —
+   carries a last-verified date.
+2. Cadence: an asset is re-verified at every release gate that touches its
+   domain, and at least every 90 days even when nothing touched it.
+3. A behavior-changing pull request that lands without updating the assets it
+   makes stale is flagged under the doc-consistency rule in
+   [CONTRIBUTING.md](../../CONTRIBUTING.md); the same change must reset the
+   date or record why the date stands.
+4. An asset past its cadence is stale: it may remain in place for history, but
+   a packaged employee or public doc may not cite it as current until it is
+   re-verified or corrected. Corrections append a dated note or a new dated
+   revision rather than rewriting the old record.

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,20 +1,21 @@
 # Verification ledger
 
-Last reviewed: 2026-08-20
+Last reviewed: 2026-08-22
 
 This file distinguishes shipped code from the environments in which it has
 actually been exercised. A passing fixture test is not presented as a live
 provider integration.
 
-Dated counts below are historical snapshots tied to their stated date. The
-current package-bound deploy changes are newer than public `0.3.0`; their final
-exact-PR-head test counts and package sizes remain pending and are deliberately
-not inferred from an earlier run.
+Dated counts below are historical snapshots tied to their stated date. Public
+`0.4.0` is the current tagged release and contains the package-bound deploy;
+changes merged after that tag are not themselves a published release, and
+their exact-head test counts and package sizes are deliberately not inferred
+from an earlier run.
 
 | Path | Evidence | Result |
 | --- | --- | --- |
 | Local answer and escalation | Public example files, extractive model, real CLI process | Verified |
-| Automated suite (historical source snapshot) | `npm run check` on Node.js 24.13.0 | 1,176/1,176 tests plus strict TypeScript, build and the repository security scan passed on 2026-08-10; this is not a final-current-head claim for the newer deploy changes, and provider fixtures do not make live model requests |
+| Automated suite (historical source snapshot) | `npm run check` on Node.js 24.13.0 | 1,176/1,176 tests plus strict TypeScript, build and the repository security scan passed on 2026-08-10; this historical snapshot is not a current-head claim, and provider fixtures do not make live model requests |
 | Coverage gate (historical pre-deploy baseline) | `npm run test:coverage` on Node.js 22.23.2 | 343/343 tests on 2026-08-04; 91.97% line, 73.48% branch and 90.44% function coverage; not presented as coverage for the newer deploy surface |
 | Strict TypeScript | `npm run typecheck` | 0 errors across shipped runtime sources |
 | Agent-host install probes | Real local version/init probes plus bounded fixture processes | Qoder CLI 1.1.17, Codex CLI 0.148.0, Qwen Code 0.17.1 and CodeBuddy Code 2.106.4 found locally; Claude Code 2.1.209 is below the verified range and its probe failed; live authentication/model access not tested |
@@ -25,12 +26,12 @@ not inferred from an earlier run.
 | Issue #113 capability evidence | Deterministic marker fixtures across all four runnable Adapters plus the exact-version table in `docs/agent-hosts.md` | Schema bytes asserted absent from argv, process environment values, and the public event stream on Qoder, Claude, Qwen and CodeBuddy; exact locked Host versions named (Qoder `1.1.x` family / fixture `1.1.12`, Claude Code `>=2.1.214 <2.2.0`, Qwen Code `0.17.1`, CodeBuddy Code `2.106.4`); fixture conformance only with `liveQualified: false`; no tool, MCP, write, network or approval authority added; the later versioned release proving generic downstream selection remains a separate release gate |
 | Probe-only compatibility | CLI integration fixture and source audit | Codex CLI 0.148.0 remains probe-only because `apply_patch` and other model-visible built-ins cannot all be reliably removed; its bounded `--version` subprocess probe does not authenticate, invoke a model or execute tools; missing service keys and unverified runnable-host versions fail closed |
 | Employee package | `init`, static `validate`, schema parity and hostile path fixtures | Atomic scaffold verified; malformed Skill/YAML/JSON Schema, direct/nested traversal, symlinks, glob artifacts and policy mismatches rejected |
-| Package-bound deploy (current source, unreleased) | Built-CLI and direct fault fixtures in `tests/apps/deploy-cli.test.ts`; clean installed-tarball consumer gate in `release.yml` | The source test surface covers exact package/cwd binding, localized automation and help, private atomic state, HTTP health/ask readback, activation and cleanup faults, locks, races and replay fences. A release must additionally install the exact root tgz in a clean prefix, scaffold a recipe, report the installed version, start a fake-Qoder HTTP deployment, read health/ask, and prove PID cleanup. Final current-PR-head results are pending; `0.3.0` does not contain deploy. DingTalk fixtures remain E3 only and real provider E4 remains external HOLD. |
+| Package-bound deploy | Built-CLI and direct fault fixtures in `tests/apps/deploy-cli.test.ts`; clean installed-tarball consumer gate in `release.yml` | The source test surface covers exact package/cwd binding, localized automation and help, private atomic state, HTTP health/ask readback, activation and cleanup faults, locks, races and replay fences. The release gate additionally installs the exact root tgz in a clean prefix, scaffolds a recipe, reports the installed version, starts a fake-Qoder HTTP deployment, reads health/ask, and proves PID cleanup. Deploy shipped in public `0.4.0` through that workflow; `0.3.0` predates deploy. DingTalk fixtures remain E3 only and real provider E4 remains external HOLD. |
 | Publisher-owned Runner kernel | Protocol, lease, replay, package snapshot and executor fixtures | Trusted-key Ed25519 task/receipt envelope verification, canonical event hash chains, signed monotonic renewals, fencing identity, nonce replay rejection, exact local package digest, read-only one-run snapshot, lease abort and stable signed failure receipts verified |
 | Cross-repository Runner path | Manual compiled framework and private-platform acceptance harness; not yet a committed CI job | Platform claim → local package/Agent Host → 4 uploaded events → Runner-signed receipt → independent usage verification → settled Credit completed on 2026-08-04; the platform never received a local path, package bytes or Host credential |
 | Real-local mem/doc read path (#42 Phase A) | Manual `scripts/real-local-harness.mjs` run against actual pinned services (mem `3335ebe`, doc `b22ff1d`), plus offline loopback-fake host/matrix tests in CI | 9/9 scenarios passed on 2026-08-06 (two-session granted resume with stable locators, cross-principal/workspace denial, wrong-revision/unauthorized/revoked-or-unlisted document reads, unreachable service, unsupported matrix); evidence class `real-local-e2e`, secret scan empty |
 | MCP declaration | TypeScript and public Schema fixtures | stdio and HTTPS declarations accept environment names only; inline HTTP auth fields, insecure HTTP and duplicate servers rejected |
-| Compiled package | Public `v0.3.0` artifacts; current-source `npm pack --json` and release consumer gate | `0.3.0` is the historical public root/core release. Current-source release policy requires immutable archive digest checks plus clean-tarball import/init/setup/deploy/health/ask/PID-cleanup verification; final current-PR-head file counts and byte sizes are pending. |
+| Compiled package | Public `v0.4.0` and `v0.3.0` artifacts; current-source `npm pack --json` and release consumer gate | `0.4.0` is the current public root/core release; `0.3.0` remains public and historical. Current-source release policy requires immutable archive digest checks plus clean-tarball import/init/setup/deploy/health/ask/PID-cleanup verification; per-change file counts and byte sizes are recorded per change, not inferred from a tag. |
 | Second profile | Explicitly allowlisted `minimal-reader` fixture through source and compiled runtimes | Answered with one approved citation; no core/CLI switch change |
 | Dependency audit | `npm audit --audit-level=high` | 0 known vulnerabilities |
 | Container | Built the current source `Dockerfile`; ran it with no arguments, then with explicit `legacy serve` | Default Agent-native help verified; explicit compatibility `/health` and `/v1/ask` verified |


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/143
- Consumed revision: R1
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | CONTRIBUTING.md, .github/pull_request_template.md | Doc-consistency rule stated for contributors: behavior-changing PRs carry a doc delta or an explicit no-doc-needed note; additive template checklist line verified compatible with the governance validator |
| REQ-001 / AC-001 | docs/verification.md, docs/deploy.md, docs/employee-package.md, docs/architecture.md | Doc drift repaired: stale pre-0.4.0 release framing and Codex CLI 0.146.0 citation updated to shipped 0.4.0 and audited 0.148.0 reality |
| REQ-002 / AC-002 | docs/knowledge/asset-convention.md | Knowledge asset convention committed: locations (package knowledge/, repo docs, DWS drive, mem/doc services, internal bases), naming, freshness, public-safe vs internal boundary |
| REQ-003 / AC-003 | docs/knowledge/knowledge-source-quality-bar.md, docs/employee-package.md, README.md | Quality bar (scope, freshness, provenance) aligned with the issue 42 read-path contract and deferring runtime retention to RFC 104; referenced from employee-package guidance and the README documentation index |
| REQ-004 / AC-003 | docs/knowledge/knowledge-source-quality-bar.md | Staleness convention: every context asset carries a last-verified date; review cadence per release gate and at least every 90 days |

## File domains

Single domain: context-infrastructure documentation plus one contributor-facing rule.

- `docs/knowledge/asset-convention.md` — new: asset locations, naming, freshness, public-safe boundary.
- `docs/knowledge/knowledge-source-quality-bar.md` — new: knowledge-source bar with staleness cadence.
- `docs/employee-package.md`, `README.md` — references to the bar; drift repairs.
- `CONTRIBUTING.md`, `.github/pull_request_template.md` — doc-consistency rule and checklist flag.
- `docs/verification.md`, `docs/deploy.md`, `docs/architecture.md` — drift repairs only.

## Scope and non-goals

User-visible change: contributors now have a stated doc-consistency rule, and employee authors have a committed knowledge-asset convention plus a knowledge-source quality bar referenced from package guidance.

Implementation boundary: documentation and PR-template checklist only.

Non-goals: no runtime change to the mem/doc read path or retention; no internal identifiers, private URLs, or secrets in any example.

## Validation

- Exact commands: `npm run check` under `LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8` on branch HEAD fd818b8.
- Observed counts/results: PASS 1431/1431 tests, fail 0; governance:check passed; security:check passed; template fill/validate tests pass with the additive checklist line.
- Check URLs: NOT VERIFIED: CI triggers on PR creation; the green run URL will be posted as a follow-up comment.

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-001 | Doc-consistency rule stated; no known drift in docs/ | `npm run check` plus manual pass over docs/ | macOS 15.5 arm64, Node v24.13.0 | Rule committed; drift list repaired | CONTRIBUTING rule committed; four stale framings repaired; no further drift found | PASS |
| V2 | AC-002 | Convention and quality bar committed and referenced | `ls docs/knowledge/` and grep employee-package guidance | Same as V1 | Both documents present; bar referenced from package guidance and README index | Both documents committed; references present in docs/employee-package.md and README.md | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs.
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed.
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded.

Docs-only change with one additive PR-template checklist line; the governance validator was checked before the template edit and only requires heading presence and required strings, so additive content is permitted. No dependency changes. npm audit: NOT VERIFIED on this branch; no dependency changed since the last green audit on main.

## Known limitations

- The doc-consistency flag is a checklist convention, not a CI-enforced rule; enforcement stays with reviewers.
- Interactive deploy-cli prompt tests are locale-sensitive (pre-existing); the full gate passes under en_US.UTF-8.
- Staleness cadence begins with newly committed assets; backfilling last-verified dates on older docs is follow-up.

## Risk and rollback

Low risk: documentation and template checklist only. Rollback: revert the two commits on this branch (5b969d4, fd818b8). No permissions, data flow, or irreversible effects.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: no release packet; content-side convention tracked on the canonical issue
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
