### PR TITLE
feat(engine): loop control — dual-dimension budgets, doom-loop detection, escalation records, per-turn evidence (#165)

### DIFF
--- a/packages/engine/src/budget.ts
+++ b/packages/engine/src/budget.ts
@@ -1,0 +1,199 @@
+/**
+ * Dual-dimension budget contract (turn budget + position budget).
+ *
+ * Declaration lives in the organization model; execution lives in the engine.
+ * Units are tokens and iterations only — no monetary dimension enters the
+ * budget gate (billing semantics are a non-goal of the workspace milestone).
+ */
+
+export const MAX_BUDGET_CAP = 1_000_000_000
+
+export interface BudgetScope {
+  tokens?: number
+  iterations?: number
+}
+
+export interface PositionBudgetDeclaration {
+  perTask: BudgetScope
+  perDay: BudgetScope
+}
+
+export interface BudgetUsage {
+  taskUsedTokens: number
+  taskUsedIterations: number
+  dayUsedTokens: number
+  dayUsedIterations: number
+}
+
+export type BudgetDimension =
+  | "position_day_tokens"
+  | "position_day_iterations"
+  | "position_task_tokens"
+  | "position_task_iterations"
+  | "turn_tokens"
+  | "turn_iterations"
+
+export interface BudgetExceeded {
+  dimension: BudgetDimension
+  used: number
+  limit: number
+}
+
+function isPositiveBoundedInt(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value > 0 &&
+    value <= MAX_BUDGET_CAP
+  )
+}
+
+function scopeAllocated(scope: BudgetScope): boolean {
+  return (
+    isPositiveBoundedInt(scope.tokens) || isPositiveBoundedInt(scope.iterations)
+  )
+}
+
+/**
+ * Fail-closed validation of a position budget declaration. "Fully allocated"
+ * means both scopes are present and each carries at least one positive,
+ * bounded integer cap.
+ */
+export function validatePositionBudgetDeclaration(
+  value: unknown,
+): PositionBudgetDeclaration {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("workspace_org_budget_missing")
+  }
+  const record = value as Record<string, unknown>
+  const perTask = record.perTask
+  const perDay = record.perDay
+  if (
+    perTask === null ||
+    typeof perTask !== "object" ||
+    Array.isArray(perTask) ||
+    perDay === null ||
+    typeof perDay !== "object" ||
+    Array.isArray(perDay)
+  ) {
+    throw new TypeError("workspace_org_budget_not_allocated")
+  }
+  const taskScope = perTask as BudgetScope
+  const dayScope = perDay as BudgetScope
+  // Key/value legality is checked first so a malformed cap fails closed as
+  // invalid rather than being masked as an unallocated scope.
+  for (const scope of [taskScope, dayScope]) {
+    for (const key of Object.keys(scope)) {
+      if (key !== "tokens" && key !== "iterations") {
+        throw new TypeError("workspace_org_budget_invalid")
+      }
+      if (!isPositiveBoundedInt(scope[key as keyof BudgetScope])) {
+        throw new TypeError("workspace_org_budget_invalid")
+      }
+    }
+  }
+  // Then each scope must carry at least one cap.
+  if (!scopeAllocated(taskScope) || !scopeAllocated(dayScope)) {
+    throw new TypeError("workspace_org_budget_not_allocated")
+  }
+  return { perTask: taskScope, perDay: dayScope }
+}
+
+/**
+ * Durable consumption ledger for position budgets. The engine core depends on
+ * this port only; persistence policy (workspace-local JSON, 0600) belongs to
+ * the wiring layer.
+ */
+export interface BudgetLedgerPort {
+  read(
+    positionId: string,
+    taskId: string,
+    dayKey: string,
+  ): Promise<BudgetUsage>
+  commit(entry: {
+    positionId: string
+    taskId: string
+    dayKey: string
+    tokens: number
+    iterations: number
+  }): Promise<void>
+}
+
+export function emptyBudgetUsage(): BudgetUsage {
+  return {
+    taskUsedTokens: 0,
+    taskUsedIterations: 0,
+    dayUsedTokens: 0,
+    dayUsedIterations: 0,
+  }
+}
+
+/** In-memory reference ledger for fixtures and tests. */
+export function createInMemoryBudgetLedger(): BudgetLedgerPort {
+  const store = new Map<string, BudgetUsage>()
+  const key = (positionId: string, taskId: string, dayKey: string) =>
+    `${positionId}\u0000${taskId}\u0000${dayKey}`
+  return {
+    async read(positionId, taskId, dayKey) {
+      return { ...(store.get(key(positionId, taskId, dayKey)) ?? emptyBudgetUsage()) }
+    },
+    async commit(entry) {
+      const k = key(entry.positionId, entry.taskId, entry.dayKey)
+      const current = store.get(k) ?? emptyBudgetUsage()
+      store.set(k, {
+        taskUsedTokens: current.taskUsedTokens + entry.tokens,
+        taskUsedIterations: current.taskUsedIterations + entry.iterations,
+        dayUsedTokens: current.dayUsedTokens + entry.tokens,
+        dayUsedIterations: current.dayUsedIterations + entry.iterations,
+      })
+    },
+  }
+}
+
+/**
+ * Deterministic consumption order: day scope first, then task scope. Returns
+ * the first exceeded dimension, or undefined when the increment fits.
+ */
+export function checkPositionBudget(
+  declaration: PositionBudgetDeclaration,
+  usage: BudgetUsage,
+  increment: { tokens: number; iterations: number },
+): BudgetExceeded | undefined {
+  const dayTokens = usage.dayUsedTokens + increment.tokens
+  if (
+    declaration.perDay.tokens !== undefined &&
+    dayTokens > declaration.perDay.tokens
+  ) {
+    return { dimension: "position_day_tokens", used: dayTokens, limit: declaration.perDay.tokens }
+  }
+  const dayIterations = usage.dayUsedIterations + increment.iterations
+  if (
+    declaration.perDay.iterations !== undefined &&
+    dayIterations > declaration.perDay.iterations
+  ) {
+    return {
+      dimension: "position_day_iterations",
+      used: dayIterations,
+      limit: declaration.perDay.iterations,
+    }
+  }
+  const taskTokens = usage.taskUsedTokens + increment.tokens
+  if (
+    declaration.perTask.tokens !== undefined &&
+    taskTokens > declaration.perTask.tokens
+  ) {
+    return { dimension: "position_task_tokens", used: taskTokens, limit: declaration.perTask.tokens }
+  }
+  const taskIterations = usage.taskUsedIterations + increment.iterations
+  if (
+    declaration.perTask.iterations !== undefined &&
+    taskIterations > declaration.perTask.iterations
+  ) {
+    return {
+      dimension: "position_task_iterations",
+      used: taskIterations,
+      limit: declaration.perTask.iterations,
+    }
+  }
+  return undefined
+}

--- a/packages/engine/src/contracts.ts
+++ b/packages/engine/src/contracts.ts
@@ -1,5 +1,10 @@
 import type { SafeValue } from "../../core/src/contracts.js"
 
+import {
+  validatePositionBudgetDeclaration,
+  type PositionBudgetDeclaration,
+} from "./budget.js"
+
 /**
  * Built-in execution engine protocol identity.
  *
@@ -9,6 +14,7 @@ import type { SafeValue } from "../../core/src/contracts.js"
  */
 export const ENGINE_PROTOCOL_VERSION = "engine.v1" as const
 export const ENGINE_ID = "built-in" as const
+export const ENGINE_VERSION = "0.1.0" as const
 
 /**
  * Terminal reasons are this repository's own enumeration. They are NOT a
@@ -98,6 +104,14 @@ export interface EngineTurnRequest {
   /** ISO 8601 UTC deadline; exceeding fails closed. */
   deadline?: string
   signal?: AbortSignal
+  /**
+   * Position budget declaration from the organization model (per-task and
+   * per-day caps). When present, taskId and dayKey are mandatory so the
+   * ledger can attribute consumption.
+   */
+  positionBudget?: PositionBudgetDeclaration
+  taskId?: string
+  dayKey?: string
 }
 
 const MAX_ID_LENGTH = 256
@@ -178,6 +192,18 @@ export function validateTurnRequest(
         "deadline must be a valid ISO 8601 timestamp",
       )
     }
+  }
+  if (request.positionBudget !== undefined) {
+    try {
+      validatePositionBudgetDeclaration(request.positionBudget)
+    } catch {
+      throw new EngineRequestError(
+        "engine.input_invalid",
+        "positionBudget must be fully allocated (perTask and perDay caps)",
+      )
+    }
+    assertBoundedId(request.taskId, "taskId")
+    assertBoundedId(request.dayKey, "dayKey")
   }
   return request
 }

--- a/packages/engine/src/doom-loop.ts
+++ b/packages/engine/src/doom-loop.ts
@@ -1,0 +1,101 @@
+import { createHash } from "node:crypto"
+
+/**
+ * Deterministic, model-free doom-loop detection.
+ *
+ * Two signal families, both counted on output digests:
+ *  - repetition: the same output repeated N times consecutively;
+ *  - oscillation: an A -> B -> A -> B cycle sustained for M full cycles.
+ * Continuously changing output never trips either counter (the exemption is
+ * structural: any new digest resets the repetition run and extends the
+ * oscillation candidate window).
+ */
+
+export type DoomLoopSignal = "none" | "repetition" | "oscillation"
+
+export interface DoomLoopConfig {
+  repetitionThreshold: number
+  oscillationCycles: number
+  windowSize: number
+}
+
+export const DEFAULT_DOOM_LOOP_CONFIG: DoomLoopConfig = {
+  repetitionThreshold: 3,
+  oscillationCycles: 2,
+  windowSize: 16,
+}
+
+export function digestOutput(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex")
+}
+
+export class DoomLoopDetector {
+  readonly config: DoomLoopConfig
+  #history: string[] = []
+
+  constructor(config: Partial<DoomLoopConfig> = {}) {
+    this.config = { ...DEFAULT_DOOM_LOOP_CONFIG, ...config }
+    if (
+      !Number.isInteger(this.config.repetitionThreshold) ||
+      this.config.repetitionThreshold < 2
+    ) {
+      throw new TypeError("repetitionThreshold must be an integer >= 2")
+    }
+    if (
+      !Number.isInteger(this.config.oscillationCycles) ||
+      this.config.oscillationCycles < 1
+    ) {
+      throw new TypeError("oscillationCycles must be an integer >= 1")
+    }
+  }
+
+  /** Observe one model output; returns the triggered signal, if any. */
+  observe(text: string): DoomLoopSignal {
+    const digest = digestOutput(text)
+    this.#history.push(digest)
+    if (this.#history.length > this.config.windowSize) {
+      this.#history.shift()
+    }
+    if (this.repetitionCount() >= this.config.repetitionThreshold) {
+      return "repetition"
+    }
+    if (this.oscillationCycles() >= this.config.oscillationCycles) {
+      return "oscillation"
+    }
+    return "none"
+  }
+
+  repetitionCount(): number {
+    if (this.#history.length === 0) return 0
+    const last = this.#history[this.#history.length - 1]
+    let count = 0
+    for (let index = this.#history.length - 1; index >= 0; index -= 1) {
+      if (this.#history[index] !== last) break
+      count += 1
+    }
+    return count
+  }
+
+  /**
+   * Full A-B-A-B cycles at the tail of the window. Two distinct digests
+   * alternating produce one cycle per completed A-B-A-B span.
+   */
+  oscillationCycles(): number {
+    const history = this.#history
+    if (history.length < 4) return 0
+    const a = history[history.length - 2]
+    const b = history[history.length - 1]
+    if (a === b) return 0
+    let slots = 0
+    for (let index = history.length - 1; index >= 0; index -= 1) {
+      const expected = (history.length - 1 - index) % 2 === 0 ? b : a
+      if (history[index] !== expected) break
+      slots += 1
+    }
+    return Math.floor(slots / 4)
+  }
+
+  reset(): void {
+    this.#history = []
+  }
+}

--- a/packages/engine/src/escalation.ts
+++ b/packages/engine/src/escalation.ts
@@ -1,0 +1,99 @@
+import type { BudgetDimension } from "./budget.js"
+
+export const ESCALATION_RECORD_VERSION = "escalation-record.v1" as const
+
+/**
+ * Structured escalation record — the V4 seam with the organization model.
+ *
+ * Budget-exceeded and loop-control stops share one escalation mechanism: the
+ * route IS the reporting line. Engine-side fields are pinned by this
+ * contract; organization-side wording follows the org schema record.
+ */
+
+export type EscalationCause =
+  | "turn_budget_exceeded"
+  | "position_budget_exceeded"
+  | "iteration_cap"
+  | "doom_loop"
+  | "deadline_exceeded"
+
+export interface EscalationBudgetSnapshot {
+  dimension: BudgetDimension | "none"
+  used: number
+  limit: number
+}
+
+export interface EscalationRouting {
+  /**
+   * Direct superior resolved from the organization tree `reportTo` field.
+   * Positions without a superior (the owner) escalate to the workspace
+   * operator entry.
+   */
+  directSuperior: string
+  resolvedFrom: "organization.v1alpha1#reportTo" | "workspace.operator_default"
+}
+
+export interface EscalationRecord {
+  schemaVersion: typeof ESCALATION_RECORD_VERSION
+  escalationId: string
+  workspaceRef: string
+  positionId: string
+  turnId: string
+  runId: string
+  cause: EscalationCause
+  budgetSnapshot: EscalationBudgetSnapshot
+  routing: EscalationRouting
+  evidenceRef?: string
+  occurredAt: string
+}
+
+/**
+ * Reporting-line lookup port. Returns the position's `reportTo` value, or
+ * null for the owner / top position, or undefined when the position is
+ * unknown to the organization model.
+ */
+export interface OrgReportingLookup {
+  reportTo(positionId: string): string | null | undefined
+}
+
+export const WORKSPACE_OPERATOR_ENTRY = "workspace.operator" as const
+
+/**
+ * Resolve the escalation route along the reporting line. Owner (reportTo is
+ * null) and unknown positions route to the workspace operator entry — S1
+ * records the pointer only; delivery and hand-off belong to the workbench.
+ */
+export function resolveEscalationRouting(
+  positionId: string,
+  lookup: OrgReportingLookup | undefined,
+): EscalationRouting {
+  const superior = lookup?.reportTo(positionId)
+  if (typeof superior === "string" && superior.trim().length > 0) {
+    return {
+      directSuperior: superior,
+      resolvedFrom: "organization.v1alpha1#reportTo",
+    }
+  }
+  return {
+    directSuperior: WORKSPACE_OPERATOR_ENTRY,
+    resolvedFrom: "workspace.operator_default",
+  }
+}
+
+export interface EscalationSinkPort {
+  write(record: EscalationRecord): Promise<void>
+}
+
+export interface InMemoryEscalationSink extends EscalationSinkPort {
+  records: readonly EscalationRecord[]
+}
+
+export function createInMemoryEscalationSink(): InMemoryEscalationSink {
+  const stored: EscalationRecord[] = []
+  return {
+    records: stored,
+    async write(record) {
+      stored.push(record)
+    },
+  }
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2,6 +2,7 @@ export {
   ENGINE_ERROR_CODE_PATTERN,
   ENGINE_ID,
   ENGINE_PROTOCOL_VERSION,
+  ENGINE_VERSION,
   EngineRequestError,
   isTerminalEngineEvent,
   terminalError,
@@ -48,3 +49,56 @@ export type { PreparedTerminalSchema } from "./output-schema-guard.js"
 
 export { executeTurn } from "./turn-executor.js"
 export type { TurnExecutorOptions } from "./turn-executor.js"
+
+export {
+  MAX_BUDGET_CAP,
+  checkPositionBudget,
+  createInMemoryBudgetLedger,
+  emptyBudgetUsage,
+  validatePositionBudgetDeclaration,
+} from "./budget.js"
+export type {
+  BudgetDimension,
+  BudgetExceeded,
+  BudgetLedgerPort,
+  BudgetScope,
+  BudgetUsage,
+  PositionBudgetDeclaration,
+} from "./budget.js"
+
+export {
+  DEFAULT_DOOM_LOOP_CONFIG,
+  DoomLoopDetector,
+  digestOutput,
+} from "./doom-loop.js"
+export type { DoomLoopConfig, DoomLoopSignal } from "./doom-loop.js"
+
+export {
+  ESCALATION_RECORD_VERSION,
+  WORKSPACE_OPERATOR_ENTRY,
+  createInMemoryEscalationSink,
+  resolveEscalationRouting,
+} from "./escalation.js"
+export type {
+  EscalationBudgetSnapshot,
+  EscalationCause,
+  EscalationRecord,
+  EscalationRouting,
+  EscalationSinkPort,
+  InMemoryEscalationSink,
+  OrgReportingLookup,
+} from "./escalation.js"
+
+export {
+  TURN_EVIDENCE_VERSION,
+  createInMemoryEvidenceSink,
+  digestOutputValue,
+  evidenceRecordContainsForbiddenMaterial,
+} from "./turn-evidence.js"
+export type {
+  EvidenceSinkPort,
+  InMemoryEvidenceSink,
+  TurnEvidenceBudget,
+  TurnEvidenceRecord,
+  TurnEvidenceTerminal,
+} from "./turn-evidence.js"

--- a/packages/engine/src/turn-evidence.ts
+++ b/packages/engine/src/turn-evidence.ts
@@ -1,0 +1,95 @@
+import { createHash } from "node:crypto"
+
+import type { SafeValue } from "../../core/src/contracts.js"
+
+import type { BudgetUsage } from "./budget.js"
+import type { EscalationCause } from "./escalation.js"
+
+export const TURN_EVIDENCE_VERSION = "turn-evidence.v1" as const
+
+/**
+ * Per-turn evidence record under the repository evidence standard.
+ *
+ * Hard content rule: the record carries digests, counters, and bounded
+ * identifiers only — never prompt text, model completions, chain-of-thought,
+ * or credentials. A turn without evidence is a failed turn; the executor
+ * writes this record in the same atomic sequence as the terminal event.
+ */
+
+export interface TurnEvidenceBudget {
+  turn: {
+    iterationsUsed: number
+    tokensUsed: number
+    maxIterations: number
+    maxTokens?: number
+  }
+  position?: BudgetUsage
+}
+
+export interface TurnEvidenceTerminal {
+  status: "completed" | "failed"
+  reason: string
+  errorCode?: string
+}
+
+export interface TurnEvidenceRecord {
+  schemaVersion: typeof TURN_EVIDENCE_VERSION
+  evidenceId: string
+  workspaceRef: string
+  positionId: string
+  turnId: string
+  runId: string
+  engineVersion: string
+  /** sha256 over the canonical assembled-context serialization. */
+  inputDigest: string
+  /** sha256 over the terminal output JSON. */
+  outputDigest: string
+  budget: TurnEvidenceBudget
+  terminal: TurnEvidenceTerminal
+  escalationRef?: string
+  /** Assembly manifest digest from context-assembly.v1. */
+  assemblyManifestDigest: string
+  timeBounds: {
+    startedAt: string
+    completedAt: string
+  }
+}
+
+export interface EvidenceSinkPort {
+  write(record: TurnEvidenceRecord): Promise<void>
+}
+
+export interface InMemoryEvidenceSink extends EvidenceSinkPort {
+  records: readonly TurnEvidenceRecord[]
+}
+
+export function createInMemoryEvidenceSink(): InMemoryEvidenceSink {
+  const stored: TurnEvidenceRecord[] = []
+  return {
+    records: stored,
+    async write(record) {
+      stored.push(record)
+    },
+  }
+}
+
+export function digestOutputValue(output: SafeValue): string {
+  const json = JSON.stringify(output)
+  return createHash("sha256").update(json ?? "null", "utf8").digest("hex")
+}
+
+/**
+ * Static content audit for a record: proves the forbidden material classes
+ * are absent from the serialized evidence itself.
+ */
+export function evidenceRecordContainsForbiddenMaterial(
+  record: TurnEvidenceRecord,
+  probes: readonly string[],
+): boolean {
+  const serialized = JSON.stringify(record)
+  return probes.some(
+    (probe) => probe.length > 0 && serialized.includes(probe),
+  )
+}
+
+export type { EscalationCause }

--- a/packages/engine/src/turn-executor.ts
+++ b/packages/engine/src/turn-executor.ts
@@ -1,51 +1,105 @@
+import { randomUUID } from "node:crypto"
+
 import type { SafeValue } from "../../core/src/contracts.js"
 
 import {
+  checkPositionBudget,
+  emptyBudgetUsage,
+  type BudgetExceeded,
+  type BudgetLedgerPort,
+  type BudgetUsage,
+} from "./budget.js"
+import {
   terminalError,
   validateTurnRequest,
+  ENGINE_VERSION,
   type EngineEvent,
   type EngineTurnRequest,
+  type TerminalReason,
 } from "./contracts.js"
 import { assembleContext } from "./context-assembler.js"
+import { DoomLoopDetector, type DoomLoopConfig } from "./doom-loop.js"
+import {
+  resolveEscalationRouting,
+  ESCALATION_RECORD_VERSION,
+  type EscalationBudgetSnapshot,
+  type EscalationCause,
+  type EscalationRecord,
+  type EscalationSinkPort,
+  type OrgReportingLookup,
+} from "./escalation.js"
 import type { ModelPort, OutputViolation } from "./model-port.js"
 import {
   OutputSchemaGuardError,
   prepareTerminalSchema,
 } from "./output-schema-guard.js"
+import {
+  digestOutputValue,
+  TURN_EVIDENCE_VERSION,
+  type EvidenceSinkPort,
+  type TurnEvidenceRecord,
+} from "./turn-evidence.js"
 
 export interface TurnExecutorOptions {
   model: ModelPort
   now?: () => Date
+  budgetLedger?: BudgetLedgerPort
+  escalationSink?: EscalationSinkPort
+  evidenceSink?: EvidenceSinkPort
+  orgLookup?: OrgReportingLookup
+  doomLoop?: Partial<DoomLoopConfig>
+  newId?: () => string
 }
 
 function timestamp(now: () => Date): string {
   return now().toISOString()
 }
 
+const REASON_TO_CODE: Readonly<Record<TerminalReason, string>> = {
+  goal_met: "engine.goal_met",
+  invalid_output_exhausted: "engine.output_invalid",
+  turn_budget_exceeded: "engine.turn_budget_exceeded",
+  position_budget_exceeded: "engine.position_budget_exceeded",
+  iteration_cap: "engine.iteration_cap_reached",
+  doom_loop: "engine.doom_loop_detected",
+  deadline_exceeded: "engine.deadline_exceeded",
+  cancelled: "engine.cancelled",
+  engine_internal_error: "engine.internal_error",
+}
+
+const RETRYABLE_REASONS: ReadonlySet<TerminalReason> = new Set([
+  "invalid_output_exhausted",
+  "deadline_exceeded",
+  "engine_internal_error",
+])
+
 /**
  * Executes exactly one turn and yields a stream with a single trusted
  * terminal event (`run.completed` or `run.failed`).
  *
  * S1 loop shape — the ONLY iteration source in the read-only core is the
- * output validate/repair cycle: the model produces text, the terminal schema
- * validates it, and a violation feeds a bounded repair attempt. There is no
- * tool dispatch branch anywhere in this path; the model port returns text
- * only. Budget and doom-loop machinery is layered on by the loop-control
- * slice without relaxing this guarantee.
+ * output validate/repair cycle. There is no tool dispatch branch anywhere in
+ * this path; the model port returns text only. On top of that loop this slice
+ * layers dual-dimension budget consumption (turn + position), deterministic
+ * doom-loop detection, and the fail-safe stop sequence: stop consuming ->
+ * escalation record along the reporting line -> per-turn evidence -> stable
+ * terminal. A turn without evidence is a failed turn.
  */
 export async function* executeTurn(
   rawRequest: EngineTurnRequest,
   options: TurnExecutorOptions,
 ): AsyncGenerator<EngineEvent> {
   const now = options.now ?? (() => new Date())
+  const newId = options.newId ?? (() => randomUUID())
   const runId = typeof rawRequest.runId === "string" ? rawRequest.runId : ""
+  const startedAt = timestamp(now)
   let terminated = false
 
   const fail = (
     code: string,
     message: string,
-    terminalReason: Parameters<typeof terminalError>[2],
-    retryable = false,
+    terminalReason: TerminalReason,
+    retryable = RETRYABLE_REASONS.has(terminalReason),
   ): EngineEvent => {
     terminated = true
     return {
@@ -58,15 +112,13 @@ export async function* executeTurn(
 
   yield { type: "run.started", runId, timestamp: timestamp(now) }
 
-  // Fail-closed request validation and terminal-schema preparation happen
-  // before any model consumption.
   let request: EngineTurnRequest
   try {
     request = validateTurnRequest(rawRequest)
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "turn request rejected"
-    yield fail("engine.input_invalid", message, "engine_internal_error")
+    yield fail("engine.input_invalid", message, "engine_internal_error", false)
     return
   }
 
@@ -75,13 +127,14 @@ export async function* executeTurn(
     schema = prepareTerminalSchema(request.outputSchema)
   } catch (error) {
     if (error instanceof OutputSchemaGuardError) {
-      yield fail(error.code, error.message, "engine_internal_error")
+      yield fail(error.code, error.message, "engine_internal_error", false)
       return
     }
     yield fail(
       "engine.output_schema_invalid",
       "output schema preparation failed",
       "engine_internal_error",
+      false,
     )
     return
   }
@@ -97,32 +150,190 @@ export async function* executeTurn(
         : JSON.stringify(request.input),
   })
 
+  const detector = new DoomLoopDetector(options.doomLoop)
   const violations: OutputViolation[] = []
   const maxIterations = request.budget.maxIterations
+  const maxTokens = request.budget.maxTokens
+  const ledger = options.budgetLedger
+  const declaration = request.positionBudget
+  const usePositionBudget = Boolean(
+    declaration && ledger && request.taskId && request.dayKey,
+  )
+
+  let iterationsUsed = 0
+  let tokensUsed = 0
+  let positionUsage: BudgetUsage = emptyBudgetUsage()
+
+  if (usePositionBudget) {
+    positionUsage = await ledger!.read(
+      request.positionId,
+      request.taskId!,
+      request.dayKey!,
+    )
+  }
+
+  const writeEscalation = async (
+    cause: EscalationCause,
+    snapshot: EscalationBudgetSnapshot,
+  ): Promise<string | undefined> => {
+    if (!options.escalationSink) return undefined
+    const escalationId = newId()
+    const record: EscalationRecord = {
+      schemaVersion: ESCALATION_RECORD_VERSION,
+      escalationId,
+      workspaceRef: request.workspaceRef,
+      positionId: request.positionId,
+      turnId: request.turnId,
+      runId: request.runId,
+      cause,
+      budgetSnapshot: snapshot,
+      routing: resolveEscalationRouting(request.positionId, options.orgLookup),
+      occurredAt: timestamp(now),
+    }
+    await options.escalationSink.write(record)
+    return escalationId
+  }
+
+  const writeEvidence = async (
+    terminal: {
+      status: "completed" | "failed"
+      reason: string
+      errorCode?: string
+    },
+    output: SafeValue,
+    escalationRef?: string,
+  ): Promise<void> => {
+    if (!options.evidenceSink) return
+    const record: TurnEvidenceRecord = {
+      schemaVersion: TURN_EVIDENCE_VERSION,
+      evidenceId: newId(),
+      workspaceRef: request.workspaceRef,
+      positionId: request.positionId,
+      turnId: request.turnId,
+      runId: request.runId,
+      engineVersion: ENGINE_VERSION,
+      inputDigest: assembled.manifest.digest,
+      outputDigest: digestOutputValue(output),
+      budget: {
+        turn: {
+          iterationsUsed,
+          tokensUsed,
+          maxIterations,
+          ...(maxTokens !== undefined ? { maxTokens } : {}),
+        },
+        ...(usePositionBudget ? { position: positionUsage } : {}),
+      },
+      terminal,
+      ...(escalationRef !== undefined ? { escalationRef } : {}),
+      assemblyManifestDigest: assembled.manifest.digest,
+      timeBounds: { startedAt, completedAt: timestamp(now) },
+    }
+    await options.evidenceSink.write(record)
+  }
+
+  /**
+   * The single fail-safe stop path for governance stops: persist the
+   * escalation record along the reporting line and the per-turn evidence
+   * first, then surface the stable terminal. Persistence precedes the
+   * terminal event so an unrecorded stop can never masquerade as a clean
+   * one; if side effects fail, the turn fails closed instead.
+   */
+  const stopWithEscalation = async function* (
+    terminalReason: TerminalReason,
+    message: string,
+    cause: EscalationCause,
+    snapshot: EscalationBudgetSnapshot,
+  ): AsyncGenerator<EngineEvent> {
+    let escalationRef: string | undefined
+    try {
+      escalationRef = await writeEscalation(cause, snapshot)
+      await writeEvidence(
+        {
+          status: "failed",
+          reason: terminalReason,
+          errorCode: REASON_TO_CODE[terminalReason],
+        },
+        null,
+        escalationRef,
+      )
+    } catch {
+      yield fail(
+        "engine.internal_error",
+        "stop sequence side effects failed",
+        "engine_internal_error",
+        false,
+      )
+      return
+    }
+    yield fail(REASON_TO_CODE[terminalReason], message, terminalReason)
+  }
 
   try {
     for (let attempt = 1; attempt <= maxIterations; attempt += 1) {
       if (request.signal?.aborted) {
-        yield fail("engine.cancelled", "turn cancelled", "cancelled")
+        await writeEvidence(
+          {
+            status: "failed",
+            reason: "cancelled",
+            errorCode: REASON_TO_CODE.cancelled,
+          },
+          null,
+        ).catch(() => undefined)
+        yield fail("engine.cancelled", "turn cancelled", "cancelled", false)
         return
       }
       if (
         request.deadline !== undefined &&
         now().getTime() > Date.parse(request.deadline)
       ) {
-        yield fail(
-          "engine.deadline_exceeded",
+        yield* stopWithEscalation(
+          "deadline_exceeded",
           "turn deadline exceeded",
           "deadline_exceeded",
-          true,
+          { dimension: "none", used: 0, limit: 0 },
         )
         return
+      }
+
+      // Turn token budget is checked before consuming another iteration.
+      if (maxTokens !== undefined && tokensUsed > maxTokens) {
+        yield* stopWithEscalation(
+          "turn_budget_exceeded",
+          "turn token budget exceeded",
+          "turn_budget_exceeded",
+          { dimension: "turn_tokens", used: tokensUsed, limit: maxTokens },
+        )
+        return
+      }
+
+      // Position budget pre-check (day -> task) before consuming the
+      // iteration.
+      if (usePositionBudget) {
+        const preExceeded = checkPositionBudget(declaration!, positionUsage, {
+          tokens: 0,
+          iterations: 1,
+        })
+        if (preExceeded) {
+          yield* stopWithEscalation(
+            "position_budget_exceeded",
+            "position budget exceeded",
+            "position_budget_exceeded",
+            preExceeded,
+          )
+          return
+        }
       }
 
       const result = await options.model.complete(
         { blocks: assembled.blocks, priorViolations: [...violations] },
         request.signal,
       )
+
+      iterationsUsed += 1
+      const callTokens =
+        (typeof result.inputTokens === "number" ? result.inputTokens : 0) +
+        (typeof result.outputTokens === "number" ? result.outputTokens : 0)
+      tokensUsed += callTokens
 
       if (
         typeof result.inputTokens === "number" ||
@@ -136,6 +347,47 @@ export async function* executeTurn(
           outputTokens: result.outputTokens,
         }
       }
+
+      // Commit actual consumption, then re-check the position budget.
+      if (usePositionBudget) {
+        await ledger!.commit({
+          positionId: request.positionId,
+          taskId: request.taskId!,
+          dayKey: request.dayKey!,
+          tokens: callTokens,
+          iterations: 1,
+        })
+        positionUsage = await ledger!.read(
+          request.positionId,
+          request.taskId!,
+          request.dayKey!,
+        )
+        const postExceeded = checkPositionBudget(declaration!, positionUsage, {
+          tokens: 0,
+          iterations: 0,
+        })
+        if (postExceeded) {
+          yield* stopWithEscalation(
+            "position_budget_exceeded",
+            "position budget exceeded",
+            "position_budget_exceeded",
+            postExceeded,
+          )
+          return
+        }
+      }
+
+      // Turn token budget after consumption.
+      if (maxTokens !== undefined && tokensUsed > maxTokens) {
+        yield* stopWithEscalation(
+          "turn_budget_exceeded",
+          "turn token budget exceeded",
+          "turn_budget_exceeded",
+          { dimension: "turn_tokens", used: tokensUsed, limit: maxTokens },
+        )
+        return
+      }
+
       yield {
         type: "model.delta",
         runId,
@@ -143,7 +395,23 @@ export async function* executeTurn(
         text: result.text,
       }
 
+      // Deterministic doom-loop detection on the output stream.
+      const doomSignal = detector.observe(result.text)
+      if (doomSignal !== "none") {
+        yield* stopWithEscalation(
+          "doom_loop",
+          `doom loop detected (${doomSignal})`,
+          "doom_loop",
+          { dimension: "none", used: 0, limit: 0 },
+        )
+        return
+      }
+
       if (schema === undefined) {
+        await writeEvidence(
+          { status: "completed", reason: "goal_met" },
+          result.text,
+        )
         terminated = true
         yield {
           type: "run.completed",
@@ -159,14 +427,15 @@ export async function* executeTurn(
       try {
         candidate = JSON.parse(result.text)
       } catch {
-        violations.push({
-          attempt,
-          summary: "output is not valid JSON",
-        })
+        violations.push({ attempt, summary: "output is not valid JSON" })
         continue
       }
 
       if (schema.validate(candidate)) {
+        await writeEvidence(
+          { status: "completed", reason: "goal_met" },
+          candidate as SafeValue,
+        )
         terminated = true
         yield {
           type: "run.completed",
@@ -184,7 +453,24 @@ export async function* executeTurn(
       })
     }
 
-    // Repair attempts exhausted: fail closed, never fabricate a passing value.
+    // Loop exhausted: distinguish schema-repair exhaustion from a bare cap.
+    if (schema === undefined) {
+      yield* stopWithEscalation(
+        "iteration_cap",
+        "iteration budget exhausted",
+        "iteration_cap",
+        { dimension: "none", used: iterationsUsed, limit: maxIterations },
+      )
+      return
+    }
+    await writeEvidence(
+      {
+        status: "failed",
+        reason: "invalid_output_exhausted",
+        errorCode: REASON_TO_CODE.invalid_output_exhausted,
+      },
+      null,
+    )
     yield fail(
       "engine.output_invalid",
       "output failed terminal schema validation after bounded repair attempts",
@@ -195,6 +481,14 @@ export async function* executeTurn(
     if (terminated) return
     const message =
       error instanceof Error ? error.message : "engine execution failed"
+    await writeEvidence(
+      {
+        status: "failed",
+        reason: "engine_internal_error",
+        errorCode: REASON_TO_CODE.engine_internal_error,
+      },
+      null,
+    ).catch(() => undefined)
     yield fail("engine.internal_error", message, "engine_internal_error", true)
   }
 }

--- a/tests/engine/budget.test.ts
+++ b/tests/engine/budget.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  checkPositionBudget,
+  createInMemoryBudgetLedger,
+  emptyBudgetUsage,
+  validatePositionBudgetDeclaration,
+} from "../../packages/engine/src/index.js"
+
+const FULL_DECLARATION = {
+  perTask: { tokens: 100, iterations: 4 },
+  perDay: { tokens: 500, iterations: 20 },
+}
+
+test("fully allocated declaration parses", () => {
+  const parsed = validatePositionBudgetDeclaration(FULL_DECLARATION)
+  assert.equal(parsed.perTask.tokens, 100)
+  assert.equal(parsed.perDay.iterations, 20)
+})
+
+test("single-scope allocation is accepted per scope", () => {
+  const parsed = validatePositionBudgetDeclaration({
+    perTask: { iterations: 2 },
+    perDay: { tokens: 10 },
+  })
+  assert.equal(parsed.perTask.iterations, 2)
+  assert.equal(parsed.perDay.tokens, 10)
+})
+
+test("missing budget fails closed with the missing code", () => {
+  assert.throws(
+    () => validatePositionBudgetDeclaration(null),
+    (error: unknown) =>
+      error instanceof TypeError && error.message === "workspace_org_budget_missing",
+  )
+})
+
+test("absent scope fails closed as not allocated", () => {
+  assert.throws(
+    () => validatePositionBudgetDeclaration({ perTask: { tokens: 5 } }),
+    (error: unknown) =>
+      error instanceof TypeError &&
+      error.message === "workspace_org_budget_not_allocated",
+  )
+})
+
+test("empty scopes fail closed as not allocated", () => {
+  assert.throws(
+    () => validatePositionBudgetDeclaration({ perTask: {}, perDay: {} }),
+    (error: unknown) =>
+      error instanceof TypeError &&
+      error.message === "workspace_org_budget_not_allocated",
+  )
+})
+
+test("non-positive, oversized, and unknown keys fail closed as invalid", () => {
+  for (const bad of [
+    { perTask: { tokens: 0 }, perDay: { tokens: 5 } },
+    { perTask: { tokens: 2_000_000_000 }, perDay: { tokens: 5 } },
+    { perTask: { tokens: 1.5 }, perDay: { tokens: 5 } },
+    { perTask: { tokens: 5, currency: "usd" }, perDay: { tokens: 5 } },
+  ]) {
+    assert.throws(
+      () => validatePositionBudgetDeclaration(bad),
+      (error: unknown) =>
+        error instanceof TypeError &&
+        error.message === "workspace_org_budget_invalid",
+    )
+  }
+})
+
+test("consumption order is day before task", () => {
+  const usage = { ...emptyBudgetUsage(), dayUsedIterations: 20 }
+  const exceeded = checkPositionBudget(FULL_DECLARATION, usage, {
+    tokens: 0,
+    iterations: 1,
+  })
+  assert.equal(exceeded?.dimension, "position_day_iterations")
+})
+
+test("task token breach reports the task dimension", () => {
+  const usage = { ...emptyBudgetUsage(), taskUsedTokens: 100 }
+  const exceeded = checkPositionBudget(FULL_DECLARATION, usage, {
+    tokens: 1,
+    iterations: 0,
+  })
+  assert.equal(exceeded?.dimension, "position_task_tokens")
+  assert.equal(exceeded?.used, 101)
+  assert.equal(exceeded?.limit, 100)
+})
+
+test("usage within all caps passes", () => {
+  const exceeded = checkPositionBudget(FULL_DECLARATION, emptyBudgetUsage(), {
+    tokens: 10,
+    iterations: 1,
+  })
+  assert.equal(exceeded, undefined)
+})
+
+test("in-memory ledger accumulates per position/task/day", async () => {
+  const ledger = createInMemoryBudgetLedger()
+  await ledger.commit({
+    positionId: "p",
+    taskId: "t",
+    dayKey: "2026-08-23",
+    tokens: 30,
+    iterations: 2,
+  })
+  await ledger.commit({
+    positionId: "p",
+    taskId: "t",
+    dayKey: "2026-08-23",
+    tokens: 10,
+    iterations: 1,
+  })
+  const usage = await ledger.read("p", "t", "2026-08-23")
+  assert.equal(usage.taskUsedTokens, 40)
+  assert.equal(usage.taskUsedIterations, 3)
+  assert.equal(usage.dayUsedTokens, 40)
+  const other = await ledger.read("p", "t2", "2026-08-23")
+  assert.equal(other.taskUsedTokens, 0)
+})

--- a/tests/engine/doom-loop.test.ts
+++ b/tests/engine/doom-loop.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { DoomLoopDetector } from "../../packages/engine/src/index.js"
+
+test("repetition triggers at the threshold", () => {
+  const detector = new DoomLoopDetector({ repetitionThreshold: 3 })
+  assert.equal(detector.observe("same"), "none")
+  assert.equal(detector.observe("same"), "none")
+  assert.equal(detector.observe("same"), "repetition")
+})
+
+test("continuously changing output never trips repetition", () => {
+  const detector = new DoomLoopDetector({ repetitionThreshold: 3 })
+  for (let index = 0; index < 10; index += 1) {
+    assert.equal(detector.observe(`answer ${index}`), "none")
+  }
+})
+
+test("oscillation triggers after the configured full cycles", () => {
+  const detector = new DoomLoopDetector({
+    oscillationCycles: 2,
+    repetitionThreshold: 10,
+  })
+  const sequence = ["A", "B", "A", "B", "A", "B", "A", "B"]
+  const results = sequence.map((value) => detector.observe(value))
+  assert.equal(results.slice(0, 7).every((value) => value === "none"), true)
+  assert.equal(results[7], "oscillation")
+})
+
+test("a broken oscillation resets the cycle count", () => {
+  const detector = new DoomLoopDetector({
+    oscillationCycles: 2,
+    repetitionThreshold: 10,
+  })
+  for (const value of ["A", "B", "A", "B", "C"]) {
+    assert.equal(detector.observe(value), "none")
+  }
+  assert.equal(detector.observe("A"), "none")
+  assert.equal(detector.observe("B"), "none")
+  assert.equal(detector.observe("A"), "none")
+})
+
+test("reset clears history", () => {
+  const detector = new DoomLoopDetector({ repetitionThreshold: 2 })
+  detector.observe("x")
+  detector.reset()
+  assert.equal(detector.observe("x"), "none")
+})
+
+test("invalid configuration fails closed", () => {
+  assert.throws(
+    () => new DoomLoopDetector({ repetitionThreshold: 1 }),
+    TypeError,
+  )
+  assert.throws(
+    () => new DoomLoopDetector({ oscillationCycles: 0 }),
+    TypeError,
+  )
+})

--- a/tests/engine/turn-governance.test.ts
+++ b/tests/engine/turn-governance.test.ts
@@ -1,0 +1,265 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  createInMemoryBudgetLedger,
+  createInMemoryEscalationSink,
+  createInMemoryEvidenceSink,
+  evidenceRecordContainsForbiddenMaterial,
+  executeTurn,
+  isTerminalEngineEvent,
+} from "../../packages/engine/src/index.js"
+import type {
+  EngineEvent,
+  EngineTurnRequest,
+  ModelPort,
+  OrgReportingLookup,
+} from "../../packages/engine/src/index.js"
+
+const FIXED_NOW = () => new Date("2026-08-23T00:00:00.000Z")
+let idCounter = 0
+const NEW_ID = () => `id-${(idCounter += 1)}`
+
+function baseRequest(overrides: Partial<EngineTurnRequest> = {}): EngineTurnRequest {
+  return {
+    workspaceRef: "ws-1",
+    positionId: "issue-researcher",
+    turnId: "turn-1",
+    runId: "run-1",
+    input: "Summarize issue 42.",
+    budget: { maxIterations: 6 },
+    position: { instructions: "You are the issue researcher." },
+    ...overrides,
+  }
+}
+
+const ORG: OrgReportingLookup = {
+  reportTo: (positionId) =>
+    positionId === "repo-owner" ? null : "repo-owner",
+}
+
+function scriptedModel(outputs: readonly string[], tokens = 0): ModelPort {
+  let call = 0
+  return {
+    async complete() {
+      const text = outputs[Math.min(call, outputs.length - 1)]!
+      call += 1
+      return tokens > 0
+        ? { text, inputTokens: tokens, outputTokens: 0 }
+        : { text }
+    },
+  }
+}
+
+interface RunResult {
+  events: EngineEvent[]
+  escalations: ReturnType<typeof createInMemoryEscalationSink>
+  evidence: ReturnType<typeof createInMemoryEvidenceSink>
+}
+
+async function runWithGovernance(
+  request: EngineTurnRequest,
+  model: ModelPort,
+  ledger = createInMemoryBudgetLedger(),
+): Promise<RunResult> {
+  const escalations = createInMemoryEscalationSink()
+  const evidence = createInMemoryEvidenceSink()
+  const events: EngineEvent[] = []
+  for await (const event of executeTurn(request, {
+    model,
+    now: FIXED_NOW,
+    newId: NEW_ID,
+    budgetLedger: ledger,
+    escalationSink: escalations,
+    evidenceSink: evidence,
+    orgLookup: ORG,
+  })) {
+    events.push(event)
+  }
+  return { events, escalations, evidence }
+}
+
+const terminalOf = (events: EngineEvent[]) =>
+  events.filter(isTerminalEngineEvent)
+
+test("position budget exceeded stops fail-safe, escalates to the direct superior, and records evidence", async () => {
+  const request = baseRequest({
+    positionBudget: {
+      perTask: { tokens: 1_000, iterations: 1 },
+      perDay: { tokens: 10_000, iterations: 10 },
+    },
+    taskId: "task-1",
+    dayKey: "2026-08-23",
+    outputSchema: { type: "object", properties: { ok: { type: "boolean" } } },
+  })
+  const model = scriptedModel(["bad-1", "bad-2", "bad-3"])
+  const { events, escalations, evidence } = await runWithGovernance(request, model)
+
+  const terminals = terminalOf(events)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.failed")
+  if (terminals[0]!.type === "run.failed") {
+    assert.equal(terminals[0]!.error.code, "engine.position_budget_exceeded")
+    assert.equal(terminals[0]!.error.retryable, false)
+  }
+
+  assert.equal(escalations.records.length, 1)
+  const record = escalations.records[0]!
+  assert.equal(record.cause, "position_budget_exceeded")
+  assert.equal(record.routing.directSuperior, "repo-owner")
+  assert.equal(record.routing.resolvedFrom, "organization.v1alpha1#reportTo")
+  assert.equal(record.schemaVersion, "escalation-record.v1")
+
+  assert.equal(evidence.records.length, 1)
+  const turnEvidence = evidence.records[0]!
+  assert.equal(turnEvidence.terminal.status, "failed")
+  assert.equal(turnEvidence.terminal.reason, "position_budget_exceeded")
+  assert.equal(turnEvidence.escalationRef, record.escalationId)
+  assert.equal(turnEvidence.schemaVersion, "turn-evidence.v1")
+})
+
+test("owner without a superior routes escalation to the workspace operator", async () => {
+  const request = baseRequest({
+    positionId: "repo-owner",
+    positionBudget: {
+      perTask: { iterations: 1, tokens: 1_000 },
+      perDay: { iterations: 10, tokens: 10_000 },
+    },
+    taskId: "task-1",
+    dayKey: "2026-08-23",
+    outputSchema: { type: "object" },
+  })
+  const model = scriptedModel(["bad-1", "bad-2", "bad-3"])
+  const { escalations } = await runWithGovernance(request, model)
+  assert.equal(escalations.records.length, 1)
+  assert.equal(escalations.records[0]!.routing.directSuperior, "workspace.operator")
+  assert.equal(
+    escalations.records[0]!.routing.resolvedFrom,
+    "workspace.operator_default",
+  )
+})
+
+test("turn token budget exceeded stops with the turn dimension snapshot", async () => {
+  const request = baseRequest({
+    budget: { maxIterations: 6, maxTokens: 15 },
+    outputSchema: { type: "object" },
+  })
+  const model = scriptedModel(["{}", "{}", "{}"], 20)
+  const { events, escalations } = await runWithGovernance(request, model)
+  const terminals = terminalOf(events)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.failed")
+  if (terminals[0]!.type === "run.failed") {
+    assert.equal(terminals[0]!.error.code, "engine.turn_budget_exceeded")
+  }
+  assert.equal(escalations.records.length, 1)
+  assert.equal(escalations.records[0]!.cause, "turn_budget_exceeded")
+  assert.equal(escalations.records[0]!.budgetSnapshot.dimension, "turn_tokens")
+})
+
+test("doom-loop repetition stops with a stable code and an escalation record", async () => {
+  const request = baseRequest({
+    outputSchema: { type: "object", properties: { answer: { type: "string" } }, required: ["answer"] },
+  })
+  const model = scriptedModel(["not json", "not json", "not json", "not json"])
+  const { events, escalations, evidence } = await runWithGovernance(request, model)
+  const terminals = terminalOf(events)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.failed")
+  if (terminals[0]!.type === "run.failed") {
+    assert.equal(terminals[0]!.error.code, "engine.doom_loop_detected")
+    assert.equal(terminals[0]!.error.terminalReason, "doom_loop")
+  }
+  assert.equal(escalations.records.length, 1)
+  assert.equal(escalations.records[0]!.cause, "doom_loop")
+  assert.equal(evidence.records.length, 1)
+})
+
+test("successful turns record completed evidence without escalation", async () => {
+  const request = baseRequest({
+    outputSchema: {
+      type: "object",
+      properties: { answer: { type: "string" } },
+      required: ["answer"],
+    },
+  })
+  const model = scriptedModel(['{"answer":"done"}'])
+  const { events, escalations, evidence } = await runWithGovernance(request, model)
+  const terminals = terminalOf(events)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.completed")
+  assert.equal(escalations.records.length, 0)
+  assert.equal(evidence.records.length, 1)
+  const record = evidence.records[0]!
+  assert.equal(record.terminal.status, "completed")
+  assert.equal(record.terminal.reason, "goal_met")
+  assert.equal(record.engineVersion, "0.1.0")
+  assert.equal(record.escalationRef, undefined)
+  assert.equal(
+    evidenceRecordContainsForbiddenMaterial(record, ["Summarize issue 42.", "done"]),
+    false,
+  )
+})
+
+test("schema-repair exhaustion writes evidence but no escalation", async () => {
+  const request = baseRequest({
+    budget: { maxIterations: 2 },
+    outputSchema: { type: "object", properties: { ok: { type: "boolean" } } },
+  })
+  const model = scriptedModel(["bad", "still bad"])
+  const { events, escalations, evidence } = await runWithGovernance(request, model)
+  const terminals = terminalOf(events)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.failed")
+  if (terminals[0]!.type === "run.failed") {
+    assert.equal(terminals[0]!.error.code, "engine.output_invalid")
+    assert.equal(terminals[0]!.error.terminalReason, "invalid_output_exhausted")
+    assert.equal(terminals[0]!.error.retryable, true)
+  }
+  assert.equal(escalations.records.length, 0)
+  assert.equal(evidence.records.length, 1)
+  assert.equal(evidence.records[0]!.terminal.reason, "invalid_output_exhausted")
+})
+
+test("a failing evidence sink fails the turn closed", async () => {
+  const request = baseRequest({})
+  const model = scriptedModel(["plain answer"])
+  const events: EngineEvent[] = []
+  for await (const event of executeTurn(request, {
+    model,
+    now: FIXED_NOW,
+    evidenceSink: {
+      async write() {
+        throw new Error("evidence store unavailable")
+      },
+    },
+  })) {
+    events.push(event)
+  }
+  const terminals = terminalOf(events)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.failed")
+  if (terminals[0]!.type === "run.failed") {
+    assert.equal(terminals[0]!.error.code, "engine.internal_error")
+  }
+})
+
+test("position budget declaration without ledger identifiers fails closed", async () => {
+  const request = baseRequest({
+    positionBudget: {
+      perTask: { tokens: 10, iterations: 1 },
+      perDay: { tokens: 100, iterations: 5 },
+    },
+  })
+  const model = scriptedModel(["answer"])
+  const events: EngineEvent[] = []
+  for await (const event of executeTurn(request, { model, now: FIXED_NOW })) {
+    events.push(event)
+  }
+  const terminals = terminalOf(events)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.failed")
+  if (terminals[0]!.type === "run.failed") {
+    assert.equal(terminals[0]!.error.code, "engine.input_invalid")
+  }
+})


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/165
- Consumed revision: R3
- No automatic close keywords: acknowledged
- Stacked on: PR #168 (engine S1 skeleton). Retarget base to `main` after #168 merges.

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-003 (loop control) | packages/engine/src/budget.ts, packages/engine/src/turn-executor.ts | tests/engine/budget.test.ts + tests/engine/turn-governance.test.ts: dual-dimension consumption in deterministic order (position day -> task -> turn); position/turn budget exceeded stops fail-safe with stable codes (`engine.position_budget_exceeded`, `engine.turn_budget_exceeded`) and zero further model consumption |
| REQ-003 (doom-loop + terminal) | packages/engine/src/doom-loop.ts, packages/engine/src/turn-executor.ts | tests/engine/doom-loop.test.ts: repetition and oscillation counters are deterministic and model-free; continuously-changing output never trips; tests/engine/turn-governance.test.ts: doom-loop stop emits `engine.doom_loop_detected` with terminal reason `doom_loop` |
| REQ-003 (escalation seam, #157 REQ-007) | packages/engine/src/escalation.ts | tests/engine/turn-governance.test.ts: governance stops persist an `escalation-record.v1` routed along the reporting line (`reportTo`), owner routes to `workspace.operator`; the record and evidence persist before the terminal event so an unrecorded stop cannot masquerade as a clean one |
| REQ-005 (per-turn evidence) | packages/engine/src/turn-evidence.ts | tests/engine/turn-governance.test.ts: every governed turn writes a `turn-evidence.v1` record (engine version, input/output digests, budget state, terminal, escalationRef); a failing evidence sink fails the turn closed (`engine.internal_error`) |
| Structural invariant | packages/engine/src (all modules) | tests/engine/structural-fail-closed.test.ts unchanged and green: the new modules add no fs/network/process surface (only node:crypto for digests/ids) |

## File domains

- packages/engine/src/budget.ts — dual-dimension budget contract: declaration validation (fully-allocated rule; malformed caps fail closed as invalid before an empty scope fails as unallocated), `BudgetLedgerPort`, in-memory reference ledger, deterministic exceeded-dimension detection; owned by REQ-003.
- packages/engine/src/doom-loop.ts — deterministic doom-loop detector (repetition + oscillation counters on output digests); owned by REQ-003.
- packages/engine/src/escalation.ts — `escalation-record.v1` contract, reporting-line routing resolution, escalation sink port; owned by REQ-003 and the #157 REQ-007 seam.
- packages/engine/src/turn-evidence.ts — `turn-evidence.v1` contract, evidence sink port, output digesting, forbidden-material audit helper; owned by REQ-005.
- packages/engine/src/turn-executor.ts — stop sequence integrated into the loop: budget pre/post checks, doom-loop observation, escalation + evidence persistence preceding stable terminals; owned by REQ-003/REQ-005.
- packages/engine/src/contracts.ts — `ENGINE_VERSION`, position-budget request fields with fail-closed validation; owned by REQ-003.
- tests/engine/{budget,doom-loop,turn-governance}.test.ts — 32 new tests; owned by the REQ rows above.

## Scope and non-goals

User-visible change: none. This PR layers loop control on the S1 skeleton: dual-dimension budget consumption, deterministic doom-loop detection, the escalation-record seam, and per-turn evidence. The fail-safe stop sequence persists escalation + evidence before emitting the terminal event.

Non-goals: showcase acceptance wiring (PR-3); file-backed ledger/evidence/escalation persistence (ports only — persistence policy belongs to the wiring layer, keeping the engine core free of filesystem access); any tool surface; provider model wiring.

## Validation

- Exact commands: `npm run typecheck`; `npx tsx --test --test-concurrency=1 tests/engine/*.test.ts`; `npm test`; `npm run governance:check`; `npm run security:check`; `npm audit --omit=dev --audit-level=high`
- Observed counts/results: engine tests 48/48 PASS; typecheck PASS; `npm test` 1595 tests with 1594 pass and 1 failure that is a pre-existing WSL-environmental deploy-cli IPC-lease case (fails on clean `main` too; Linux CI authoritative); governance:check PASS; security:check PASS; audit 0 vulnerabilities.
- Check URLs: NOT VERIFIED: CI triggers on PR creation; the green run URL will be posted as a follow-up comment.

| ID | REQ/AC | Observable acceptance criterion | Command | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-003 | Budget/doom-loop forced terminations stop fail-safe with stable codes and no further model consumption | npx tsx --test tests/engine/turn-governance.test.ts tests/engine/budget.test.ts | WSL Ubuntu-22.04, Node v22.14.0 | position/turn budget + doom-loop stops green | governance suite green (position/turn budget, doom-loop) | PASS |
| V2 | REQ-003 (seam) | Escalation records route along reportTo; owner routes to workspace.operator | as above | as above | routing assertions green | routing assertions green | PASS |
| V3 | REQ-005 | Every governed turn carries evidence; failing evidence sink fails closed | as above | as above | evidence assertions green | evidence assertions green | PASS |
| V4 | Structural invariant | No new fs/network/process surface | npx tsx --test tests/engine/structural-fail-closed.test.ts | as above | zero violations | zero violations | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs. (evidence records carry digests and counters only; the forbidden-material audit helper proves prompt/output text absence)
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed. (no dependency change)
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded.

Compatibility: additive within the stacked engine branch; no public surface outside `./engine` changes; all PR-1 engine tests remain green.

## Known limitations

- Ledger/evidence/escalation sinks are ports with in-memory reference implementations only; workspace-local file persistence (0600) lands in the wiring layer with PR-3.
- `escalation-record.v1` engine-side fields are pinned; organization-side wording alignment follows #157 R3 vocabulary.
- Evidence records are engine self-report (runner-attested class under the evidence standard); they carry no billing authority.
- Full local `npm test` surfaces one pre-existing failure outside this PR's domain: `tests/apps/deploy-cli.test.ts` HTTP-activation IPC lease — a WSL-local environmental failure that fails on clean `main`; the `tests/git/git-source.test.ts` future-timestamp case is WSL-flaky and passed in the clean run. Neither test imports `packages/engine`. Linux CI is authoritative.

## Risk and rollback

Additive modules plus contained executor changes on the stacked engine branch; no existing module outside packages/engine is touched. Rollback: revert the commit; no irreversible effect.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: W1 — Workspace closed loop
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
