### PR TITLE
feat(cli): turn run spawn surface — sealed turn-envelope.v1, NDJSON stream, exit-code semantics (#173)

### DIFF
--- a/apps/cli/bin.ts
+++ b/apps/cli/bin.ts
@@ -28,6 +28,7 @@ import { evaluateEmployeePackage } from "./employee-eval.js";
 import { deploy, renderDeployParseFailure } from "./deploy/index.js";
 import { workspace, renderWorkspaceParseFailure } from "./workspace/index.js";
 import { org, renderOrgParseFailure } from "./org/index.js";
+import { turn } from "./turn/index.js";
 import { setup } from "./setup.js";
 
 type EmployeeResult = Awaited<ReturnType<DigitalEmployee["answer"]>>;
@@ -53,6 +54,7 @@ interface CommandValues {
   template?: string;
   tool?: string;
   context?: string;
+  position?: string;
   yes: boolean;
   help: boolean;
 }
@@ -69,6 +71,7 @@ Agent-native usage:
   digital-employee org tree [workspace] [--json]
   digital-employee org apply [workspace] [--json]
   digital-employee org scope <position> [workspace] [--tool <name> | --context <path>] [--json]
+  digital-employee turn run [workspace] --position <id> (--stdin | --input-file <path>)
   digital-employee deploy [package-path] [--package path] --channel <id> --engine <id> --runtime agent-native|standalone-v1 [options]
   digital-employee doctor [--engine claude-code|qoder|codex|qwen-code|codebuddy] [--json]
   digital-employee init <directory> [--recipe minimal-answer.v1|structured-action.v1] [--name employee-name] [--author author]
@@ -117,6 +120,7 @@ function parseCommand(argv: string[]) {
       template: { type: "string" },
       tool: { type: "string" },
       context: { type: "string" },
+      position: { type: "string" },
       yes: { type: "boolean", short: "y", default: false },
       help: { type: "boolean", short: "h", default: false }
     }
@@ -567,7 +571,7 @@ async function main() {
     throw error;
   }
   const { command, values, positionals, providedOptions } = parsed;
-  if (command === "help" || (values.help && command !== "deploy" && command !== "workspace" && command !== "org")) {
+  if (command === "help" || (values.help && command !== "deploy" && command !== "workspace" && command !== "org" && command !== "turn")) {
     process.stdout.write(usage());
     return;
   }
@@ -618,6 +622,15 @@ async function main() {
     tool: values.tool,
     context: values.context,
     providedOptions,
+  });
+  if (command === "turn") return turn({
+    subcommand: positionals[0],
+    args: positionals.slice(1),
+    position: values.position,
+    stdin: values.stdin,
+    inputFile: values.inputFile,
+    json: values.json,
+    help: values.help,
   });
   if (command === "doctor") return doctor(values);
   if (command === "init") return init(values, positionals);

--- a/apps/cli/turn/envelope-schema.ts
+++ b/apps/cli/turn/envelope-schema.ts
@@ -1,0 +1,87 @@
+/**
+ * Code-side builder for the turn-envelope.v1 JSON Schema (#173 REQ-002,
+ * open decision 3: published under configs/ with the builder byte-identity
+ * discipline). The published file configs/turn-envelope.schema.json must be
+ * byte-identical to `JSON.stringify(buildTurnEnvelopeSchema(), null, 2) +
+ * "\n"`; the schema-consistency test enforces this.
+ */
+
+import {
+  TURN_ENVELOPE_SCHEMA_ID,
+  TURN_ENVELOPE_VERSION,
+} from "./envelope.js"
+
+function boundedIdSchema(): Record<string, unknown> {
+  return { type: "string", minLength: 1, maxLength: 256 }
+}
+
+function budgetScopeSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    additionalProperties: false,
+    minProperties: 1,
+    properties: {
+      tokens: { type: "integer", exclusiveMinimum: 0, maximum: 1_000_000_000 },
+      iterations: {
+        type: "integer",
+        exclusiveMinimum: 0,
+        maximum: 1_000_000_000,
+      },
+    },
+  }
+}
+
+/**
+ * Build the turn-envelope.v1 JSON Schema (draft 2020-12). Mirrors
+ * `parseTurnEnvelope` field-by-field; validator/builder agreement is
+ * asserted by the test suite on the fixture set.
+ */
+export function buildTurnEnvelopeSchema(): Record<string, unknown> {
+  return {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    $id: TURN_ENVELOPE_SCHEMA_ID,
+    title: "turn-envelope.v1 sealed turn request",
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "schemaVersion",
+      "workspaceRef",
+      "positionId",
+      "turnId",
+      "input",
+      "envelopeDigest",
+    ],
+    properties: {
+      schemaVersion: { const: TURN_ENVELOPE_VERSION },
+      workspaceRef: boundedIdSchema(),
+      positionId: boundedIdSchema(),
+      turnId: boundedIdSchema(),
+      input: {},
+      budget: {
+        type: "object",
+        additionalProperties: false,
+        required: ["maxIterations"],
+        properties: {
+          maxIterations: { type: "integer", minimum: 1 },
+          maxTokens: { type: "integer", minimum: 1 },
+        },
+      },
+      positionBudget: {
+        type: "object",
+        additionalProperties: false,
+        required: ["perTask", "perDay"],
+        properties: {
+          perTask: { $ref: "#/$defs/budgetScope" },
+          perDay: { $ref: "#/$defs/budgetScope" },
+        },
+      },
+      taskId: boundedIdSchema(),
+      dayKey: boundedIdSchema(),
+      deadline: { type: "string" },
+      envelopeDigest: { type: "string", minLength: 1 },
+    },
+    $defs: {
+      budgetScope: budgetScopeSchema(),
+    },
+  }
+}

--- a/apps/cli/turn/envelope.ts
+++ b/apps/cli/turn/envelope.ts
@@ -1,0 +1,226 @@
+/**
+ * Sealed turn envelope (turn-envelope.v1) — the wire contract for the
+ * `turn run` spawn surface (#173 REQ-002, OQ-1 adjudication).
+ *
+ * The envelope is digest-bound: `envelopeDigest` is the sha256 over the
+ * canonical JSON of the envelope body (every field except the digest
+ * itself), and the CLI re-verifies it before any consumption. A mismatched
+ * or malformed envelope fails closed before any model consumption, per the
+ * #90 package-binding discipline.
+ */
+
+import { createHash } from "node:crypto"
+
+import type { SafeValue } from "../../../packages/core/src/contracts.js"
+import {
+  validatePositionBudgetDeclaration,
+  type PositionBudgetDeclaration,
+} from "../../../packages/engine/src/budget.js"
+import type { TurnBudget } from "../../../packages/engine/src/contracts.js"
+
+export const TURN_ENVELOPE_VERSION = "turn-envelope.v1" as const
+export const TURN_ENVELOPE_SCHEMA_ID =
+  "https://fullstack-ai-infra.dev/schemas/turn-envelope.schema.json" as const
+
+/**
+ * Environment allowlist for the spawn surface. Credentials never appear in
+ * argv; model keys flow only through this allowlist (#173 REQ-002).
+ */
+export const TURN_ENGINE_MODEL_ENV = "DIGITAL_EMPLOYEE_ENGINE_MODEL" as const
+export const TURN_ENGINE_MODEL_SCRIPT_ENV =
+  "DIGITAL_EMPLOYEE_ENGINE_MODEL_SCRIPT" as const
+
+export interface TurnEnvelope {
+  schemaVersion: typeof TURN_ENVELOPE_VERSION
+  workspaceRef: string
+  positionId: string
+  turnId: string
+  input: SafeValue
+  budget?: TurnBudget
+  positionBudget?: PositionBudgetDeclaration
+  taskId?: string
+  dayKey?: string
+  deadline?: string
+  envelopeDigest: string
+}
+
+export class TurnEnvelopeError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message)
+    this.name = "TurnEnvelopeError"
+  }
+}
+
+const MAX_ID_LENGTH = 256
+
+function canonicalJson(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value
+  if (Array.isArray(value)) return value.map(canonicalJson)
+  const sorted: Record<string, unknown> = {}
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    sorted[key] = canonicalJson((value as Record<string, unknown>)[key])
+  }
+  return sorted
+}
+
+/**
+ * Compute the envelope digest: sha256 over the canonical JSON of the
+ * envelope body (all fields except envelopeDigest), `sha256:<hex>` format.
+ */
+export function computeEnvelopeDigest(body: Record<string, unknown>): string {
+  const canonical = JSON.stringify(canonicalJson(body))
+  return `sha256:${createHash("sha256").update(canonical, "utf8").digest("hex")}`
+}
+
+function assertBoundedId(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TurnEnvelopeError(
+      "engine.input_invalid",
+      `${label} must be a non-empty string`,
+    )
+  }
+  if (value.length > MAX_ID_LENGTH) {
+    throw new TurnEnvelopeError(
+      "engine.input_invalid",
+      `${label} exceeds the bounded identifier length`,
+    )
+  }
+  return value
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function envelopeBody(raw: Record<string, unknown>): Record<string, unknown> {
+  const body: Record<string, unknown> = { ...raw }
+  delete body.envelopeDigest
+  return body
+}
+
+/**
+ * Fail-closed envelope validation. Every structural problem rejects before
+ * any engine consumption.
+ */
+export function parseTurnEnvelope(raw: unknown): TurnEnvelope {
+  if (!isRecord(raw)) {
+    throw new TurnEnvelopeError(
+      "engine.envelope_invalid",
+      "envelope must be a JSON object",
+    )
+  }
+  if (raw.schemaVersion !== TURN_ENVELOPE_VERSION) {
+    throw new TurnEnvelopeError(
+      "engine.envelope_invalid",
+      `schemaVersion must be ${TURN_ENVELOPE_VERSION}`,
+    )
+  }
+  const workspaceRef = assertBoundedId(raw.workspaceRef, "workspaceRef")
+  const positionId = assertBoundedId(raw.positionId, "positionId")
+  const turnId = assertBoundedId(raw.turnId, "turnId")
+  if (raw.input === undefined) {
+    throw new TurnEnvelopeError(
+      "engine.input_invalid",
+      "envelope input is required",
+    )
+  }
+
+  let budget: TurnBudget | undefined
+  if (raw.budget !== undefined) {
+    if (
+      !isRecord(raw.budget) ||
+      !Number.isInteger(raw.budget.maxIterations) ||
+      (raw.budget.maxIterations as number) < 1
+    ) {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "budget.maxIterations must be a positive integer",
+      )
+    }
+    const maxTokens = raw.budget.maxTokens
+    if (
+      maxTokens !== undefined &&
+      (!Number.isInteger(maxTokens) || (maxTokens as number) < 1)
+    ) {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "budget.maxTokens must be a positive integer when present",
+      )
+    }
+    budget = {
+      maxIterations: raw.budget.maxIterations as number,
+      ...(maxTokens !== undefined ? { maxTokens: maxTokens as number } : {}),
+    }
+  }
+
+  // Position-budget triple: all-present or all-absent (#173 REQ-002).
+  const hasDeclaration = raw.positionBudget !== undefined
+  const hasTaskId = raw.taskId !== undefined
+  const hasDayKey = raw.dayKey !== undefined
+  if (hasDeclaration !== hasTaskId || hasDeclaration !== hasDayKey) {
+    throw new TurnEnvelopeError(
+      "engine.input_invalid",
+      "positionBudget, taskId and dayKey must be all-present or all-absent",
+    )
+  }
+  let positionBudget: PositionBudgetDeclaration | undefined
+  let taskId: string | undefined
+  let dayKey: string | undefined
+  if (hasDeclaration) {
+    try {
+      positionBudget = validatePositionBudgetDeclaration(
+        raw.positionBudget as PositionBudgetDeclaration,
+      )
+    } catch {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "positionBudget must be fully allocated (perTask and perDay caps)",
+      )
+    }
+    taskId = assertBoundedId(raw.taskId, "taskId")
+    dayKey = assertBoundedId(raw.dayKey, "dayKey")
+  }
+
+  if (raw.deadline !== undefined) {
+    if (
+      typeof raw.deadline !== "string" ||
+      Number.isNaN(Date.parse(raw.deadline))
+    ) {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "deadline must be a valid ISO 8601 timestamp",
+      )
+    }
+  }
+
+  if (typeof raw.envelopeDigest !== "string" || raw.envelopeDigest.length === 0) {
+    throw new TurnEnvelopeError(
+      "engine.envelope_invalid",
+      "envelopeDigest is required",
+    )
+  }
+  const expected = computeEnvelopeDigest(envelopeBody(raw))
+  if (raw.envelopeDigest !== expected) {
+    throw new TurnEnvelopeError(
+      "engine.envelope_digest_mismatch",
+      "envelope digest does not match the canonical envelope body",
+    )
+  }
+
+  return {
+    schemaVersion: TURN_ENVELOPE_VERSION,
+    workspaceRef,
+    positionId,
+    turnId,
+    input: raw.input as SafeValue,
+    ...(budget !== undefined ? { budget } : {}),
+    ...(positionBudget !== undefined
+      ? { positionBudget, taskId, dayKey }
+      : {}),
+    ...(raw.deadline !== undefined ? { deadline: raw.deadline as string } : {}),
+    envelopeDigest: raw.envelopeDigest,
+  }
+}

--- a/apps/cli/turn/index.ts
+++ b/apps/cli/turn/index.ts
@@ -1,0 +1,90 @@
+/**
+ * `digital-employee turn` command surface (#173 REQ-001). Subcommand:
+ *
+ *   turn run [workspace] --position <id> (--stdin | --input-file <path>)
+ *
+ * The spawn surface carries exactly one input source — the sealed
+ * turn-envelope.v1 JSON — and one output discipline: NDJSON engine.v1
+ * events on stdout, bounded diagnostics on stderr. `--json` is rejected
+ * because the NDJSON stream IS the machine surface; a second formatting
+ * mode would fork the contract.
+ */
+
+import { createReadStream } from "node:fs"
+
+import { runTurn } from "./turn-run.js"
+
+export interface TurnOptions {
+  subcommand?: string
+  args: string[]
+  position?: string
+  stdin?: boolean
+  inputFile?: string
+  json?: boolean
+  help?: boolean
+}
+
+const TURN_INPUT_LIMIT_BYTES = 1024 * 1024
+
+function turnUsage(): string {
+  return `digital-employee turn run [workspace] --position <id> (--stdin | --input-file <path>)
+
+Spawn surface for the built-in engine: consumes a sealed turn-envelope.v1
+request and streams NDJSON engine.v1 events. Exit 0 = exactly one trusted
+terminal; exit 1 = spawn-level failure (no terminal, indeterminate).
+`
+}
+
+async function readBoundedEnvelope(
+  stream: AsyncIterable<string | Buffer>,
+): Promise<string> {
+  const chunks: Buffer[] = []
+  let bytes = 0
+  for await (const chunk of stream) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    bytes += buffer.byteLength
+    if (bytes > TURN_INPUT_LIMIT_BYTES) {
+      throw new TypeError("turn_envelope_too_large")
+    }
+    chunks.push(buffer)
+  }
+  return Buffer.concat(chunks).toString("utf8")
+}
+
+export async function turn(options: TurnOptions): Promise<void> {
+  if (options.help) {
+    process.stdout.write(turnUsage())
+    return
+  }
+  if (options.subcommand !== "run") {
+    throw new TypeError(
+      `unknown_turn_subcommand:${options.subcommand || "missing"}`,
+    )
+  }
+  if (options.args.length > 1) {
+    throw new TypeError("turn_run_accepts_one_workspace")
+  }
+  if (!options.position) {
+    throw new TypeError("turn_run_requires_position")
+  }
+  if (options.json) {
+    throw new TypeError("turn_run_emits_ndjson_not_json")
+  }
+  const inputModes = [Boolean(options.stdin), Boolean(options.inputFile)].filter(
+    Boolean,
+  ).length
+  if (inputModes !== 1) {
+    throw new TypeError("turn_run_accepts_one_input_source")
+  }
+
+  const envelopeText = options.inputFile
+    ? await readBoundedEnvelope(createReadStream(options.inputFile))
+    : await readBoundedEnvelope(process.stdin)
+
+  const result = await runTurn({
+    workspace: options.args[0] || process.cwd(),
+    positionId: options.position,
+    envelopeText,
+  })
+  process.exitCode = result.exitCode
+}

--- a/apps/cli/turn/turn-run.ts
+++ b/apps/cli/turn/turn-run.ts
@@ -1,0 +1,267 @@
+/**
+ * `turn run` spawn surface (#173 REQ-001/REQ-003/REQ-004/REQ-005, OQ-1).
+ *
+ * Projects the merged engine core onto a stable CLI wire surface for
+ * cross-product clients: sealed turn-envelope.v1 in, NDJSON engine.v1
+ * events out, exactly one trusted terminal, unambiguous exit codes.
+ * Engine-internal contracts are consumed, never changed.
+ *
+ * Exit-code semantics (#102 crash discipline):
+ *   0 = exactly one trusted terminal reached (completed, or a modeled
+ *       run.failed such as budget-exceeded/doom-loop: a governance
+ *       verdict, not a crash)
+ *   1 = spawn/process-level failure — no terminal emitted (malformed or
+ *       digest-mismatched envelope, missing model credentials, internal
+ *       crash). Clients treat exit 1 as indeterminate: no automatic retry;
+ *       an explicit retry is a new attempt.
+ */
+
+import { randomUUID } from "node:crypto"
+import { lstat } from "node:fs/promises"
+import path from "node:path"
+
+import {
+  createInMemoryBudgetLedger,
+  createInMemoryEscalationSink,
+  createInMemoryEvidenceSink,
+} from "../../../packages/engine/src/index.js"
+import {
+  createDeterministicModelPort,
+  type ModelPort,
+} from "../../../packages/engine/src/model-port.js"
+import type { EngineTurnRequest } from "../../../packages/engine/src/contracts.js"
+import { executeTurn } from "../../../packages/engine/src/turn-executor.js"
+import { loadOrgModel } from "../org/model.js"
+import {
+  parseTurnEnvelope,
+  TurnEnvelopeError,
+  TURN_ENGINE_MODEL_ENV,
+  TURN_ENGINE_MODEL_SCRIPT_ENV,
+  type TurnEnvelope,
+} from "./envelope.js"
+
+const MAX_STDERR_DIAGNOSTIC_BYTES = 8 * 1024
+
+export interface TurnRunOptions {
+  workspace: string
+  positionId: string
+  /** Raw envelope JSON text read from --stdin or --input-file. */
+  envelopeText: string
+  writeEvent?: (line: string) => void
+  writeDiagnostic?: (line: string) => void
+  /** Test seams. */
+  env?: NodeJS.ProcessEnv
+  model?: ModelPort
+  now?: () => Date
+  newId?: () => string
+}
+
+export interface TurnRunResult {
+  exitCode: 0 | 1
+  /** True when exactly one trusted terminal event was emitted. */
+  terminalEmitted: boolean
+}
+
+class TurnSpawnError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message)
+    this.name = "TurnSpawnError"
+  }
+}
+
+function resolveModelPort(env: NodeJS.ProcessEnv): ModelPort {
+  const engine = env[TURN_ENGINE_MODEL_ENV]
+  if (engine === undefined || engine.trim().length === 0) {
+    throw new TurnSpawnError(
+      "engine.model_unavailable",
+      `no model port configured: set ${TURN_ENGINE_MODEL_ENV} via the environment allowlist`,
+    )
+  }
+  if (engine === "deterministic") {
+    // Zero-credential reference port: replays a scripted JSON string array
+    // for fixtures and acceptance. Never pretends to be an online model.
+    const scriptRaw = env[TURN_ENGINE_MODEL_SCRIPT_ENV]
+    if (!scriptRaw) {
+      throw new TurnSpawnError(
+        "engine.model_unavailable",
+        `deterministic model port requires ${TURN_ENGINE_MODEL_SCRIPT_ENV} (JSON string array)`,
+      )
+    }
+    let script: unknown
+    try {
+      script = JSON.parse(scriptRaw)
+    } catch {
+      throw new TurnSpawnError(
+        "engine.model_unavailable",
+        `${TURN_ENGINE_MODEL_SCRIPT_ENV} must be a JSON string array`,
+      )
+    }
+    if (
+      !Array.isArray(script) ||
+      script.some((entry) => typeof entry !== "string")
+    ) {
+      throw new TurnSpawnError(
+        "engine.model_unavailable",
+        `${TURN_ENGINE_MODEL_SCRIPT_ENV} must be a JSON string array`,
+      )
+    }
+    return createDeterministicModelPort(script as string[])
+  }
+  throw new TurnSpawnError(
+    "engine.model_unavailable",
+    `unknown engine model port: ${engine}`,
+  )
+}
+
+async function assertWorkspaceRef(
+  workspace: string,
+  envelope: TurnEnvelope,
+): Promise<void> {
+  let stat
+  try {
+    stat = await lstat(workspace)
+  } catch {
+    throw new TurnSpawnError(
+      "engine.workspace_invalid",
+      `workspace directory not found: ${workspace}`,
+    )
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new TurnSpawnError(
+      "engine.workspace_invalid",
+      `workspace must be a real directory: ${workspace}`,
+    )
+  }
+  // The workspace must carry the organization model marker; a spawn turn
+  // against an uninitialized workspace fails closed.
+  try {
+    await loadOrgModel(workspace)
+  } catch (error) {
+    const code =
+      error instanceof TypeError ? error.message : "engine.workspace_invalid"
+    throw new TurnSpawnError(
+      code.startsWith("workspace_org_") ? code : "engine.workspace_invalid",
+      `workspace organization model unavailable: ${code}`,
+    )
+  }
+  if (path.resolve(envelope.workspaceRef) !== path.resolve(workspace)) {
+    throw new TurnSpawnError(
+      "engine.input_invalid",
+      "envelope workspaceRef does not match the workspace argument",
+    )
+  }
+}
+
+function boundedDiagnostic(line: string): string {
+  const buffer = Buffer.from(line, "utf8")
+  if (buffer.byteLength <= MAX_STDERR_DIAGNOSTIC_BYTES) return line
+  return `${buffer.subarray(0, MAX_STDERR_DIAGNOSTIC_BYTES).toString("utf8")}…`
+}
+
+/**
+ * Execute the spawn surface. Emits one NDJSON `engine.v1` event per stdout
+ * line; diagnostics are bounded and go to stderr only.
+ */
+export async function runTurn(options: TurnRunOptions): Promise<TurnRunResult> {
+  const env = options.env ?? process.env
+  const writeEvent =
+    options.writeEvent ?? ((line: string) => process.stdout.write(`${line}\n`))
+  const writeDiagnostic =
+    options.writeDiagnostic ??
+    ((line: string) =>
+      process.stderr.write(`${boundedDiagnostic(line)}\n`))
+
+  const failSpawn = (code: string, message: string): TurnRunResult => {
+    writeDiagnostic(`digital-employee: ${code}: ${message}`)
+    return { exitCode: 1, terminalEmitted: false }
+  }
+
+  let envelope: TurnEnvelope
+  try {
+    envelope = parseTurnEnvelope(JSON.parse(options.envelopeText))
+  } catch (error) {
+    if (error instanceof TurnEnvelopeError) {
+      return failSpawn(error.code, error.message)
+    }
+    return failSpawn("engine.envelope_invalid", "envelope is not valid JSON")
+  }
+
+  if (envelope.positionId !== options.positionId) {
+    return failSpawn(
+      "engine.input_invalid",
+      "envelope positionId does not match the --position argument",
+    )
+  }
+
+  try {
+    await assertWorkspaceRef(options.workspace, envelope)
+  } catch (error) {
+    if (error instanceof TurnSpawnError) {
+      return failSpawn(error.code, error.message)
+    }
+    throw error
+  }
+
+  let model: ModelPort
+  try {
+    model = options.model ?? resolveModelPort(env)
+  } catch (error) {
+    if (error instanceof TurnSpawnError) {
+      return failSpawn(error.code, error.message)
+    }
+    throw error
+  }
+
+  const request: EngineTurnRequest = {
+    workspaceRef: envelope.workspaceRef,
+    positionId: envelope.positionId,
+    turnId: envelope.turnId,
+    runId: randomUUID(),
+    input: envelope.input,
+    budget: envelope.budget ?? { maxIterations: 1 },
+    ...(envelope.positionBudget !== undefined
+      ? {
+          positionBudget: envelope.positionBudget,
+          taskId: envelope.taskId,
+          dayKey: envelope.dayKey,
+        }
+      : {}),
+    ...(envelope.deadline !== undefined
+      ? { deadline: envelope.deadline }
+      : {}),
+  }
+
+  const escalationSink = createInMemoryEscalationSink()
+  const evidenceSink = createInMemoryEvidenceSink()
+
+  let terminalEmitted = false
+  try {
+    for await (const event of executeTurn(request, {
+      model,
+      budgetLedger: createInMemoryBudgetLedger(),
+      escalationSink,
+      evidenceSink,
+      ...(options.now !== undefined ? { now: options.now } : {}),
+      ...(options.newId !== undefined ? { newId: options.newId } : {}),
+    })) {
+      writeEvent(JSON.stringify(event))
+      if (event.type === "run.completed" || event.type === "run.failed") {
+        terminalEmitted = true
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "engine crash"
+    return failSpawn("engine.internal_error", message)
+  }
+
+  if (!terminalEmitted) {
+    return failSpawn(
+      "engine.internal_error",
+      "turn ended without a terminal event",
+    )
+  }
+  return { exitCode: 0, terminalEmitted: true }
+}

--- a/configs/turn-envelope.schema.json
+++ b/configs/turn-envelope.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fullstack-ai-infra.dev/schemas/turn-envelope.schema.json",
+  "title": "turn-envelope.v1 sealed turn request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "workspaceRef",
+    "positionId",
+    "turnId",
+    "input",
+    "envelopeDigest"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "turn-envelope.v1"
+    },
+    "workspaceRef": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "positionId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "turnId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "input": {},
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "maxIterations"
+      ],
+      "properties": {
+        "maxIterations": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxTokens": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "positionBudget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "perTask",
+        "perDay"
+      ],
+      "properties": {
+        "perTask": {
+          "$ref": "#/$defs/budgetScope"
+        },
+        "perDay": {
+          "$ref": "#/$defs/budgetScope"
+        }
+      }
+    },
+    "taskId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "dayKey": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "deadline": {
+      "type": "string"
+    },
+    "envelopeDigest": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "$defs": {
+    "budgetScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "tokens": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000
+        },
+        "iterations": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000
+        }
+      }
+    }
+  }
+}

--- a/scripts/distribution-policy.js
+++ b/scripts/distribution-policy.js
@@ -20,6 +20,7 @@ export const DISTRIBUTION_ASSET_MAPPINGS = Object.freeze([
   ["configs/org-tree.schema.json", "dist/configs/org-tree.schema.json"],
   ["configs/profile.schema.json", "dist/configs/profile.schema.json"],
   ["configs/schema.json", "dist/configs/schema.json"],
+  ["configs/turn-envelope.schema.json", "dist/configs/turn-envelope.schema.json"],
   ["configs/workspace-org.schema.json", "dist/configs/workspace-org.schema.json"],
   ["locales/README.md", "dist/locales/README.md"],
   ["locales/en.json", "dist/locales/en.json"],

--- a/tests/apps/turn-envelope-schema.test.ts
+++ b/tests/apps/turn-envelope-schema.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+import { buildTurnEnvelopeSchema } from "../../apps/cli/turn/envelope-schema.js"
+import {
+  computeEnvelopeDigest,
+  parseTurnEnvelope,
+  TURN_ENVELOPE_VERSION,
+} from "../../apps/cli/turn/envelope.js"
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+)
+const publishedSchemaPath = path.join(
+  packageRoot,
+  "configs",
+  "turn-envelope.schema.json",
+)
+
+test("published turn-envelope.schema.json matches the code-side builder", async () => {
+  const published = await readFile(publishedSchemaPath, "utf8")
+  assert.equal(
+    published,
+    `${JSON.stringify(buildTurnEnvelopeSchema(), null, 2)}\n`,
+  )
+})
+
+function sealedEnvelope(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const body = {
+    schemaVersion: TURN_ENVELOPE_VERSION,
+    workspaceRef: "/tmp/ws",
+    positionId: "repo-owner",
+    turnId: "turn-1",
+    input: "Summarize the open issues.",
+    budget: { maxIterations: 2 },
+    ...overrides,
+  }
+  return { ...body, envelopeDigest: computeEnvelopeDigest(body) }
+}
+
+test("parseTurnEnvelope accepts a correctly sealed envelope", () => {
+  const envelope = parseTurnEnvelope(sealedEnvelope())
+  assert.equal(envelope.schemaVersion, TURN_ENVELOPE_VERSION)
+  assert.equal(envelope.positionId, "repo-owner")
+  assert.equal(envelope.budget?.maxIterations, 2)
+})
+
+test("parseTurnEnvelope rejects a tampered envelope before consumption", () => {
+  const envelope = sealedEnvelope()
+  envelope.input = "tampered after sealing"
+  assert.throws(
+    () => parseTurnEnvelope(envelope),
+    (error: unknown) =>
+      (error as { code?: string }).code === "engine.envelope_digest_mismatch",
+  )
+})
+
+test("parseTurnEnvelope rejects an unknown schemaVersion", () => {
+  const envelope = sealedEnvelope({ schemaVersion: "turn-envelope.v0" })
+  assert.throws(
+    () => parseTurnEnvelope(envelope),
+    (error: unknown) =>
+      (error as { code?: string }).code === "engine.envelope_invalid",
+  )
+})
+
+test("position-budget triple must be all-present or all-absent", () => {
+  const partial = sealedEnvelope({
+    taskId: "task-1",
+    dayKey: "2026-08-23",
+  })
+  assert.throws(
+    () => parseTurnEnvelope(partial),
+    (error: unknown) =>
+      (error as { code?: string }).code === "engine.input_invalid",
+  )
+  const complete = sealedEnvelope({
+    positionBudget: {
+      perTask: { iterations: 2 },
+      perDay: { iterations: 10 },
+    },
+    taskId: "task-1",
+    dayKey: "2026-08-23",
+  })
+  const envelope = parseTurnEnvelope(complete)
+  assert.equal(envelope.taskId, "task-1")
+  assert.equal(envelope.positionBudget?.perDay.iterations, 10)
+})
+
+test("computeEnvelopeDigest is canonical: key order does not matter", () => {
+  const a = computeEnvelopeDigest({ b: 1, a: { d: 2, c: [1, 2] } })
+  const b = computeEnvelopeDigest({ a: { c: [1, 2], d: 2 }, b: 1 })
+  assert.equal(a, b)
+})

--- a/tests/apps/turn-run.test.ts
+++ b/tests/apps/turn-run.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Spawn-surface semantics tests for `turn run` (#173 AC-001..AC-004):
+ * golden-path single terminal, digest-mismatch rejection before any
+ * consumption, modeled budget-exceeded terminals exiting 0, crash-level
+ * failures exiting 1 without a terminal, and budget-injection mapping.
+ */
+
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import { runTurn } from "../../apps/cli/turn/turn-run.js"
+import {
+  computeEnvelopeDigest,
+  TURN_ENVELOPE_VERSION,
+} from "../../apps/cli/turn/envelope.js"
+import type { ModelPort } from "../../packages/engine/src/index.js"
+import {
+  createDeterministicModelPort,
+} from "../../packages/engine/src/index.js"
+import {
+  OSS_MAINTAINER_TEMPLATE,
+  renderOrganizationFile,
+} from "../../apps/cli/workspace/templates.js"
+
+async function createWorkspace(): Promise<string> {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "turn-run-ws-"))
+  const digests: Record<string, { name: string; version: string; digest: string }> = {}
+  for (const role of OSS_MAINTAINER_TEMPLATE.roles) {
+    digests[role.id] = {
+      name: role.id,
+      version: "0.1.0",
+      digest: `sha256:${"a".repeat(64)}`,
+    }
+  }
+  const organization = renderOrganizationFile(
+    OSS_MAINTAINER_TEMPLATE,
+    "oss-maintainer",
+    workspace,
+    digests,
+    "2026-08-23T00:00:00.000Z",
+  )
+  await mkdir(workspace, { recursive: true })
+  await writeFile(
+    path.join(workspace, organization.portablePath),
+    organization.content,
+  )
+  await mkdir(path.join(workspace, "positions"), { recursive: true })
+  return workspace
+}
+
+function sealedEnvelope(
+  workspaceRef: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const body = {
+    schemaVersion: TURN_ENVELOPE_VERSION,
+    workspaceRef,
+    positionId: "repo-owner",
+    turnId: "turn-1",
+    input: "Summarize the open issues.",
+    budget: { maxIterations: 2 },
+    ...overrides,
+  }
+  return { ...body, envelopeDigest: computeEnvelopeDigest(body) }
+}
+
+interface CapturedRun {
+  result: Awaited<ReturnType<typeof runTurn>>
+  events: Array<Record<string, unknown>>
+  diagnostics: string[]
+}
+
+async function execute(
+  workspace: string,
+  envelopeText: string,
+  model?: ModelPort,
+): Promise<CapturedRun> {
+  const events: Array<Record<string, unknown>> = []
+  const diagnostics: string[] = []
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText,
+    model,
+    writeEvent: (line) => events.push(JSON.parse(line)),
+    writeDiagnostic: (line) => diagnostics.push(line),
+  })
+  return { result, events, diagnostics }
+}
+
+test("AC-001: golden path — sealed envelope yields one terminal, exit 0", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace)
+  const { result, events } = await execute(
+    workspace,
+    JSON.stringify(envelope),
+    createDeterministicModelPort(["all issues summarized"]),
+  )
+  assert.equal(result.exitCode, 0)
+  assert.equal(result.terminalEmitted, true)
+  assert.equal(events[0]!.type, "run.started")
+  const terminals = events.filter(
+    (event) => event.type === "run.completed" || event.type === "run.failed",
+  )
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.completed")
+  for (const event of events) {
+    assert.equal(typeof event.runId, "string")
+    assert.equal(typeof event.timestamp, "string")
+  }
+})
+
+test("AC-001: digest mismatch rejects before any model consumption, exit 1", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace)
+  envelope.input = "tampered after sealing"
+  let modelCalls = 0
+  const model: ModelPort = {
+    async complete() {
+      modelCalls += 1
+      return { text: "never" }
+    },
+  }
+  const { result, events, diagnostics } = await execute(
+    workspace,
+    JSON.stringify(envelope),
+    model,
+  )
+  assert.equal(result.exitCode, 1)
+  assert.equal(result.terminalEmitted, false)
+  assert.equal(events.length, 0)
+  assert.equal(modelCalls, 0)
+  assert.ok(
+    diagnostics.some((line) =>
+      line.includes("engine.envelope_digest_mismatch"),
+    ),
+  )
+})
+
+test("AC-003: malformed envelope exits 1 with no terminal line", async () => {
+  const workspace = await createWorkspace()
+  const { result, events, diagnostics } = await execute(workspace, "{not json")
+  assert.equal(result.exitCode, 1)
+  assert.equal(events.length, 0)
+  assert.ok(
+    diagnostics.some((line) => line.includes("engine.envelope_invalid")),
+  )
+})
+
+test("AC-003: missing model credentials exits 1, no terminal line", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace)
+  const events: Array<Record<string, unknown>> = []
+  const diagnostics: string[] = []
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText: JSON.stringify(envelope),
+    env: {},
+    writeEvent: (line) => events.push(JSON.parse(line)),
+    writeDiagnostic: (line) => diagnostics.push(line),
+  })
+  assert.equal(result.exitCode, 1)
+  assert.equal(events.length, 0)
+  assert.ok(
+    diagnostics.some((line) => line.includes("engine.model_unavailable")),
+  )
+})
+
+test("model port resolves through the environment allowlist only", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace)
+  const events: Array<Record<string, unknown>> = []
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText: JSON.stringify(envelope),
+    env: {
+      DIGITAL_EMPLOYEE_ENGINE_MODEL: "deterministic",
+      DIGITAL_EMPLOYEE_ENGINE_MODEL_SCRIPT: '["done via env"]',
+    },
+    writeEvent: (line) => events.push(JSON.parse(line)),
+    writeDiagnostic: () => undefined,
+  })
+  assert.equal(result.exitCode, 0)
+  const terminal = events.find((event) => event.type === "run.completed")
+  assert.ok(terminal)
+  assert.equal(terminal!.output, "done via env")
+})
+
+test("AC-002: modeled budget-exceeded terminal exits 0 with escalation verdict", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, {
+    budget: { maxIterations: 4, maxTokens: 50 },
+  })
+  const model: ModelPort = {
+    async complete() {
+      return { text: "verbose", inputTokens: 60, outputTokens: 60 }
+    },
+  }
+  const { result, events } = await execute(
+    workspace,
+    JSON.stringify(envelope),
+    model,
+  )
+  assert.equal(result.exitCode, 0)
+  const terminal = events.find((event) => event.type === "run.failed")
+  assert.ok(terminal, "expected a modeled run.failed terminal")
+  const error = terminal!.error as { code: string; terminalReason: string }
+  assert.equal(error.code, "engine.turn_budget_exceeded")
+  assert.equal(error.terminalReason, "turn_budget_exceeded")
+})
+
+test("AC-004: position-budget triple accepted with in-memory ledger", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, {
+    positionBudget: {
+      perTask: { iterations: 4 },
+      perDay: { iterations: 100 },
+    },
+    taskId: "task-1",
+    dayKey: "2026-08-23",
+  })
+  const { result, events } = await execute(
+    workspace,
+    JSON.stringify(envelope),
+    createDeterministicModelPort(["done"]),
+  )
+  assert.equal(result.exitCode, 0)
+  const terminal = events.find((event) => event.type === "run.completed")
+  assert.ok(terminal)
+})
+
+test("AC-004: partial position-budget triple fails closed", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, {
+    taskId: "task-1",
+    dayKey: "2026-08-23",
+  })
+  const { result, events, diagnostics } = await execute(
+    workspace,
+    JSON.stringify(envelope),
+    createDeterministicModelPort(["never"]),
+  )
+  assert.equal(result.exitCode, 1)
+  assert.equal(events.length, 0)
+  assert.ok(
+    diagnostics.some((line) => line.includes("engine.input_invalid")),
+  )
+})
+
+test("envelope positionId must match the --position argument", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, { positionId: "other-role" })
+  const { result, events } = await execute(
+    workspace,
+    JSON.stringify(envelope),
+    createDeterministicModelPort(["never"]),
+  )
+  assert.equal(result.exitCode, 1)
+  assert.equal(events.length, 0)
+})
+
+test("uninitialized workspace fails closed", async () => {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "turn-run-empty-"))
+  const envelope = sealedEnvelope(workspace)
+  const { result, events, diagnostics } = await execute(
+    workspace,
+    JSON.stringify(envelope),
+    createDeterministicModelPort(["never"]),
+  )
+  assert.equal(result.exitCode, 1)
+  assert.equal(events.length, 0)
+  assert.ok(
+    diagnostics.some((line) =>
+      line.includes("workspace_org_workspace_not_initialized"),
+    ),
+  )
+})
+
+test("workspaceRef mismatch fails closed", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(path.join(workspace, "elsewhere"))
+  const { result, events } = await execute(
+    workspace,
+    JSON.stringify(envelope),
+    createDeterministicModelPort(["never"]),
+  )
+  assert.equal(result.exitCode, 1)
+  assert.equal(events.length, 0)
+})


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/173
- Consumed revision: R1
- No automatic close keywords: acknowledged
- Open decisions adopted per the record's recommendations: (1) `--input-file`/`--stdin` carry the sealed envelope only — one path, no raw-input convenience mode; (2) stderr diagnostics bounded at 8 KiB per line; (3) envelope schema published under configs/ with builder byte-identity discipline (`configs/turn-envelope.schema.json`).

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 (command surface), AC-001 | apps/cli/bin.ts, apps/cli/turn/index.ts | `digital-employee turn run` registered in usage/parse/dispatch with one workspace positional, `--position` required, exactly one input source, help honored; `--json` rejected because the NDJSON stream is the machine surface; real-CLI golden-path smoke in Validation V1 |
| REQ-002 (sealed envelope), AC-001/AC-004 | apps/cli/turn/envelope.ts, apps/cli/turn/envelope-schema.ts, configs/turn-envelope.schema.json | tests/apps/turn-envelope-schema.test.ts: digest-bound acceptance, tamper rejection (`engine.envelope_digest_mismatch`) before any consumption, schemaVersion pin, position-budget all-present-or-all-absent rule (`engine.input_invalid`), canonical key-order digest; published schema byte-identical to builder |
| REQ-003 (NDJSON stream), AC-001 | apps/cli/turn/turn-run.ts | tests/apps/turn-run.test.ts: one JSON object per stdout line, every event carries runId plus timestamp, exactly one terminal, diagnostics only on stderr |
| REQ-004 (exit-code semantics), AC-002/AC-003 | apps/cli/turn/turn-run.ts | tests/apps/turn-run.test.ts: golden path exit 0 with one terminal; modeled `engine.turn_budget_exceeded` terminal exits 0; malformed envelope, digest mismatch, missing model credentials, uninitialized workspace all exit 1 with zero stdout events (indeterminate, no automatic retry) |
| REQ-005 (structural invariants), AC-001 | apps/cli/turn/ (all modules) | projection only: consumes merged engine core (`executeTurn`, budgets, escalation, evidence ports) without changing engine-internal contracts; no tool surface, no new network or filesystem authority; model keys flow only through the `DIGITAL_EMPLOYEE_ENGINE_MODEL` environment allowlist, never argv; full pre-existing suite stays green (Validation V6) |

## File domains

- apps/cli/turn/envelope.ts — turn-envelope.v1 contract: canonical-JSON sha256 digest, fail-closed parsing, budget-injection mapping rules; owned by REQ-002.
- apps/cli/turn/envelope-schema.ts — code-side schema builder; owned by REQ-002 (open decision 3).
- apps/cli/turn/turn-run.ts — spawn-surface projection: workspace/org-model marker check, workspaceRef/positionId consistency, environment-allowlist model-port resolution, NDJSON projection of executeTurn with single-terminal tracking and exit-code semantics; owned by REQ-003/REQ-004.
- apps/cli/turn/index.ts — `turn run` argument discipline (one workspace, one input source, `--position` required, `--json` rejected); owned by REQ-001.
- apps/cli/bin.ts — usage line, `--position` option, dispatch; owned by REQ-001.
- configs/turn-envelope.schema.json — published schema, builder byte-identical; owned by REQ-002.
- scripts/distribution-policy.js — distribution mapping for the new schema.
- tests/apps/turn-envelope-schema.test.ts, tests/apps/turn-run.test.ts — 17 new tests; owned by the REQ rows above.

## Scope and non-goals

User-visible change: new `digital-employee turn run` spawn surface. Sealed turn-envelope.v1 in, NDJSON engine.v1 events out, exactly one trusted terminal, exit 0/1 semantics a client can fail-closed against. Engine core (#168/#172) is consumed unchanged.

Non-goals: engine-internal contract changes (projection only); tool surface, MCP wiring, or session resume; credential material in argv/events/evidence; automatic client-side retry; in-process SDK packaging; durable (file-backed) ledger/evidence/escalation persistence — this slice wires the merged in-memory ports so the fail-safe stop sequence keeps its persistence-before-terminal guarantee inside the process.

## Validation

- Exact commands: `npm run typecheck`; `npx tsx --test tests/apps/turn-envelope-schema.test.ts tests/apps/turn-run.test.ts`; `npm run check`; real-CLI smoke via `npx tsx apps/cli/bin.ts turn run`.
- Observed counts/results: new tests 17/17 PASS; typecheck PASS; real-CLI golden path emits run.started, model.delta, run.completed NDJSON with EXIT=0; tampered envelope exits 1 with `engine.envelope_digest_mismatch` and zero stdout events; missing model credentials exits 1 with `engine.model_unavailable`. Full local gate on macOS arm64 Node v24.13.0: build, typecheck, governance:check, security:check PASS, npm audit 0/0 high vulnerabilities; all suites PASS except 2 pre-existing tests in tests/apps/deploy-cli.test.ts that assert English prompt strings while this machine's zh locale renders zh-CN (locale is detected from LC_ALL/LANG in apps/cli/deploy/i18n.ts); under `LANG=en_US.UTF-8` that suite is 359/359 PASS. Deploy domain is untouched by this PR; Linux CI (en locale) is the authoritative gate.
- Check URLs: NOT VERIFIED: CI triggers on PR creation; the green run URL will be posted as a follow-up comment.

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001/REQ-002, AC-001 | Sealed envelope yields NDJSON stream with exactly one terminal; digest mismatch rejected before any model consumption | npx tsx apps/cli/bin.ts turn run /tmp/ws --position repo-owner --input-file envelope.json (plus tampered variant) | macOS arm64, Node v24.13.0 | golden path EXIT=0 single terminal; tampered EXIT=1, zero events, zero model calls | golden path 3 events EXIT=0; tampered EXIT=1 `engine.envelope_digest_mismatch` | PASS |
| V2 | REQ-004, AC-002 | Budget-exceeded terminates with `engine.turn_budget_exceeded` and exit 0 (modeled terminal) | npx tsx --test tests/apps/turn-run.test.ts | as above | modeled run.failed terminal, exit 0 | AC-002 test green: `engine.turn_budget_exceeded` / `turn_budget_exceeded`, exit 0 | PASS |
| V3 | REQ-004, AC-003 | Crash/no-terminal paths exit 1 with no terminal line | npx tsx --test tests/apps/turn-run.test.ts plus real-CLI no-credentials smoke | as above | exit 1, zero stdout events | malformed envelope, missing credentials, uninitialized workspace all exit 1 with zero events | PASS |
| V4 | REQ-002, AC-004 | Budget injection mapping covers turn budget, position budget, all-present-or-all-absent | npx tsx --test tests/apps/turn-run.test.ts tests/apps/turn-envelope-schema.test.ts | as above | mapping fixtures green, partial triple fails closed with `engine.input_invalid` | green | PASS |
| V5 | REQ-002, AC-004 | Published schema byte-identical to builder | npx tsx --test tests/apps/turn-envelope-schema.test.ts | as above | byte-identity assertion green | green | PASS |
| V6 | REQ-005, AC-001 | Pre-existing suite unaffected by the additive surface | npm run check (full gate) | as above | all suites green except disclosed environmental cases | all suites green; 2 deploy-cli locale cases fail only under zh locale, 359/359 PASS under `LANG=en_US.UTF-8` | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs. (diagnostics carry stable codes only; envelope content is never echoed)
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed. (no dependency change)
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded.

Compatibility: additive CLI surface only; no existing command behavior changes. Cross-repository: org-workbench D3 client line (#5) consumes this surface via `digital-employee turn run` per the OQ-1 adjudication; engine `engine_capability_missing` handling on the client remains for turn surfaces not yet shipped.

## Known limitations

- Model port resolution ships with the zero-credential deterministic reference port only (`DIGITAL_EMPLOYEE_ENGINE_MODEL=deterministic`); a live provider port lands in a later engine slice — until then a production run exits 1 with `engine.model_unavailable` rather than pretending to be online.
- Budget ledger, escalation sink, and evidence sink are the merged in-memory ports; workspace-local durable persistence (0600) belongs to a later wiring slice, so position-budget consumption does not survive process restarts yet.
- Envelope carries no position context (instructions/spec) or output schema in this slice; the engine runs with assembled input only.
- Full local `npm run check` under a zh locale surfaces 2 pre-existing deploy-cli prompt-language failures outside this PR's domains (deploy/ and locales/ untouched; i18n detects LC_ALL/LANG); the same suite is 359/359 PASS under `LANG=en_US.UTF-8`. Linux CI (en locale) is authoritative.

## Risk and rollback

Additive modules plus a contained bin.ts dispatch addition; no engine-internal module is touched. Rollback: revert the commit; no irreversible effect.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: W2 engine spawn surface is tracked in canonical issue #173; no standalone packet URL exists yet
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
