### PR TITLE
feat(engine): built-in execution engine S1 skeleton — turn execution, context assembly, structural fail-closed (#165)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -476,6 +476,10 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@fullstack-ai-infra/digital-employee-engine": {
+      "resolved": "packages/engine",
+      "link": true
+    },
     "node_modules/@types/node": {
       "version": "26.2.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
@@ -1432,6 +1436,17 @@
       "name": "@fullstack-ai-infra/digital-employee-core",
       "version": "0.4.0",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/engine": {
+      "name": "@fullstack-ai-infra/digital-employee-engine",
+      "version": "0.4.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "8.20.0"
+      },
       "engines": {
         "node": ">=20"
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "./host-runtime": {
       "types": "./dist/apps/cli/host-runtime.d.ts",
       "import": "./dist/apps/cli/host-runtime.js"
+    },
+    "./engine": {
+      "types": "./dist/packages/engine/index.d.ts",
+      "import": "./dist/packages/engine/index.js"
     }
   },
   "workspaces": [

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@fullstack-ai-infra/digital-employee-engine",
+  "version": "0.4.0",
+  "description": "Built-in, TypeScript-native execution engine (read-only S1 core) for digital employees. Clean-room, dependency-light, no tool surface.",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fullstack-ai-infra/digital-employee.git"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "NOTICE"
+  ],
+  "scripts": {
+    "prepack": "npm --prefix ../.. run build"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "ajv": "8.20.0"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/engine/src/context-assembler.ts
+++ b/packages/engine/src/context-assembler.ts
@@ -1,0 +1,151 @@
+import { createHash } from "node:crypto"
+
+export const CONTEXT_ASSEMBLY_VERSION = "context-assembly.v1" as const
+
+/**
+ * Deterministic assembly order. The position bundle is the mandatory layer;
+ * the memory-recall slot is the single seam for the memory plane and stays
+ * empty until memory integration lands (its position is contractually fixed).
+ */
+export type ContextSlot =
+  | "position_instructions"
+  | "position_spec"
+  | "turn_input"
+  | "memory_recall"
+
+export const CONTEXT_SLOT_ORDER: readonly ContextSlot[] = [
+  "position_instructions",
+  "position_spec",
+  "turn_input",
+  "memory_recall",
+]
+
+export interface ContextBlock {
+  slot: ContextSlot
+  text: string
+  byteLength: number
+  /** Bytes removed by deterministic window management; 0 when untouched. */
+  truncatedBytes: number
+}
+
+export interface AssemblyManifestEntry {
+  slot: ContextSlot
+  byteLength: number
+  truncatedBytes: number
+}
+
+export interface AssemblyManifest {
+  schemaVersion: typeof CONTEXT_ASSEMBLY_VERSION
+  positionId: string
+  turnId: string
+  order: readonly ContextSlot[]
+  blocks: AssemblyManifestEntry[]
+  /** sha256 over the canonical serialization of the assembled block texts. */
+  digest: string
+}
+
+export interface AssembleContextInput {
+  positionId: string
+  turnId: string
+  instructions?: string
+  spec?: string
+  turnInput: string
+  /** Memory-plane recall lines; empty in the read-only skeleton. */
+  memoryRecall?: readonly string[]
+}
+
+export interface ContextWindowLimits {
+  maxBlockBytes?: number
+  maxTotalBytes?: number
+}
+
+export interface AssembledContext {
+  blocks: ContextBlock[]
+  manifest: AssemblyManifest
+}
+
+function truncateToByteBudget(text: string, maxBytes: number): {
+  kept: string
+  truncatedBytes: number
+} {
+  const total = Buffer.byteLength(text, "utf8")
+  if (total <= maxBytes) return { kept: text, truncatedBytes: 0 }
+  const buffer = Buffer.from(text, "utf8")
+  let end = maxBytes
+  // Never split a multi-byte sequence: walk back to a UTF-8 boundary.
+  while (end > 0 && (buffer[end]! & 0xc0) === 0x80) end -= 1
+  return {
+    kept: buffer.subarray(0, end).toString("utf8"),
+    truncatedBytes: total - end,
+  }
+}
+
+/**
+ * Deterministic context assembly: fixed slot order, byte-bounded blocks,
+ * truncation leaves a trace (byte counts in the manifest), and the digest
+ * covers the assembled texts so evidence can pin exactly what entered the
+ * window.
+ */
+export function assembleContext(
+  input: AssembleContextInput,
+  limits: ContextWindowLimits = {},
+): AssembledContext {
+  if (typeof input.turnInput !== "string" || input.turnInput.length === 0) {
+    throw new TypeError("turnInput must be a non-empty string")
+  }
+  const recall = input.memoryRecall ?? []
+  const candidates: Array<{ slot: ContextSlot; text: string | undefined }> = [
+    { slot: "position_instructions", text: input.instructions },
+    { slot: "position_spec", text: input.spec },
+    { slot: "turn_input", text: input.turnInput },
+    { slot: "memory_recall", text: recall.length > 0 ? recall.join("\n") : undefined },
+  ]
+
+  const blocks: ContextBlock[] = []
+  let remaining = limits.maxTotalBytes
+  for (const slotOrder of CONTEXT_SLOT_ORDER) {
+    const candidate = candidates.find((entry) => entry.slot === slotOrder)
+    if (!candidate || candidate.text === undefined) continue
+    let text = candidate.text
+    let truncatedBytes = 0
+    if (limits.maxBlockBytes !== undefined) {
+      const blockCut = truncateToByteBudget(text, limits.maxBlockBytes)
+      text = blockCut.kept
+      truncatedBytes += blockCut.truncatedBytes
+    }
+    if (remaining !== undefined) {
+      const totalCut = truncateToByteBudget(text, Math.max(0, remaining))
+      text = totalCut.kept
+      truncatedBytes += totalCut.truncatedBytes
+      remaining -= Buffer.byteLength(text, "utf8")
+    }
+    if (text.length === 0 && truncatedBytes === 0) continue
+    blocks.push({
+      slot: slotOrder,
+      text,
+      byteLength: Buffer.byteLength(text, "utf8"),
+      truncatedBytes,
+    })
+  }
+
+  const canonical = JSON.stringify(
+    blocks.map((block) => [block.slot, block.text]),
+  )
+  const digest = createHash("sha256").update(canonical, "utf8").digest("hex")
+
+  return {
+    blocks,
+    manifest: {
+      schemaVersion: CONTEXT_ASSEMBLY_VERSION,
+      positionId: input.positionId,
+      turnId: input.turnId,
+      order: CONTEXT_SLOT_ORDER,
+      blocks: blocks.map((block) => ({
+        slot: block.slot,
+        byteLength: block.byteLength,
+        truncatedBytes: block.truncatedBytes,
+      })),
+      digest,
+    },
+  }
+}

--- a/packages/engine/src/contracts.ts
+++ b/packages/engine/src/contracts.ts
@@ -1,0 +1,198 @@
+import type { SafeValue } from "../../core/src/contracts.js"
+
+/**
+ * Built-in execution engine protocol identity.
+ *
+ * The engine is the workspace's default execution body. It speaks its own
+ * contract vocabulary (independently defined); the event *shape* is kept
+ * compatible with agent-host.v1 so the workbench stays engine-agnostic.
+ */
+export const ENGINE_PROTOCOL_VERSION = "engine.v1" as const
+export const ENGINE_ID = "built-in" as const
+
+/**
+ * Terminal reasons are this repository's own enumeration. They are NOT a
+ * translation of any external enumeration; the coverage mapping is maintained
+ * only in internal design documents.
+ */
+export type TerminalReason =
+  | "goal_met"
+  | "invalid_output_exhausted"
+  | "turn_budget_exceeded"
+  | "position_budget_exceeded"
+  | "iteration_cap"
+  | "doom_loop"
+  | "deadline_exceeded"
+  | "cancelled"
+  | "engine_internal_error"
+
+/** Lowercase ASCII machine code: `[a-z0-9][a-z0-9._-]{0,127}`. */
+export const ENGINE_ERROR_CODE_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/
+
+export interface EngineTerminalError {
+  code: string
+  message: string
+  retryable: boolean
+  terminalReason: TerminalReason
+}
+
+interface EngineEventBase {
+  runId: string
+  timestamp: string
+}
+
+export type EngineEvent =
+  | (EngineEventBase & { type: "run.started" })
+  | (EngineEventBase & { type: "model.delta"; text: string })
+  | (EngineEventBase & {
+      type: "usage"
+      inputTokens?: number
+      outputTokens?: number
+      totalTokens?: number
+    })
+  | (EngineEventBase & {
+      type: "run.completed"
+      output: SafeValue
+      terminalReason: "goal_met"
+    })
+  | (EngineEventBase & {
+      type: "run.failed"
+      error: EngineTerminalError
+    })
+
+export function isTerminalEngineEvent(
+  event: EngineEvent,
+): event is Extract<EngineEvent, { type: "run.completed" | "run.failed" }> {
+  return event.type === "run.completed" || event.type === "run.failed"
+}
+
+/**
+ * Budget carried by a single turn. `maxIterations` bounds the
+ * validate/repair loop and is mandatory (no unbounded runs). Token budget is
+ * optional at the skeleton stage; full dual-dimension budget consumption
+ * (turn + position) lands with the loop-control slice.
+ */
+export interface TurnBudget {
+  maxIterations: number
+  maxTokens?: number
+}
+
+export interface PositionContextInput {
+  /** Position package instructions (SKILL/instruction asset). */
+  instructions?: string
+  /** Organization-tree role descriptor projection. */
+  spec?: string
+}
+
+export interface EngineTurnRequest {
+  workspaceRef: string
+  positionId: string
+  turnId: string
+  runId: string
+  /** Bounded, schema-validated turn input. */
+  input: SafeValue
+  budget: TurnBudget
+  /** Synchronous terminal schema, <= 16 KiB, compiled once. */
+  outputSchema?: SafeValue
+  position?: PositionContextInput
+  /** ISO 8601 UTC deadline; exceeding fails closed. */
+  deadline?: string
+  signal?: AbortSignal
+}
+
+const MAX_ID_LENGTH = 256
+const MAX_INPUT_BYTES = 256 * 1024
+
+export class EngineRequestError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly retryable = false,
+  ) {
+    super(message)
+    this.name = "EngineRequestError"
+  }
+}
+
+function assertBoundedId(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new EngineRequestError(
+      "engine.input_invalid",
+      `${label} must be a non-empty string`,
+    )
+  }
+  if (value.length > MAX_ID_LENGTH) {
+    throw new EngineRequestError(
+      "engine.input_invalid",
+      `${label} exceeds the bounded identifier length`,
+    )
+  }
+  return value
+}
+
+/**
+ * Fail-closed request validation. Any malformed field rejects the turn before
+ * any model consumption, assembly, or side effect.
+ */
+export function validateTurnRequest(
+  request: EngineTurnRequest,
+): EngineTurnRequest {
+  assertBoundedId(request.workspaceRef, "workspaceRef")
+  assertBoundedId(request.positionId, "positionId")
+  assertBoundedId(request.turnId, "turnId")
+  assertBoundedId(request.runId, "runId")
+  if (
+    typeof request.input === "string" &&
+    Buffer.byteLength(request.input, "utf8") > MAX_INPUT_BYTES
+  ) {
+    throw new EngineRequestError(
+      "engine.input_invalid",
+      "turn input exceeds the bounded size",
+    )
+  }
+  if (
+    !request.budget ||
+    !Number.isInteger(request.budget.maxIterations) ||
+    request.budget.maxIterations < 1
+  ) {
+    throw new EngineRequestError(
+      "engine.input_invalid",
+      "budget.maxIterations must be a positive integer",
+    )
+  }
+  if (
+    request.budget.maxTokens !== undefined &&
+    (!Number.isInteger(request.budget.maxTokens) ||
+      request.budget.maxTokens < 1)
+  ) {
+    throw new EngineRequestError(
+      "engine.input_invalid",
+      "budget.maxTokens must be a positive integer when present",
+    )
+  }
+  if (request.deadline !== undefined) {
+    const parsed = Date.parse(request.deadline)
+    if (Number.isNaN(parsed)) {
+      throw new EngineRequestError(
+        "engine.input_invalid",
+        "deadline must be a valid ISO 8601 timestamp",
+      )
+    }
+  }
+  return request
+}
+
+export function terminalError(
+  code: string,
+  message: string,
+  terminalReason: TerminalReason,
+  retryable = false,
+): EngineTerminalError {
+  if (!ENGINE_ERROR_CODE_PATTERN.test(code)) {
+    throw new EngineRequestError(
+      "engine.internal_error",
+      `terminal error code violates the machine-code pattern: ${code}`,
+    )
+  }
+  return { code, message, retryable, terminalReason }
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,0 +1,50 @@
+export {
+  ENGINE_ERROR_CODE_PATTERN,
+  ENGINE_ID,
+  ENGINE_PROTOCOL_VERSION,
+  EngineRequestError,
+  isTerminalEngineEvent,
+  terminalError,
+  validateTurnRequest,
+} from "./contracts.js"
+export type {
+  EngineEvent,
+  EngineTerminalError,
+  EngineTurnRequest,
+  PositionContextInput,
+  TerminalReason,
+  TurnBudget,
+} from "./contracts.js"
+
+export {
+  CONTEXT_ASSEMBLY_VERSION,
+  CONTEXT_SLOT_ORDER,
+  assembleContext,
+} from "./context-assembler.js"
+export type {
+  AssemblyManifest,
+  AssemblyManifestEntry,
+  AssembleContextInput,
+  AssembledContext,
+  ContextBlock,
+  ContextSlot,
+  ContextWindowLimits,
+} from "./context-assembler.js"
+
+export { createDeterministicModelPort } from "./model-port.js"
+export type {
+  ModelPort,
+  ModelTurnInput,
+  ModelTurnResult,
+  OutputViolation,
+} from "./model-port.js"
+
+export {
+  ENGINE_MAX_OUTPUT_SCHEMA_BYTES,
+  OutputSchemaGuardError,
+  prepareTerminalSchema,
+} from "./output-schema-guard.js"
+export type { PreparedTerminalSchema } from "./output-schema-guard.js"
+
+export { executeTurn } from "./turn-executor.js"
+export type { TurnExecutorOptions } from "./turn-executor.js"

--- a/packages/engine/src/model-port.ts
+++ b/packages/engine/src/model-port.ts
@@ -1,0 +1,54 @@
+import type { ContextBlock } from "./context-assembler.js"
+
+/**
+ * The model port is the engine's only outward seam for inference. The
+ * read-only engine core has no tool surface: the port returns text and usage,
+ * nothing executable.
+ */
+export interface OutputViolation {
+  attempt: number
+  /** Bounded, sanitized violation summary fed back into the repair loop. */
+  summary: string
+}
+
+export interface ModelTurnInput {
+  blocks: readonly ContextBlock[]
+  priorViolations: readonly OutputViolation[]
+}
+
+export interface ModelTurnResult {
+  text: string
+  inputTokens?: number
+  outputTokens?: number
+}
+
+export interface ModelPort {
+  complete(
+    input: ModelTurnInput,
+    signal?: AbortSignal,
+  ): Promise<ModelTurnResult>
+}
+
+/**
+ * Deterministic reference model port for fixtures and zero-credential
+ * acceptance: replays a scripted response list, one entry per call. A call
+ * beyond the script fails closed.
+ */
+export function createDeterministicModelPort(
+  script: readonly string[],
+): ModelPort {
+  let call = 0
+  return {
+    async complete(_input, signal) {
+      if (signal?.aborted) {
+        throw new Error("deterministic model port aborted")
+      }
+      if (call >= script.length) {
+        throw new Error("deterministic model port script exhausted")
+      }
+      const text = script[call]!
+      call += 1
+      return { text }
+    },
+  }
+}

--- a/packages/engine/src/output-schema-guard.ts
+++ b/packages/engine/src/output-schema-guard.ts
@@ -1,0 +1,79 @@
+import { Ajv2020 } from "ajv/dist/2020.js"
+
+import type { SafeValue } from "../../core/src/contracts.js"
+
+export const ENGINE_MAX_OUTPUT_SCHEMA_BYTES = 16 * 1024
+
+/**
+ * One bounded, immutable terminal-schema snapshot per turn. The compiled
+ * validator is the single synchronous terminal check: the validate/repair
+ * loop must consume this snapshot and never recompile.
+ *
+ * Asynchronous schemas are the canonical hazard: an accepted `$async`
+ * validator would let a Promise masquerade as a synchronous terminal
+ * guarantee, so every compile failure fails closed.
+ */
+export interface PreparedTerminalSchema {
+  json: string
+  value: SafeValue
+  validate: (candidate: unknown) => boolean
+}
+
+export class OutputSchemaGuardError extends Error {
+  constructor(
+    readonly code:
+      | "engine.output_schema_too_large"
+      | "engine.output_schema_invalid",
+    message: string,
+  ) {
+    super(message)
+    this.name = "OutputSchemaGuardError"
+  }
+}
+
+export function prepareTerminalSchema(
+  schema: SafeValue | undefined,
+  maxBytes = ENGINE_MAX_OUTPUT_SCHEMA_BYTES,
+): PreparedTerminalSchema | undefined {
+  if (schema === undefined) return undefined
+  try {
+    const json = JSON.stringify(schema)
+    if (typeof json !== "string" || json.length === 0) {
+      throw new OutputSchemaGuardError(
+        "engine.output_schema_invalid",
+        "output schema must serialize to a non-empty JSON document",
+      )
+    }
+    if (Buffer.byteLength(json, "utf8") > maxBytes) {
+      throw new OutputSchemaGuardError(
+        "engine.output_schema_too_large",
+        `output schema exceeds ${maxBytes} bytes`,
+      )
+    }
+    const ajv = new Ajv2020({
+      allErrors: true,
+      allowUnionTypes: true,
+      strict: false,
+      validateSchema: true,
+    })
+    const value = JSON.parse(json) as SafeValue
+    const compiled = ajv.compile(value as object)
+    if ("$async" in compiled && compiled.$async === true) {
+      throw new OutputSchemaGuardError(
+        "engine.output_schema_invalid",
+        "asynchronous output schemas are rejected",
+      )
+    }
+    return {
+      json,
+      value,
+      validate: (candidate: unknown) => compiled(candidate) === true,
+    }
+  } catch (error) {
+    if (error instanceof OutputSchemaGuardError) throw error
+    throw new OutputSchemaGuardError(
+      "engine.output_schema_invalid",
+      "output schema failed to compile",
+    )
+  }
+}

--- a/packages/engine/src/turn-executor.ts
+++ b/packages/engine/src/turn-executor.ts
@@ -1,0 +1,200 @@
+import type { SafeValue } from "../../core/src/contracts.js"
+
+import {
+  terminalError,
+  validateTurnRequest,
+  type EngineEvent,
+  type EngineTurnRequest,
+} from "./contracts.js"
+import { assembleContext } from "./context-assembler.js"
+import type { ModelPort, OutputViolation } from "./model-port.js"
+import {
+  OutputSchemaGuardError,
+  prepareTerminalSchema,
+} from "./output-schema-guard.js"
+
+export interface TurnExecutorOptions {
+  model: ModelPort
+  now?: () => Date
+}
+
+function timestamp(now: () => Date): string {
+  return now().toISOString()
+}
+
+/**
+ * Executes exactly one turn and yields a stream with a single trusted
+ * terminal event (`run.completed` or `run.failed`).
+ *
+ * S1 loop shape — the ONLY iteration source in the read-only core is the
+ * output validate/repair cycle: the model produces text, the terminal schema
+ * validates it, and a violation feeds a bounded repair attempt. There is no
+ * tool dispatch branch anywhere in this path; the model port returns text
+ * only. Budget and doom-loop machinery is layered on by the loop-control
+ * slice without relaxing this guarantee.
+ */
+export async function* executeTurn(
+  rawRequest: EngineTurnRequest,
+  options: TurnExecutorOptions,
+): AsyncGenerator<EngineEvent> {
+  const now = options.now ?? (() => new Date())
+  const runId = typeof rawRequest.runId === "string" ? rawRequest.runId : ""
+  let terminated = false
+
+  const fail = (
+    code: string,
+    message: string,
+    terminalReason: Parameters<typeof terminalError>[2],
+    retryable = false,
+  ): EngineEvent => {
+    terminated = true
+    return {
+      type: "run.failed",
+      runId,
+      timestamp: timestamp(now),
+      error: terminalError(code, message, terminalReason, retryable),
+    }
+  }
+
+  yield { type: "run.started", runId, timestamp: timestamp(now) }
+
+  // Fail-closed request validation and terminal-schema preparation happen
+  // before any model consumption.
+  let request: EngineTurnRequest
+  try {
+    request = validateTurnRequest(rawRequest)
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "turn request rejected"
+    yield fail("engine.input_invalid", message, "engine_internal_error")
+    return
+  }
+
+  let schema
+  try {
+    schema = prepareTerminalSchema(request.outputSchema)
+  } catch (error) {
+    if (error instanceof OutputSchemaGuardError) {
+      yield fail(error.code, error.message, "engine_internal_error")
+      return
+    }
+    yield fail(
+      "engine.output_schema_invalid",
+      "output schema preparation failed",
+      "engine_internal_error",
+    )
+    return
+  }
+
+  const assembled = assembleContext({
+    positionId: request.positionId,
+    turnId: request.turnId,
+    instructions: request.position?.instructions,
+    spec: request.position?.spec,
+    turnInput:
+      typeof request.input === "string"
+        ? request.input
+        : JSON.stringify(request.input),
+  })
+
+  const violations: OutputViolation[] = []
+  const maxIterations = request.budget.maxIterations
+
+  try {
+    for (let attempt = 1; attempt <= maxIterations; attempt += 1) {
+      if (request.signal?.aborted) {
+        yield fail("engine.cancelled", "turn cancelled", "cancelled")
+        return
+      }
+      if (
+        request.deadline !== undefined &&
+        now().getTime() > Date.parse(request.deadline)
+      ) {
+        yield fail(
+          "engine.deadline_exceeded",
+          "turn deadline exceeded",
+          "deadline_exceeded",
+          true,
+        )
+        return
+      }
+
+      const result = await options.model.complete(
+        { blocks: assembled.blocks, priorViolations: [...violations] },
+        request.signal,
+      )
+
+      if (
+        typeof result.inputTokens === "number" ||
+        typeof result.outputTokens === "number"
+      ) {
+        yield {
+          type: "usage",
+          runId,
+          timestamp: timestamp(now),
+          inputTokens: result.inputTokens,
+          outputTokens: result.outputTokens,
+        }
+      }
+      yield {
+        type: "model.delta",
+        runId,
+        timestamp: timestamp(now),
+        text: result.text,
+      }
+
+      if (schema === undefined) {
+        terminated = true
+        yield {
+          type: "run.completed",
+          runId,
+          timestamp: timestamp(now),
+          output: result.text,
+          terminalReason: "goal_met",
+        }
+        return
+      }
+
+      let candidate: unknown
+      try {
+        candidate = JSON.parse(result.text)
+      } catch {
+        violations.push({
+          attempt,
+          summary: "output is not valid JSON",
+        })
+        continue
+      }
+
+      if (schema.validate(candidate)) {
+        terminated = true
+        yield {
+          type: "run.completed",
+          runId,
+          timestamp: timestamp(now),
+          output: candidate as SafeValue,
+          terminalReason: "goal_met",
+        }
+        return
+      }
+
+      violations.push({
+        attempt,
+        summary: "output failed terminal schema validation",
+      })
+    }
+
+    // Repair attempts exhausted: fail closed, never fabricate a passing value.
+    yield fail(
+      "engine.output_invalid",
+      "output failed terminal schema validation after bounded repair attempts",
+      "invalid_output_exhausted",
+      true,
+    )
+  } catch (error) {
+    if (terminated) return
+    const message =
+      error instanceof Error ? error.message : "engine execution failed"
+    yield fail("engine.internal_error", message, "engine_internal_error", true)
+  }
+}

--- a/tests/engine/context-assembler.test.ts
+++ b/tests/engine/context-assembler.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  CONTEXT_SLOT_ORDER,
+  assembleContext,
+} from "../../packages/engine/src/index.js"
+
+const input = {
+  positionId: "repo-owner",
+  turnId: "turn-1",
+  instructions: "You are the repo owner.",
+  spec: "mode=read_only",
+  turnInput: "Summarize the open issues.",
+}
+
+test("assembly order is fixed and deterministic", () => {
+  const assembled = assembleContext(input)
+  assert.deepEqual(
+    assembled.blocks.map((block) => block.slot),
+    ["position_instructions", "position_spec", "turn_input"],
+  )
+  assert.deepEqual(assembled.manifest.order, [...CONTEXT_SLOT_ORDER])
+})
+
+test("memory recall slot stays empty until integration but keeps its place", () => {
+  const withoutRecall = assembleContext(input)
+  assert.ok(
+    !withoutRecall.blocks.some((block) => block.slot === "memory_recall"),
+  )
+  const withRecall = assembleContext({ ...input, memoryRecall: ["fact A"] })
+  const recallBlock = withRecall.blocks.find(
+    (block) => block.slot === "memory_recall",
+  )
+  assert.ok(recallBlock)
+  assert.equal(recallBlock!.text, "fact A")
+  assert.equal(
+    withRecall.blocks[withRecall.blocks.length - 1]!.slot,
+    "memory_recall",
+  )
+})
+
+test("digest is stable for identical inputs and changes with content", () => {
+  const first = assembleContext(input)
+  const second = assembleContext({ ...input })
+  assert.equal(first.manifest.digest, second.manifest.digest)
+  const changed = assembleContext({ ...input, turnInput: "Different." })
+  assert.notEqual(first.manifest.digest, changed.manifest.digest)
+})
+
+test("block byte limit truncates and leaves a trace", () => {
+  const assembled = assembleContext(
+    { ...input, instructions: "a".repeat(100) },
+    { maxBlockBytes: 40 },
+  )
+  const instructions = assembled.blocks.find(
+    (block) => block.slot === "position_instructions",
+  )!
+  assert.equal(instructions.byteLength, 40)
+  assert.equal(instructions.truncatedBytes, 60)
+  assert.equal(
+    assembled.manifest.blocks.find(
+      (entry) => entry.slot === "position_instructions",
+    )!.truncatedBytes,
+    60,
+  )
+})
+
+test("total byte limit truncates lower-priority slots last", () => {
+  const assembled = assembleContext(
+    {
+      ...input,
+      instructions: "i".repeat(50),
+      spec: "s".repeat(50),
+      turnInput: "t".repeat(50),
+    },
+    { maxTotalBytes: 120 },
+  )
+  const total = assembled.blocks.reduce(
+    (sum, block) => sum + block.byteLength,
+    0,
+  )
+  assert.ok(total <= 120)
+  assert.equal(assembled.blocks[0]!.byteLength, 50)
+  assert.equal(assembled.blocks[1]!.byteLength, 50)
+  assert.equal(assembled.blocks[2]!.byteLength, 20)
+  assert.equal(assembled.blocks[2]!.truncatedBytes, 30)
+})
+
+test("multi-byte truncation never splits a code point", () => {
+  const assembled = assembleContext(
+    { ...input, instructions: "汉".repeat(10) },
+    { maxBlockBytes: 4 },
+  )
+  const instructions = assembled.blocks.find(
+    (block) => block.slot === "position_instructions",
+  )!
+  assert.equal(instructions.byteLength, 3)
+  assert.equal(instructions.text, "汉")
+  assert.equal(instructions.truncatedBytes, 27)
+})
+
+test("empty turn input is rejected", () => {
+  assert.throws(() => assembleContext({ ...input, turnInput: "" }), TypeError)
+})

--- a/tests/engine/output-schema-guard.test.ts
+++ b/tests/engine/output-schema-guard.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  ENGINE_MAX_OUTPUT_SCHEMA_BYTES,
+  OutputSchemaGuardError,
+  prepareTerminalSchema,
+} from "../../packages/engine/src/index.js"
+
+test("undefined schema prepares nothing", () => {
+  assert.equal(prepareTerminalSchema(undefined), undefined)
+})
+
+test("valid schema compiles and validates candidates", () => {
+  const prepared = prepareTerminalSchema({
+    type: "object",
+    properties: { answer: { type: "string" } },
+    required: ["answer"],
+  })
+  assert.ok(prepared)
+  assert.equal(prepared!.validate({ answer: "ok" }), true)
+  assert.equal(prepared!.validate({ answer: 3 }), false)
+  assert.equal(prepared!.validate("nope"), false)
+})
+
+test("oversized schema fails closed", () => {
+  const schema = {
+    type: "object",
+    properties: { filler: { description: "x".repeat(ENGINE_MAX_OUTPUT_SCHEMA_BYTES) } },
+  }
+  assert.throws(
+    () => prepareTerminalSchema(schema),
+    (error: unknown) =>
+      error instanceof OutputSchemaGuardError &&
+      error.code === "engine.output_schema_too_large",
+  )
+})
+
+test("async schema fails closed", () => {
+  const schema = {
+    $async: true,
+    type: "object",
+    properties: { answer: { type: "string" } },
+  }
+  assert.throws(
+    () => prepareTerminalSchema(schema),
+    (error: unknown) =>
+      error instanceof OutputSchemaGuardError &&
+      error.code === "engine.output_schema_invalid",
+  )
+})
+
+test("malformed schema fails closed", () => {
+  assert.throws(
+    () => prepareTerminalSchema({ type: "not-a-type" }),
+    (error: unknown) => error instanceof OutputSchemaGuardError,
+  )
+})
+
+test("the snapshot json round-trips the schema value", () => {
+  const schema = { type: "object", properties: { ok: { type: "boolean" } } }
+  const prepared = prepareTerminalSchema(schema)
+  assert.deepEqual(JSON.parse(prepared!.json), schema)
+})

--- a/tests/engine/structural-fail-closed.test.ts
+++ b/tests/engine/structural-fail-closed.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict"
+import { readdirSync, readFileSync } from "node:fs"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+/**
+ * Structural fail-closed assertion for the read-only engine core.
+ *
+ * The engine's absence of a tool surface is a fact of construction, not a
+ * configuration: the package must contain no process spawning, no network
+ * stack, and no filesystem access outside the explicitly-scoped reference
+ * ports (none exist in the skeleton slice). This scan makes that guarantee
+ * machine-checked and regression-proof.
+ */
+
+const ENGINE_SRC = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../packages/engine/src",
+)
+
+const FORBIDDEN_IMPORT_SPECS = [
+  "node:child_process",
+  "node:net",
+  "node:http",
+  "node:http2",
+  "node:https",
+  "node:tls",
+  "node:dgram",
+  "node:worker_threads",
+  "node:fs",
+  "node:fs/promises",
+  "child_process",
+  "net",
+  "http",
+  "https",
+] as const
+
+const FORBIDDEN_USAGE_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  { name: "global fetch", pattern: /\bfetch\s*\(/ },
+  { name: "WebSocket", pattern: /\bWebSocket\b/ },
+  { name: "XMLHttpRequest", pattern: /\bXMLHttpRequest\b/ },
+  { name: "process.env credential surface", pattern: /\bprocess\.env\b/ },
+  { name: "dynamic import of arbitrary modules", pattern: /\bimport\s*\(/ },
+]
+
+/** Node built-ins the engine core may use (hashing for digests only). */
+const ALLOWED_NODE_SPECS = new Set(["node:crypto"])
+
+function listSourceFiles(dir: string): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true })
+  const files: string[] = []
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...listSourceFiles(full))
+    } else if (entry.name.endsWith(".ts")) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+function importSpecifiers(source: string): string[] {
+  const specs: string[] = []
+  const staticPattern = /(?:import|export)[^;]*?from\s*["']([^"']+)["']/g
+  const sideEffectPattern = /^\s*import\s*["']([^"']+)["']/gm
+  for (const match of source.matchAll(staticPattern)) specs.push(match[1]!)
+  for (const match of source.matchAll(sideEffectPattern)) specs.push(match[1]!)
+  return specs
+}
+
+test("engine source contains no forbidden module imports", () => {
+  const files = listSourceFiles(ENGINE_SRC)
+  assert.ok(files.length > 0, "engine source files must exist")
+  const violations: string[] = []
+  for (const file of files) {
+    const source = readFileSync(file, "utf8")
+    for (const spec of importSpecifiers(source)) {
+      if (FORBIDDEN_IMPORT_SPECS.includes(spec as never)) {
+        violations.push(`${path.relative(ENGINE_SRC, file)}: imports ${spec}`)
+      }
+      if (spec.startsWith("node:") && !ALLOWED_NODE_SPECS.has(spec)) {
+        violations.push(
+          `${path.relative(ENGINE_SRC, file)}: unlisted node builtin ${spec}`,
+        )
+      }
+    }
+  }
+  assert.deepEqual(violations, [])
+})
+
+test("engine source contains no network or process usage", () => {
+  const files = listSourceFiles(ENGINE_SRC)
+  const violations: string[] = []
+  for (const file of files) {
+    const source = readFileSync(file, "utf8")
+    for (const { name, pattern } of FORBIDDEN_USAGE_PATTERNS) {
+      if (pattern.test(source)) {
+        violations.push(`${path.relative(ENGINE_SRC, file)}: ${name}`)
+      }
+    }
+  }
+  assert.deepEqual(violations, [])
+})

--- a/tests/engine/turn-executor.test.ts
+++ b/tests/engine/turn-executor.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  createDeterministicModelPort,
+  executeTurn,
+  isTerminalEngineEvent,
+} from "../../packages/engine/src/index.js"
+import type {
+  EngineEvent,
+  EngineTurnRequest,
+} from "../../packages/engine/src/index.js"
+
+const FIXED_NOW = () => new Date("2026-08-23T00:00:00.000Z")
+
+function baseRequest(overrides: Partial<EngineTurnRequest> = {}): EngineTurnRequest {
+  return {
+    workspaceRef: "ws-1",
+    positionId: "repo-owner",
+    turnId: "turn-1",
+    runId: "run-1",
+    input: "Summarize the open issues.",
+    budget: { maxIterations: 3 },
+    position: {
+      instructions: "You are the repo owner.",
+      spec: "mode=read_only",
+    },
+    ...overrides,
+  }
+}
+
+async function collect(
+  request: EngineTurnRequest,
+  model: ReturnType<typeof createDeterministicModelPort>,
+): Promise<EngineEvent[]> {
+  const events: EngineEvent[] = []
+  for await (const event of executeTurn(request, { model, now: FIXED_NOW })) {
+    events.push(event)
+  }
+  return events
+}
+
+test("completes with a single terminal event and no schema", async () => {
+  const model = createDeterministicModelPort(["plain answer"])
+  const events = await collect(baseRequest(), model)
+  const terminals = events.filter(isTerminalEngineEvent)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.completed")
+  if (terminals[0]!.type === "run.completed") {
+    assert.equal(terminals[0]!.output, "plain answer")
+    assert.equal(terminals[0]!.terminalReason, "goal_met")
+  }
+  assert.equal(events[0]!.type, "run.started")
+})
+
+test("repair loop recovers within the iteration budget", async () => {
+  const schema = {
+    type: "object",
+    properties: { answer: { type: "string" } },
+    required: ["answer"],
+    additionalProperties: false,
+  }
+  const model = createDeterministicModelPort([
+    "not json",
+    '{"answer":"fixed"}',
+  ])
+  const events = await collect(baseRequest({ outputSchema: schema }), model)
+  const terminal = events.filter(isTerminalEngineEvent)
+  assert.equal(terminal.length, 1)
+  assert.equal(terminal[0]!.type, "run.completed")
+  if (terminal[0]!.type === "run.completed") {
+    assert.deepEqual(terminal[0]!.output, { answer: "fixed" })
+  }
+})
+
+test("exhausted repair attempts fail closed with a stable code", async () => {
+  const schema = { type: "object", properties: { ok: { type: "boolean" } } }
+  const model = createDeterministicModelPort(["bad", "still bad", "nope"])
+  const events = await collect(
+    baseRequest({ outputSchema: schema, budget: { maxIterations: 3 } }),
+    model,
+  )
+  const terminal = events.filter(isTerminalEngineEvent)
+  assert.equal(terminal.length, 1)
+  assert.equal(terminal[0]!.type, "run.failed")
+  if (terminal[0]!.type === "run.failed") {
+    assert.equal(terminal[0]!.error.code, "engine.output_invalid")
+    assert.equal(terminal[0]!.error.terminalReason, "invalid_output_exhausted")
+    assert.equal(terminal[0]!.error.retryable, true)
+  }
+})
+
+test("malformed request fails closed before model consumption", async () => {
+  let calls = 0
+  const model = {
+    async complete() {
+      calls += 1
+      return { text: "never" }
+    },
+  }
+  const events = await collect(
+    baseRequest({ budget: { maxIterations: 0 } }),
+    model,
+  )
+  assert.equal(calls, 0)
+  const terminal = events.filter(isTerminalEngineEvent)
+  assert.equal(terminal.length, 1)
+  assert.equal(terminal[0]!.type, "run.failed")
+  if (terminal[0]!.type === "run.failed") {
+    assert.equal(terminal[0]!.error.code, "engine.input_invalid")
+  }
+})
+
+test("oversized output schema is rejected before any model call", async () => {
+  let calls = 0
+  const model = {
+    async complete() {
+      calls += 1
+      return { text: "{}" }
+    },
+  }
+  const hugeSchema = {
+    type: "object",
+    properties: { filler: { type: "string", description: "x".repeat(20_000) } },
+  }
+  const events = await collect(
+    baseRequest({ outputSchema: hugeSchema }),
+    model,
+  )
+  assert.equal(calls, 0)
+  const terminal = events.filter(isTerminalEngineEvent)
+  assert.equal(terminal.length, 1)
+  assert.equal(terminal[0]!.type, "run.failed")
+  if (terminal[0]!.type === "run.failed") {
+    assert.equal(terminal[0]!.error.code, "engine.output_schema_too_large")
+  }
+})
+
+test("abort signal yields the cancelled terminal", async () => {
+  const controller = new AbortController()
+  controller.abort()
+  const model = createDeterministicModelPort(["unused"])
+  const events = await collect(
+    baseRequest({ signal: controller.signal }),
+    model,
+  )
+  const terminal = events.filter(isTerminalEngineEvent)
+  assert.equal(terminal.length, 1)
+  assert.equal(terminal[0]!.type, "run.failed")
+  if (terminal[0]!.type === "run.failed") {
+    assert.equal(terminal[0]!.error.terminalReason, "cancelled")
+  }
+})
+
+test("deadline exceeded fails closed retryable", async () => {
+  const model = createDeterministicModelPort(["unused"])
+  const events = await collect(
+    baseRequest({ deadline: "2026-08-22T00:00:00.000Z" }),
+    model,
+  )
+  const terminal = events.filter(isTerminalEngineEvent)
+  assert.equal(terminal.length, 1)
+  assert.equal(terminal[0]!.type, "run.failed")
+  if (terminal[0]!.type === "run.failed") {
+    assert.equal(terminal[0]!.error.terminalReason, "deadline_exceeded")
+    assert.equal(terminal[0]!.error.retryable, true)
+  }
+})
+
+test("model failure surfaces as engine_internal_error with one terminal", async () => {
+  const model = {
+    async complete(): Promise<{ text: string }> {
+      throw new Error("inference unavailable")
+    },
+  }
+  const events = await collect(baseRequest(), model)
+  const terminal = events.filter(isTerminalEngineEvent)
+  assert.equal(terminal.length, 1)
+  assert.equal(terminal[0]!.type, "run.failed")
+  if (terminal[0]!.type === "run.failed") {
+    assert.equal(terminal[0]!.error.code, "engine.internal_error")
+    assert.equal(terminal[0]!.error.terminalReason, "engine_internal_error")
+  }
+})
+
+test("usage events are emitted when the model reports tokens", async () => {
+  const model = {
+    async complete() {
+      return { text: "answer", inputTokens: 10, outputTokens: 4 }
+    },
+  }
+  const events = await collect(baseRequest(), model)
+  const usage = events.filter((event) => event.type === "usage")
+  assert.equal(usage.length, 1)
+  assert.equal(usage[0]!.type, "usage")
+  if (usage[0]!.type === "usage") {
+    assert.equal(usage[0]!.inputTokens, 10)
+    assert.equal(usage[0]!.outputTokens, 4)
+  }
+})


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/165
- Consumed revision: R3
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 (S1 skeleton) | packages/engine/src/contracts.ts, packages/engine/src/turn-executor.ts | tests/engine/turn-executor.test.ts: bounded request validation fails closed before any model consumption; exactly one terminal event per turn; output validate/repair cycle is the only iteration source; abort/deadline/model-failure terminals carry stable `engine.*` codes with retryable flags |
| REQ-001 (terminal schema discipline) | packages/engine/src/output-schema-guard.ts | tests/engine/output-schema-guard.test.ts: schema <= 16 KiB, synchronous-only (`$async` rejected), single compiled snapshot reused for terminal validation; oversize/invalid schemas rejected before any model call |
| REQ-002 (S1 skeleton) | packages/engine/src/context-assembler.ts | tests/engine/context-assembler.test.ts: fixed deterministic slot order; sha256 assembly digest pins exactly what entered the window; truncation leaves byte-count trace; memory-recall slot fixed in place and empty (seam asserted) |
| REQ-004 | packages/engine/src (all modules, by construction) | tests/engine/structural-fail-closed.test.ts: static import-surface scan rejects child_process/net/http/https/tls/dgram/worker_threads/fs and unlisted node builtins (only node:crypto allowed); usage scan rejects fetch/WebSocket/process.env/dynamic import |
| Decision record (open decision 1) | package.json (root exports), packages/engine/package.json | new `./engine` export-map entry; workspace package `@fullstack-ai-infra/digital-employee-engine`; engine is the built-in default Host behind its own `engine.v1` contract |

## File domains

- packages/engine/src/contracts.ts — engine.v1 vocabulary: terminal-reason enumeration (independently defined), `engine.*` stable machine codes, bounded `EngineTurnRequest` validation, event stream with exactly one trusted terminal; owned by REQ-001.
- packages/engine/src/turn-executor.ts — the S1 loop skeleton: fail-closed request/schema preparation, context assembly, bounded output validate/repair cycle, single-terminal guarantee; no tool dispatch branch exists in this path; owned by REQ-001.
- packages/engine/src/context-assembler.ts — deterministic context assembly: fixed slot order (position instructions / position spec / turn input / memory recall), byte-bounded blocks, truncation traces, content digest for evidence; owned by REQ-002.
- packages/engine/src/model-port.ts — the engine's only outward inference seam: text + usage in, nothing executable out; deterministic reference port for zero-credential fixtures; owned by REQ-001/REQ-004.
- packages/engine/src/output-schema-guard.ts — bounded synchronous terminal-schema snapshot (16 KiB cap, `$async` rejected, single compile); owned by REQ-001.
- packages/engine/src/index.ts — public engine surface; owned by the packaging decision.
- tests/engine/*.test.ts — 24 tests across executor, assembler, guard, and the structural fail-closed scan; owned by REQ-001/REQ-002/REQ-004.
- package.json / package-lock.json — additive `./engine` export entry and workspace-member lockfile entry; owned by the packaging decision.

## Scope and non-goals

User-visible change: none. This PR adds the built-in engine package (`./engine` export) with the S1 skeleton: turn-contract execution, deterministic context assembly, and structural fail-closed assertions. The engine has no tool surface by construction — no process spawning, no network stack, no filesystem access in the core modules (machine-checked by the import-surface scan).

Non-goals (per the approved PR split): budget consumption, doom-loop detection, escalation records, and turn evidence land in PR-2; showcase acceptance wiring lands in PR-3. No CLI surface, no org-model changes, no credentials, no model provider wiring, no network egress.

## Validation

- Exact commands: `npm run typecheck`; `npx tsx --test --test-concurrency=1 tests/engine/*.test.ts`; `npm run check`
- Observed counts/results: engine tests 24/24 PASS; `npm run typecheck` PASS (both projects); full suite 1571 tests with 2 pre-existing failures outside this PR's domains (see Known limitations).
- Check URLs: NOT VERIFIED: CI triggers on PR creation; the green run URL will be posted as a follow-up comment.

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 | Every turn yields exactly one terminal; malformed requests and oversize/async schemas fail closed before model consumption | npx tsx --test tests/engine/turn-executor.test.ts tests/engine/output-schema-guard.test.ts | WSL Ubuntu-22.04, Node v22.14.0 | single-terminal assertions green; zero model calls on rejection paths | 24/24 engine assertions green; rejection paths make zero model calls | PASS |
| V2 | REQ-002 | Assembly order deterministic; digest stable; truncation traced; memory seam empty but placed | npx tsx --test tests/engine/context-assembler.test.ts | as above | 7/7 assertions green | 7/7 green | PASS |
| V3 | REQ-004 | No forbidden imports/usage anywhere in packages/engine/src | npx tsx --test tests/engine/structural-fail-closed.test.ts | as above | zero violations | zero violations | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs. (engine emits no logs; events carry bounded digests and counters, and model text stays inside the turn stream)
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed. (packages/engine declares ajv 8.20.0, already the root runtime dependency; no new lockfile package added)
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded.

Compatibility: additive only. New workspace package and one export-map entry; existing init/validate/eval/run/deploy/doctor/workspace semantics unchanged. `npm audit --omit=dev` reports 0 vulnerabilities.

## Known limitations

- Budget consumption (turn + position), doom-loop detection, escalation records, and turn-evidence.v1 are intentionally deferred to PR-2 per the approved split; the skeleton's iteration cap is the only loop bound in this PR.
- ModelPort ships with a deterministic reference implementation only; provider wiring is out of scope for the read-only skeleton.
- Engine events mirror the agent-host.v1 event shape for workbench compatibility; no agent-host.v1 conformance claim is made for the built-in engine in this PR.
- Full local `npm run check` surfaces two pre-existing failures outside this PR's domains, both confirmed unrelated to these additive changes: (a) `tests/apps/deploy-cli.test.ts` HTTP-activation IPC lease — a known WSL-local environmental failure that fails on clean `main` and is gated by Linux CI; (b) `tests/git/git-source.test.ts` future-timestamp case — re-run on clean `main` with this PR stashed and it fails identically (27/28). Neither test imports `packages/engine`. Linux CI is authoritative.

## Risk and rollback

The change only adds a new package and tests; it cannot mutate existing runtime behavior (no existing module imports the engine yet). Rollback: revert the commit; no irreversible effect.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: W1 — Workspace closed loop
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
