### PR TITLE
chore(governance): require separated delivery owners in Issue and PR templates (#95)

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap_item.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap_item.yml
@@ -36,6 +36,9 @@ body:
         priority: P2
         productOwner: "@product-owner"
         technicalOwner: "unassigned"
+        implementationOwner: "unassigned"
+        automatedPreReviewOwner: "unassigned"
+        humanReviewOwner: "none"
         userOutcome: "A named user can observe one bounded outcome."
         requirements:
           - REQ-001
@@ -71,6 +74,23 @@ body:
         Public route:
         Owning team:
         Boundary:
+    validations:
+      required: true
+
+  - type: textarea
+    id: delivery_owners
+    attributes:
+      label: Delivery and review owners
+      description: Name the implementation, automated pre-review, and human final-review owners. Keep them independent. Use `none` for human review unless this Issue or CODEOWNERS explicitly routes a stable high-risk, cross-repository, or public-contract candidate to a human reviewer.
+      value: |
+        implementationOwner: "unassigned"
+        automatedPreReviewOwner: "unassigned"
+        humanReviewOwner: "none"
+
+        Review boundary:
+        - Automated review may report `PREFLIGHT PASS`; it cannot submit or claim a GitHub approval.
+        - A human final reviewer does not also implement the same candidate.
+        - Request human review once, after the candidate head is stable, automated pre-review has no P0/P1 findings, and required CI is green.
     validations:
       required: true
 
@@ -181,4 +201,6 @@ body:
         - label: Future semantic changes will follow the append-only policy by adding a `requirement-decision:v1` comment before replacing this body; corrections use a new comment and revision.
           required: true
         - label: Merge, release, product acceptance, and owner milestone acceptance remain separate evidence events.
+          required: true
+        - label: "`implementationOwner`, `automatedPreReviewOwner`, and `humanReviewOwner` are explicit and do not assign implementation and final human review to the same person."
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,13 @@
 - Consumed revision: <!-- R1, R2, ... -->
 - No automatic close keywords: <!-- After checking the PR body and commit messages, replace this comment with acknowledged. -->
 
+## Delivery ownership
+
+- implementationOwner: <!-- P8 implementation owner from the consumed Issue revision -->
+- automatedPreReviewOwner: <!-- Independent automated reviewer; may report PREFLIGHT PASS, never GitHub APPROVE -->
+- humanReviewOwner: <!-- none, @Bindy-lbb, or another reviewer explicitly named by the Issue/CODEOWNERS -->
+- Separation of duties: <!-- Confirm that the implementation owner is not the final human reviewer. -->
+
 ## Requirement trace
 
 | REQ/AC IDs | Changed files / domain | Tests or review evidence |
@@ -50,6 +57,8 @@
 
 ## Product review handoff
 
+- Automated pre-review result: <!-- PREFLIGHT PASS | HOLD with P0/P1 findings | NOT RUN -->
+- Human final review: <!-- PENDING | APPROVED by <actual GitHub reviewer> | N/A: humanReviewOwner=none -->
 - Merge ledger owner: <!-- @maintainer -->
 - Product reviewer: <!-- @product-owner -->
 - Milestone or release packet: <!-- Full canonical URL, or N/A: <reason>. -->

--- a/docs/requirement-governance.md
+++ b/docs/requirement-governance.md
@@ -35,6 +35,9 @@ status: needs-design
 priority: P2
 productOwner: "@product-owner"
 technicalOwner: "unassigned"
+implementationOwner: "unassigned"
+automatedPreReviewOwner: "unassigned"
+humanReviewOwner: "none"
 userOutcome: "A named user can observe one bounded outcome."
 requirements:
   - REQ-001
@@ -51,6 +54,23 @@ lastDecisionAt: null
 reuse or renumber an identifier to mean something else. A cross-repository
 dependency uses its full canonical URL and names the exact revision in prose;
 `owner/repo#12` alone is not sufficient.
+
+The three delivery fields form an auditable separation of duties:
+
+- `implementationOwner` owns the bounded P8 implementation, tests, CI fixes,
+  and evidence packet;
+- `automatedPreReviewOwner` independently replays the acceptance evidence and
+  may report `PREFLIGHT PASS`, but cannot claim or impersonate GitHub approval;
+- `humanReviewOwner` is `none` unless the Issue or CODEOWNERS explicitly names
+  a human final reviewer for a stable high-risk, cross-repository, or public
+  contract candidate.
+
+No person implements and performs the final human review of the same
+candidate. Totoro (`@Bindy-lbb`) is not a routine implementation, test, or
+evidence owner. When she is explicitly routed by the Issue or CODEOWNERS,
+request one focused review only after the candidate head is stable, automated
+pre-review has no P0/P1 finding, and required CI is green. `org-workbench` and
+`context` do not route work to her unless their own Issue explicitly does so.
 
 Every newly created requirement has one authoritative initial lifecycle value:
 `needs-design`, both in the record and in the form field. The form does not let
@@ -290,7 +310,10 @@ Every PR names the full canonical Issue URL and the exact revision it consumes.
 It maps each changed file domain and test or review artifact to `REQ-NNN` and
 `AC-NNN`; records exact commands, counts, check URLs, security and compatibility
 effects, non-goals, and known limits; and identifies product-review handoff
-owners.
+owners. It repeats `implementationOwner`, `automatedPreReviewOwner`, and
+`humanReviewOwner` from the consumed Issue revision. Automated review records
+`PREFLIGHT PASS` or findings; only the actual human reviewer may submit or be
+reported as a GitHub approval.
 
 Do not use automatic Issue close keywords. A merge is implementation evidence,
 not product acceptance. `npm run governance:check` validates the repository PR

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -281,6 +281,17 @@ modified; the platform #5/#8 HOLD marks were not touched.
 | Adoption | #163, #91, #141, #142 | Showcase, clean-machine walkthrough and adoption content |
 | Repo governance | #95, #97 | Requirement/acceptance ledgers and review-bottleneck removal |
 
+Delivery and review ownership is recorded per canonical Issue revision as
+`implementationOwner`, `automatedPreReviewOwner`, and `humanReviewOwner`.
+Product/P9 owns the Issue contract and dependency DAG; P8 owns implementation,
+tests, CI, fixes, and the evidence packet; an independent automated reviewer
+may issue only `PREFLIGHT PASS` or findings. Totoro (`@Bindy-lbb`) is routed
+only when an Issue or CODEOWNERS explicitly assigns her a stable high-risk,
+cross-repository, or public-contract candidate. She does not implement and
+finally review the same candidate, and is not repeatedly requested during
+development. `org-workbench` and `context` default to `humanReviewOwner: none`
+unless their canonical Issue explicitly names a human reviewer.
+
 ## Private work (stays inside the company)
 
 Marketplace accounts, listings, discovery, ratings, rental, dynamic pricing,

--- a/scripts/requirement-governance-check.js
+++ b/scripts/requirement-governance-check.js
@@ -33,6 +33,7 @@ const ISSUE_FIELD_TYPES = Object.freeze({
   current_record: "textarea",
   user_problem: "textarea",
   route_boundary: "textarea",
+  delivery_owners: "textarea",
   requirements: "textarea",
   dependencies: "textarea",
   acceptance: "textarea",
@@ -376,6 +377,10 @@ export function validatePullRequestTemplate(markdown) {
     "Canonical Issue URL:",
     "Consumed revision:",
     "No automatic close keywords:",
+    "implementationOwner:",
+    "automatedPreReviewOwner:",
+    "humanReviewOwner:",
+    "Separation of duties:",
     TRACE_TABLE_HEADER,
     VALIDATION_TABLE_HEADER,
     ...EXACT_EVIDENCE_FIELDS.map((field) => `${field}:`),
@@ -383,6 +388,8 @@ export function validatePullRequestTemplate(markdown) {
     "Merge ledger owner:",
     "Product reviewer:",
     "Milestone or release packet:",
+    "Automated pre-review result:",
+    "Human final review:",
     "Merge, CI, release, and model judgment do not accept or close the Issue:"
   ];
   for (const text of requiredText) {
@@ -518,7 +525,8 @@ export function validateIssueTemplate(source) {
   const record = parseCurrentRecord(entries.get("current_record")?.attributes?.value, errors);
   const recordKeys = [
     "schemaVersion", "revision", "status", "priority", "productOwner",
-    "technicalOwner", "userOutcome", "requirements", "acceptanceCriteria",
+    "technicalOwner", "implementationOwner", "automatedPreReviewOwner",
+    "humanReviewOwner", "userOutcome", "requirements", "acceptanceCriteria",
     "parent", "dependencies", "supersedes", "lastDecisionAt"
   ];
   if (record && !sameKeys(record, recordKeys)) {
@@ -535,6 +543,23 @@ export function validateIssueTemplate(source) {
   }
   if (!Array.isArray(record?.acceptanceCriteria) || !record.acceptanceCriteria.every((id) => /^AC-\d{3}$/.test(id))) {
     errors.push("Issue current record acceptanceCriteria must use AC-NNN identifiers");
+  }
+
+  const deliveryOwners = entries.get("delivery_owners")?.attributes?.value;
+  for (const field of [
+    "implementationOwner",
+    "automatedPreReviewOwner",
+    "humanReviewOwner"
+  ]) {
+    if (typeof record?.[field] !== "string" || !record[field].trim()) {
+      errors.push(`Issue current record ${field} must be a non-empty string`);
+    }
+    if (typeof deliveryOwners !== "string" || !deliveryOwners.includes(`${field}:`)) {
+      errors.push(`Issue delivery owners section is missing: ${field}`);
+    }
+  }
+  if (!String(deliveryOwners || "").includes("PREFLIGHT PASS")) {
+    errors.push("Issue delivery owners section must distinguish PREFLIGHT PASS from GitHub approval");
   }
 
   const readiness = entries.get("readiness")?.attributes?.options;

--- a/tests/scripts/requirement-governance-check.test.ts
+++ b/tests/scripts/requirement-governance-check.test.ts
@@ -506,6 +506,33 @@ test("Issue Form rejects inconsistent lifecycle defaults and extra top-level key
   assert.ok(errors.includes("Issue lifecycle default must consistently be needs-design"));
 });
 
+test("Issue and PR templates require explicit separated delivery owners", async () => {
+  const issue = await readRepositoryFile(".github/ISSUE_TEMPLATE/roadmap_item.yml");
+  const missingOwner = mutateIssue(issue, (form) => {
+    const current = form.body.find((entry: any) => entry.id === "current_record");
+    current.attributes.value = current.attributes.value.replace(
+      'humanReviewOwner: "none"\n',
+      ""
+    );
+  });
+  assert.ok(
+    validateIssueTemplate(missingOwner).includes(
+      "Issue current record has unexpected or missing keys"
+    )
+  );
+
+  const pullRequest = await readRepositoryFile(".github/pull_request_template.md");
+  const missingPreflightBoundary = pullRequest.replace(
+    "- Automated pre-review result:",
+    "- Automated review result:"
+  );
+  assert.ok(
+    validatePullRequestTemplate(missingPreflightBoundary).includes(
+      "PR template is missing: Automated pre-review result:"
+    )
+  );
+});
+
 test("fixture corpus is allowlisted and matches seven exact outcomes", async () => {
   const result = await validateFixtureCorpus(fixtureRoot);
   assert.equal(result.fixtureCount, 7);


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/95
- Consumed revision: R1
- No automatic close keywords: acknowledged

## Delivery ownership

- implementationOwner: @PeterGuy326 (execution line)
- automatedPreReviewOwner: unassigned (automated pre-review pending)
- humanReviewOwner: none (no Issue/CODEOWNERS routing of this candidate to a human final reviewer)
- Separation of duties: implementation owner is not the final human reviewer; automated review reports PREFLIGHT PASS or findings only.

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001, AC-001 | .github/ISSUE_TEMPLATE/roadmap_item.yml | Issue current record gains `implementationOwner`, `automatedPreReviewOwner`, `humanReviewOwner`; new `delivery_owners` form section states the PREFLIGHT PASS vs GitHub approval boundary; readiness checklist gains the separation-of-duties item |
| REQ-003, AC-003 | .github/pull_request_template.md | PR template gains Delivery ownership section and Automated pre-review result / Human final review handoff fields |
| REQ-001, REQ-003, AC-001, AC-003 | scripts/requirement-governance-check.js | Deterministic check now validates the three owner fields in the Issue current record, the delivery owners form section, and the new PR template headings |
| REQ-001, REQ-003, AC-001, AC-003 | docs/requirement-governance.md, docs/roadmap.md | Governance doc and roadmap record the separation-of-duties semantics and Totoro routing boundary |
| REQ-003, AC-003 | tests/scripts/requirement-governance-check.test.ts | New test rejects a record missing `humanReviewOwner` and a PR template missing the Automated pre-review result field |

## File domains

- .github/ISSUE_TEMPLATE/roadmap_item.yml — Issue form: three delivery owner fields in the current record example, delivery owners section, readiness checklist item.
- .github/pull_request_template.md — Delivery ownership section and product-review handoff fields.
- docs/requirement-governance.md — record schema and PR-trace prose updated for the three owner fields.
- docs/roadmap.md — ownership paragraph under the delivery section.
- scripts/requirement-governance-check.js — validation for Issue record keys, delivery owners section, and PR template headings.
- tests/scripts/requirement-governance-check.test.ts — one new negative-fixture test.

## Scope and non-goals

User-visible change: Issue/PR template authors must now name implementation, automated pre-review, and human final-review owners. Automated review may report `PREFLIGHT PASS`; it cannot submit or claim a GitHub approval. `humanReviewOwner` defaults to `none` unless the Issue or CODEOWNERS explicitly routes a stable high-risk, cross-repository, or public-contract candidate to a human reviewer.

Non-goals: no runtime/product behavior change; no change to branch protection or CODEOWNERS content; no reviewer appointments; no migration of existing Issues (they migrate when semantically touched).

## Validation

- Exact commands: `npm run typecheck`; `npm run governance:check`; `npm run security:check`; `npx tsx --test tests/scripts/requirement-governance-check.test.ts`; `npm audit --omit=dev --audit-level=high`.
- Observed counts/results: typecheck PASS; governance:check PASS (7 allowlisted PR fixtures); security:check PASS; governance-check test file 35/35 PASS; npm audit 0 vulnerabilities. A local full `npm run check` run additionally showed two failing cases in tests/apps/deploy-cli.test.ts (DingTalk provider scope, timing-sensitive) outside this diff's file domains; Linux CI is the source of truth and its run URL will be posted as a follow-up comment.
- Check URLs: NOT VERIFIED: CI triggers on PR creation; the green run URL will be posted as a follow-up comment.

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-003 | Governance check enforces the three owner fields in Issue record, delivery owners section, and PR template headings | npm run governance:check; npx tsx --test tests/scripts/requirement-governance-check.test.ts | macOS arm64, Node v24.13.0 | governance check PASS; test file PASS including the new separation-of-duties negative cases | governance:check PASS (7 fixtures); 35/35 tests PASS | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs. (no logging change)
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed. (no dependency change)
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded.

Compatibility: templates and governance tooling only. Existing Issues are not rewritten; the new record keys apply to Issues created or semantically touched after merge.

## Known limitations

- Existing open Issues created before this change do not carry the three owner fields until their next semantic revision; the deterministic check validates templates and fixtures, not live Issue bodies.

## Risk and rollback

Template, docs, and governance-check changes only; no production runtime touched. Rollback: revert the commit.

## Product review handoff

- Automated pre-review result: NOT RUN
- Human final review: N/A: humanReviewOwner=none
- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: governance tooling record; no release packet exists
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
