### PR TITLE
fix(runner): make replay claims carry the verified fencing token (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,15 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Public `RunnerReplayClaim` values now require the verified positive
+  safe-integer `fencingToken`; direct claim callers and typed custom guard
+  fixtures must add the field, while executor-integrated guards receive it
+  automatically. The durable adapter persists the value unchanged and rejects
+  lower tokens after a new guard instance is attached to the same store;
+  legacy durable records whose token is `0` fail closed because their original
+  ordering cannot be recovered. The preview guard now bounds nonce TTL entries
+  separately from process-lifetime task high-watermarks, but remains explicitly
+  restart-unsafe.
 - The external stdio Adapter no longer fails closed on its own teardown
   traffic (#113). After a synthesized Schema-mismatch terminal, the mandated
   closing response is drained before the run stream is deleted, and `cancel`

--- a/apps/cli/runner-executor.ts
+++ b/apps/cli/runner-executor.ts
@@ -338,6 +338,7 @@ export async function executeOneShotRunnerTask(
       runnerId: task.runnerId,
       taskId: task.taskId,
       nonce: task.nonce,
+      fencingToken: task.fencingToken,
       expiresAt: task.expiresAt,
     })
   } catch {

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -53,6 +53,13 @@ V0.3 的目标链路是：
 `executeOneShotRunnerTask()` 在签名、身份、lease 或 replay 等前置失败时 reject。nonce
 被原子消费后，包身份/摘要、输入或 Host 的确定性失败会正常 resolve，并携带 Runner
 签名的失败回执；平台据此结束 attempt，不得用同一个 nonce 重试。
+replay claim 必须把已验签的正安全整数 `fencingToken` 原样持久化；同一 task 已有更高 token
+时拒绝较低 token，不同 nonce 的相同 token 仍可按原子 claim 语义处理。旧版写入的 `0`
+无法还原原 token，因此同一 task 的后续 claim 保守失败关闭。
+`InMemoryRunnerReplayGuard` 仅在当前进程生命周期保留有界 task 高水位；nonce 到期清理不会
+降低该水位，但进程重启仍会丢失全部状态。`RunnerDurableStorePort` 及内存 reference store
+只定义和演示 compare-and-write 语义；生产 durable transaction、崩溃原子性及有界
+compaction conformance 仍为 **NOT VERIFIED**。
 
 长期 Runner 的传输层应把平台 API 映射为下面的调用关系，不能把平台返回的路径、命令
 或凭证传进执行器：

--- a/packages/core/src/runner-durable-store.ts
+++ b/packages/core/src/runner-durable-store.ts
@@ -237,6 +237,9 @@ export class DurableRunnerReplayGuard implements RunnerReplayGuardPort {
       typeof claim.runnerId !== "string" ||
       typeof claim.taskId !== "string" ||
       typeof claim.nonce !== "string" ||
+      typeof claim.fencingToken !== "number" ||
+      !Number.isSafeInteger(claim.fencingToken) ||
+      claim.fencingToken < 1 ||
       typeof claim.expiresAt !== "string"
     ) {
       throw new ValidationError("runner_replay_claim_invalid")
@@ -252,7 +255,7 @@ export class DurableRunnerReplayGuard implements RunnerReplayGuardPort {
       taskId: claim.taskId,
       runnerId: claim.runnerId,
       nonce: claim.nonce,
-      fencingToken: 0,
+      fencingToken: claim.fencingToken,
       status: "claimed",
       eventsEmitted: 0,
       claimedAt: now.toISOString(),
@@ -344,9 +347,14 @@ export class InMemoryDurableStore implements RunnerDurableStorePort {
     const key = `${attempt.taskId}::${attempt.nonce}`
     if (this.#attempts.has(key)) return false
 
-    // Check fencing: if a newer fencing token exists for this task, reject
+    // Check fencing: if a newer fencing token exists for this task, reject.
+    // A zero token can only come from the legacy replay adapter, which lost
+    // the verified value. Fail closed because its ordering cannot be proven.
     for (const existing of this.#attempts.values()) {
-      if (existing.taskId === attempt.taskId && existing.fencingToken > attempt.fencingToken) {
+      if (
+        existing.taskId === attempt.taskId &&
+        (existing.fencingToken === 0 || existing.fencingToken > attempt.fencingToken)
+      ) {
         return false
       }
     }

--- a/packages/core/src/runner-replay-guard.ts
+++ b/packages/core/src/runner-replay-guard.ts
@@ -8,6 +8,7 @@ export interface RunnerReplayClaim {
   runnerId: string
   taskId: string
   nonce: string
+  fencingToken: number
   expiresAt: string
 }
 
@@ -20,6 +21,7 @@ export interface RunnerReplayGuardPort {
 }
 
 export interface InMemoryRunnerReplayGuardOptions {
+  /** Independent upper bound for nonce entries and task high-watermarks. */
   maxEntries?: number
   clock?: () => Date
 }
@@ -41,7 +43,8 @@ function validTimestamp(value: string): number {
  * durable atomic port so restarts cannot reopen the replay window.
  */
 export class InMemoryRunnerReplayGuard implements RunnerReplayGuardPort {
-  readonly #entries = new Map<string, number>()
+  readonly #nonceEntries = new Map<string, number>()
+  readonly #taskHighWatermarks = new Map<string, number>()
   readonly #maxEntries: number
   readonly #clock: () => Date
   #lastClockMilliseconds = Number.NEGATIVE_INFINITY
@@ -69,8 +72,8 @@ export class InMemoryRunnerReplayGuard implements RunnerReplayGuardPort {
       descriptors = Object.getOwnPropertyDescriptors(claim)
       if (
         Reflect.ownKeys(descriptors).some((key) => typeof key !== "string") ||
-        Object.keys(descriptors).length !== 4 ||
-        !["runnerId", "taskId", "nonce", "expiresAt"].every((key) => {
+        Object.keys(descriptors).length !== 5 ||
+        !["runnerId", "taskId", "nonce", "fencingToken", "expiresAt"].every((key) => {
           const descriptor = descriptors[key]
           return (
             Object.hasOwn(descriptors, key) &&
@@ -88,15 +91,19 @@ export class InMemoryRunnerReplayGuard implements RunnerReplayGuardPort {
     const runnerId = descriptors.runnerId.value as unknown
     const taskId = descriptors.taskId.value as unknown
     const nonce = descriptors.nonce.value as unknown
+    const fencingToken = descriptors.fencingToken.value as unknown
     const expiresAt = descriptors.expiresAt.value as unknown
     if (
       typeof runnerId !== "string" ||
       typeof taskId !== "string" ||
       typeof nonce !== "string" ||
+      typeof fencingToken !== "number" ||
       typeof expiresAt !== "string" ||
       !CLAIM_ID_PATTERN.test(runnerId) ||
       !CLAIM_ID_PATTERN.test(taskId) ||
-      !BASE64URL_PATTERN.test(nonce)
+      !BASE64URL_PATTERN.test(nonce) ||
+      !Number.isSafeInteger(fencingToken) ||
+      fencingToken < 1
     ) {
       throw new ValidationError("runner_replay_claim_invalid")
     }
@@ -136,22 +143,37 @@ export class InMemoryRunnerReplayGuard implements RunnerReplayGuardPort {
     }
     this.#lastClockMilliseconds = nowMilliseconds
     const expiryMilliseconds = validTimestamp(expiresAt)
-    for (const [key, expiry] of this.#entries) {
-      if (expiry <= nowMilliseconds) this.#entries.delete(key)
+    for (const [key, expiry] of this.#nonceEntries) {
+      if (expiry <= nowMilliseconds) this.#nonceEntries.delete(key)
     }
     if (expiryMilliseconds <= nowMilliseconds) return false
     // Consume a nonce across all tasks for one Runner. taskId is validated for
     // auditability but deliberately cannot scope away a replay collision.
     const key = `${runnerId.length}:${runnerId}${nonce.length}:${nonce}`
-    if (this.#entries.has(key)) return false
-    if (this.#entries.size >= this.#maxEntries) {
+    if (this.#nonceEntries.has(key)) return false
+    const taskKey = taskId
+    const highWatermark = this.#taskHighWatermarks.get(taskKey)
+    if (highWatermark !== undefined && highWatermark > fencingToken) {
+      return false
+    }
+    if (
+      this.#nonceEntries.size >= this.#maxEntries ||
+      (highWatermark === undefined &&
+        this.#taskHighWatermarks.size >= this.#maxEntries)
+    ) {
       throw new CoreError(
         "RUNNER_REPLAY_GUARD_CAPACITY",
         "Runner replay guard cannot safely accept another claim",
         { retryable: true },
       )
     }
-    this.#entries.set(key, expiryMilliseconds)
+    // Capacity and ordering are checked before either table is mutated so a
+    // rejected claim cannot consume its nonce or advance a task watermark.
+    this.#taskHighWatermarks.set(
+      taskKey,
+      Math.max(highWatermark ?? fencingToken, fencingToken),
+    )
+    this.#nonceEntries.set(key, expiryMilliseconds)
     return true
   }
 }

--- a/tests/apps/runner-executor.test.ts
+++ b/tests/apps/runner-executor.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../../packages/core/src/runner-protocol.js"
 import type { RunnerTaskPayload } from "../../packages/core/src/runner-protocol.js"
 import { InMemoryRunnerReplayGuard } from "../../packages/core/src/runner-replay-guard.js"
+import type { RunnerReplayClaim } from "../../packages/core/src/runner-replay-guard.js"
 import { RunnerLeaseState } from "../../packages/core/src/runner-lease.js"
 
 function readyProbe(): AgentHostProbeResult {
@@ -240,9 +241,16 @@ function code(error: unknown): string | undefined {
 
 test("one-shot runner executes locally, chains events, aggregates usage, and signs receipt", async () => {
   const target = await fixture()
-  const replayGuard = new InMemoryRunnerReplayGuard({
+  const inMemoryReplayGuard = new InMemoryRunnerReplayGuard({
     clock: () => new Date("2026-08-04T00:00:01.000Z"),
   })
+  let observedReplayClaim: RunnerReplayClaim | undefined
+  const replayGuard = {
+    claim(claim: RunnerReplayClaim) {
+      observedReplayClaim = { ...claim }
+      return inMemoryReplayGuard.claim(claim)
+    },
+  }
   const secretReasoning = "never store this model text"
   const result = await executeOneShotRunnerTask({
     taskEnvelope: target.envelope,
@@ -273,6 +281,13 @@ test("one-shot runner executes locally, chains events, aggregates usage, and sig
     publicKey: target.runner.publicKey,
   })
   assert.equal(receipt.outcome.status, "completed")
+  assert.deepEqual(observedReplayClaim, {
+    runnerId: target.task.runnerId,
+    taskId: target.task.taskId,
+    nonce: target.task.nonce,
+    fencingToken: target.task.fencingToken,
+    expiresAt: target.task.expiresAt,
+  })
   assert.deepEqual(receipt.usage, {
     inputTokens: 10,
     outputTokens: 5,
@@ -315,6 +330,34 @@ test("one-shot runner executes locally, chains events, aggregates usage, and sig
       }),
     (error) => code(error) === "RUNNER_TASK_REPLAYED",
   )
+})
+
+test("signature failure does not call the replay guard", async () => {
+  const target = await fixture()
+  const wrong = generateKeyPairSync("ed25519")
+  let claimCalls = 0
+  await assert.rejects(
+    () =>
+      executeOneShotRunnerTask({
+        taskEnvelope: target.envelope,
+        resolvePlatformPublicKey: () => wrong.publicKey,
+        runnerId: target.task.runnerId,
+        sellerId: target.task.sellerId,
+        resolveLocalPackage: () => target.directory,
+        hostRegistry: registryFor(),
+        replayGuard: {
+          claim() {
+            claimCalls += 1
+            return true
+          },
+        },
+        receiptKeyId: "runner-key-1",
+        receiptPrivateKey: target.runner.privateKey,
+        clock: () => new Date("2026-08-04T00:00:01.000Z"),
+      }),
+    (error) => code(error) === "RUNNER_SIGNATURE_INVALID",
+  )
+  assert.equal(claimCalls, 0)
 })
 
 test("wrong keys, identities, expiry, and lease expiry are rejected before local execution", async () => {

--- a/tests/core/runner-durable-store.test.ts
+++ b/tests/core/runner-durable-store.test.ts
@@ -281,9 +281,37 @@ describe("DurableRunnerReplayGuard", () => {
       runnerId: "runner-A",
       taskId: "task-100",
       nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      fencingToken: 1,
       expiresAt: "2026-01-01T00:05:00.000Z",
     })
     assert.equal(ok, true)
+  })
+
+  it("persists the verified fencing token and rejects a lower token after restart", async () => {
+    const accepted = await guard.claim({
+      runnerId: "runner-A",
+      taskId: "task-100",
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      fencingToken: 9,
+      expiresAt: "2026-01-01T00:05:00.000Z",
+    })
+    assert.equal(accepted, true)
+    assert.equal(
+      store.getAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA")?.fencingToken,
+      9,
+    )
+
+    const restarted = new DurableRunnerReplayGuard(store, {
+      clock: () => new Date("2026-01-01T00:02:00.000Z"),
+    })
+    const stale = await restarted.claim({
+      runnerId: "runner-A",
+      taskId: "task-100",
+      nonce: "bmV3LW5vbmNlLTk4NzY1NDMyMQ",
+      fencingToken: 8,
+      expiresAt: "2026-01-01T00:05:00.000Z",
+    })
+    assert.equal(stale, false)
   })
 
   it("rejects duplicate nonce", async () => {
@@ -291,6 +319,7 @@ describe("DurableRunnerReplayGuard", () => {
       runnerId: "runner-A",
       taskId: "task-100",
       nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      fencingToken: 1,
       expiresAt: "2026-01-01T00:05:00.000Z",
     }
     await guard.claim(claim)
@@ -303,9 +332,71 @@ describe("DurableRunnerReplayGuard", () => {
       runnerId: "runner-A",
       taskId: "task-100",
       nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      fencingToken: 1,
       expiresAt: "2026-01-01T00:00:30.000Z", // before clock time
     })
     assert.equal(ok, false)
+    assert.equal(
+      store.getAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA"),
+      undefined,
+    )
+  })
+
+  it("accepts an equal fencing token with a different nonce", async () => {
+    assert.equal(
+      await guard.claim({
+        runnerId: "runner-A",
+        taskId: "task-100",
+        nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+        fencingToken: 5,
+        expiresAt: "2026-01-01T00:05:00.000Z",
+      }),
+      true,
+    )
+    assert.equal(
+      await guard.claim({
+        runnerId: "runner-A",
+        taskId: "task-100",
+        nonce: "bmV3LW5vbmNlLTk4NzY1NDMyMQ",
+        fencingToken: 5,
+        expiresAt: "2026-01-01T00:05:00.000Z",
+      }),
+      true,
+    )
+  })
+
+  it("rejects invalid fencing token numbers without persisting a claim", async () => {
+    for (const fencingToken of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      await assert.rejects(
+        () =>
+          guard.claim({
+            runnerId: "runner-A",
+            taskId: "task-100",
+            nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+            fencingToken,
+            expiresAt: "2026-01-01T00:05:00.000Z",
+          }),
+        (error: Error) => error.message.includes("invalid"),
+      )
+    }
+    assert.equal(
+      store.getAttempt("task-100", "dGVzdC1ub25jZS0xMjM0NTY3OA"),
+      undefined,
+    )
+  })
+
+  it("fails closed when a legacy zero-token record makes ordering unknowable", async () => {
+    assert.equal(store.claimNonce(makeAttempt({ fencingToken: 0 })), true)
+    assert.equal(
+      await guard.claim({
+        runnerId: "runner-A",
+        taskId: "task-100",
+        nonce: "bmV3LW5vbmNlLTk4NzY1NDMyMQ",
+        fencingToken: 10,
+        expiresAt: "2026-01-01T00:05:00.000Z",
+      }),
+      false,
+    )
   })
 
   it("throws on invalid claim shape", async () => {
@@ -320,6 +411,7 @@ describe("DurableRunnerReplayGuard", () => {
       runnerId: "runner-A",
       taskId: "task-100",
       nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      fencingToken: 1,
       expiresAt: "2026-01-01T00:05:00.000Z",
     })
     // New guard instance, same store (simulates restart)
@@ -330,6 +422,7 @@ describe("DurableRunnerReplayGuard", () => {
       runnerId: "runner-A",
       taskId: "task-100",
       nonce: "dGVzdC1ub25jZS0xMjM0NTY3OA",
+      fencingToken: 1,
       expiresAt: "2026-01-01T00:05:00.000Z",
     })
     assert.equal(ok, false)

--- a/tests/core/runner-replay-guard.test.ts
+++ b/tests/core/runner-replay-guard.test.ts
@@ -7,6 +7,7 @@ const claim = {
   runnerId: "runner-1",
   taskId: "task-1",
   nonce: Buffer.alloc(16, 1).toString("base64url"),
+  fencingToken: 1,
   expiresAt: "2026-08-04T00:05:00.000Z",
 }
 
@@ -71,12 +72,157 @@ test("replay guard rejects expired claims and bad clocks", () => {
   )
 })
 
+test("replay guard rejects a lower fencing token but accepts an equal token with a new nonce", () => {
+  const guard = new InMemoryRunnerReplayGuard({
+    clock: () => new Date("2026-08-04T00:00:00.000Z"),
+  })
+  assert.equal(guard.claim({ ...claim, fencingToken: 9 }), true)
+  assert.equal(
+    guard.claim({
+      ...claim,
+      runnerId: "runner-2",
+      nonce: Buffer.alloc(16, 2).toString("base64url"),
+      fencingToken: 8,
+    }),
+    false,
+  )
+  assert.equal(
+    guard.claim({
+      ...claim,
+      nonce: Buffer.alloc(16, 3).toString("base64url"),
+      fencingToken: 9,
+    }),
+    true,
+  )
+})
+
+test("replay guard retains a task high-watermark after the higher nonce expires", () => {
+  let now = new Date("2026-08-04T00:00:00.000Z")
+  const guard = new InMemoryRunnerReplayGuard({ clock: () => now })
+  assert.equal(
+    guard.claim({
+      ...claim,
+      fencingToken: 9,
+      expiresAt: "2026-08-04T00:01:00.000Z",
+    }),
+    true,
+  )
+  assert.equal(
+    guard.claim({
+      ...claim,
+      nonce: Buffer.alloc(16, 2).toString("base64url"),
+      fencingToken: 8,
+      expiresAt: "2026-08-04T00:10:00.000Z",
+    }),
+    false,
+  )
+
+  now = new Date("2026-08-04T00:01:00.000Z")
+  assert.equal(
+    guard.claim({
+      ...claim,
+      nonce: Buffer.alloc(16, 3).toString("base64url"),
+      fencingToken: 8,
+      expiresAt: "2026-08-04T00:10:00.000Z",
+    }),
+    false,
+  )
+  assert.equal(
+    guard.claim({
+      ...claim,
+      nonce: Buffer.alloc(16, 4).toString("base64url"),
+      fencingToken: 9,
+      expiresAt: "2026-08-04T00:10:00.000Z",
+    }),
+    true,
+  )
+})
+
+test("replay guard fails closed atomically when task watermark capacity is exhausted", () => {
+  let now = new Date("2026-08-04T00:00:00.000Z")
+  const guard = new InMemoryRunnerReplayGuard({ maxEntries: 1, clock: () => now })
+  assert.equal(
+    guard.claim({
+      ...claim,
+      fencingToken: 9,
+      expiresAt: "2026-08-04T00:01:00.000Z",
+    }),
+    true,
+  )
+
+  now = new Date("2026-08-04T00:01:00.000Z")
+  assert.throws(
+    () =>
+      guard.claim({
+        ...claim,
+        taskId: "task-2",
+        nonce: Buffer.alloc(16, 2).toString("base64url"),
+        fencingToken: 20,
+        expiresAt: "2026-08-04T00:10:00.000Z",
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "RUNNER_REPLAY_GUARD_CAPACITY",
+  )
+  assert.equal(
+    guard.claim({
+      ...claim,
+      nonce: Buffer.alloc(16, 2).toString("base64url"),
+      fencingToken: 9,
+      expiresAt: "2026-08-04T00:10:00.000Z",
+    }),
+    true,
+  )
+})
+
+test("replay guard capacity rejection does not advance an existing task watermark", () => {
+  let now = new Date("2026-08-04T00:00:00.000Z")
+  const guard = new InMemoryRunnerReplayGuard({ maxEntries: 1, clock: () => now })
+  assert.equal(
+    guard.claim({
+      ...claim,
+      fencingToken: 9,
+      expiresAt: "2026-08-04T00:01:00.000Z",
+    }),
+    true,
+  )
+  assert.throws(
+    () =>
+      guard.claim({
+        ...claim,
+        nonce: Buffer.alloc(16, 2).toString("base64url"),
+        fencingToken: 20,
+        expiresAt: "2026-08-04T00:10:00.000Z",
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "RUNNER_REPLAY_GUARD_CAPACITY",
+  )
+
+  now = new Date("2026-08-04T00:01:00.000Z")
+  assert.equal(
+    guard.claim({
+      ...claim,
+      nonce: Buffer.alloc(16, 3).toString("base64url"),
+      fencingToken: 10,
+      expiresAt: "2026-08-04T00:10:00.000Z",
+    }),
+    true,
+  )
+})
+
 test("replay guard validates and rejects proxy claims without traps", () => {
   const guard = new InMemoryRunnerReplayGuard({
     clock: () => new Date("2026-08-04T00:00:00.000Z"),
   })
   assert.throws(() => guard.claim({ ...claim, nonce: "short" }))
   assert.throws(() => guard.claim({ ...claim, taskId: "invalid task id" }))
+  for (const fencingToken of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.throws(() => guard.claim({ ...claim, fencingToken }))
+  }
+  assert.throws(() => guard.claim({ ...claim, fencingToken: "1" as never }))
 
   let traps = 0
   const proxy = new Proxy(claim, {


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/137
- Consumed revision: R1
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-002 | packages/core/src/runner-replay-guard.ts, packages/core/src/runner-durable-store.ts, apps/cli/runner-executor.ts | tests/core/runner-replay-guard.test.ts, tests/core/runner-durable-store.test.ts, tests/apps/runner-executor.test.ts |
| REQ-001 / AC-002 | docs/runner.md, CHANGELOG.md | Documentation of the fencing-token boundary and NOT VERIFIED durable-transaction scope |

## File domains

- packages/core/src/runner-replay-guard.ts — claim shape validation and in-memory preview guard; owned by the Runner trusted-execution surface under REQ-001.
- packages/core/src/runner-durable-store.ts — durable replay adapter persistence and compare-and-write fencing; owned by REQ-001.
- apps/cli/runner-executor.ts — passes the verified fencing token from the signed task into the replay claim; owned by REQ-001.
- tests/* — regression coverage for the new contract; owned by AC-002.
- docs/runner.md, CHANGELOG.md — boundary documentation; owned by REQ-001/AC-004.

## Scope and non-goals

User-visible change: replay claims now carry the verified positive safe-integer fencing token end to end. The executor passes the token from the signed task envelope; the durable adapter persists it unchanged and rejects lower tokens for the same task; legacy token-0 records fail closed because their original ordering cannot be recovered. The in-memory preview guard bounds nonce entries and per-task high-watermarks separately and remains explicitly restart-unsafe.

Non-goals: no production durable transaction, crash atomicity, or bounded compaction conformance is delivered here (documented as NOT VERIFIED); no change to lease signing, device-key lifecycle, or channel boundaries; no audit report in this PR.

## Validation

- Exact commands: `LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 npm run check`
- Observed counts/results: PASS 1440/1440
- Check URLs: NOT VERIFIED: CI triggers on PR creation; the green run URL will be posted as a follow-up comment.

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 | Replay claim without a positive safe-integer fencing token is rejected | LC_ALL=en_US.UTF-8 node --import tsx --test tests/core/runner-replay-guard.test.ts | macOS arm64, Node 24 | rejection tests pass | 43/43 pass (guard + durable store suite) | PASS |
| V2 | AC-002 | Executor-integrated guard receives the verified token; lower tokens rejected after higher ones | LC_ALL=en_US.UTF-8 node --import tsx --test tests/apps/runner-executor.test.ts | macOS arm64, Node 24 | executor suite green | 9/9 pass | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs.
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed.
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded.

Compatibility: `RunnerReplayClaim` gains a required field. Direct claim callers and typed custom guard fixtures must add `fencingToken`; executor-integrated guards receive it automatically. Legacy durable records with token 0 fail closed by design because their ordering cannot be proven. No dependency changed. L3 deep security review before push: no findings.

## Known limitations

- Production durable transaction semantics, crash atomicity, and bounded compaction conformance remain NOT VERIFIED; the durable port and in-memory reference store only define and demonstrate compare-and-write semantics.
- InMemoryRunnerReplayGuard loses all state on process restart; this is documented, not fixed, in this PR.
- The #137 audit report itself is out of scope here; this PR is the first tracked remediation under REQ-001.

## Risk and rollback

The change tightens replay fencing and only adds rejection paths; no credential flow is added or altered. Rollback: revert the commit, which restores the prior token-0 persistence behavior. No irreversible effect.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: remediation lands on main ahead of the v0.4.0 adoption release packet.
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
