### PR TITLE
feat(engine): claude-local model port for turn run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `turn run` gains a `claude-local` model port (#182 REQ-001..REQ-005), so a
+  local operator can complete a turn with the Claude Code install already
+  authenticated on their machine and no `ANTHROPIC_API_KEY`. The port spawns
+  the official binary and lets Claude Code resolve its own login: it never
+  reads, parses or forwards any credential store, and `HOME` /
+  `CLAUDE_CONFIG_DIR` are deliberately left untouched. The run stream must
+  announce `apiKeySource: claude_cli_oauth`; an `ANTHROPIC_API_KEY`-sourced
+  init is rejected so a service credential cannot be used while reporting an
+  unverified authentication source, and a `none`-sourced init maps to an
+  actionable `claude_local_not_logged_in` (verified against 2.1.223: `none`
+  means not logged in). Token usage is read from the stream, so
+  per-task and per-day budget accounting keeps working. A missing or
+  out-of-window binary fails closed during port resolution (exit 1, an
+  environment fault) instead of being modeled as a failed turn (exit 0).
+  Scope is local interactive use only — unattended, multi-tenant, third-party
+  or resale deployments still require the isolated `ANTHROPIC_API_KEY`
+  adapter, and no subscription credential may be bundled into a distributed
+  employee package. The port has not been through adapter qualification, and
+  end-to-end verification against a genuinely authenticated Claude Code is a
+  manual local check that CI does not cover. See
+  [`docs/agent-hosts.md`](docs/agent-hosts.md).
+
 - The capability evidence standard is now codified and enforced (#140
   REQ-001 / REQ-002 / REQ-004, AC-001 / AC-002): every claim must carry the
   exact Host version, the deterministic fixture (kit) version, the

--- a/apps/cli/claude-stream-agent-host.ts
+++ b/apps/cli/claude-stream-agent-host.ts
@@ -24,7 +24,18 @@ export interface ClaudeStreamNormalizerOptions {
   expectedVersion?: string
   versionSupported: (value: string | undefined) => boolean
   now: () => string
+  /**
+   * Authentication sources the announced init may declare. Defaults to the
+   * isolated service adapter's single `ANTHROPIC_API_KEY`. The local operator
+   * model port (#182) accepts the operator-login sources instead, so that a
+   * service credential can never be used while an unverified authentication
+   * source is reported. Membership is asserted exactly: anything outside the
+   * allowed set still fails closed.
+   */
+  expectedApiKeySources?: readonly string[]
 }
+
+const DEFAULT_API_KEY_SOURCES: readonly string[] = ["ANTHROPIC_API_KEY"]
 
 export interface ClaudeStreamCompletion {
   usage: Extract<AgentHostEvent, { type: "usage" }>
@@ -178,7 +189,10 @@ export class ClaudeZeroToolStreamNormalizer {
         event.capabilities.every((entry) => typeof entry === "string"))
     if (
       !boundedSessionId(event.session_id) ||
-      event.apiKeySource !== "ANTHROPIC_API_KEY" ||
+      typeof event.apiKeySource !== "string" ||
+      !(this.options.expectedApiKeySources ?? DEFAULT_API_KEY_SOURCES).includes(
+        event.apiKeySource,
+      ) ||
       event.cwd !== this.options.expectedCwd ||
       event.permissionMode !== "dontAsk" ||
       !exactEmptyArray(event.tools) ||

--- a/apps/cli/turn/claude-local-model-port.ts
+++ b/apps/cli/turn/claude-local-model-port.ts
@@ -1,0 +1,437 @@
+/**
+ * Local-operator Claude Code model port (#182).
+ *
+ * Drives the `claude` binary already installed and authenticated on the local
+ * operator's machine, so a turn runs without `ANTHROPIC_API_KEY`. The port is
+ * a pure inference seam: Claude Code runs with an empty tool, MCP, skill and
+ * slash-command set, and the engine keeps ownership of the turn loop, budget
+ * accounting, doom-loop detection and output validation.
+ *
+ * Boundary (#182 REQ-003, docs/agent-hosts.md): this port never reads, parses
+ * or forwards any credential store. It spawns the official binary and lets
+ * Claude Code resolve its own authentication. `HOME` and `CLAUDE_CONFIG_DIR`
+ * are deliberately left untouched — that is the entire mechanism by which the
+ * operator's existing login becomes visible.
+ *
+ * Scope (#182 non-goals): local operator use only. It is not for unattended
+ * servers, multi-tenant execution, running third-party tasks, or resale, and
+ * no credential may be bundled into a distributed employee package. The
+ * isolated `ANTHROPIC_API_KEY` adapter in claude-agent-host.ts remains the
+ * only option for those deployments.
+ */
+
+import { spawn, spawnSync } from "node:child_process"
+import { mkdtemp, realpath, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { createInterface } from "node:readline"
+
+import type { ModelPort, ModelTurnInput, ModelTurnResult } from "../../../packages/engine/src/model-port.js"
+import {
+  ClaudeStreamProtocolError,
+  ClaudeZeroToolStreamNormalizer,
+} from "../claude-stream-agent-host.js"
+
+/**
+ * Authentication sources accepted as a genuine operator login.
+ *
+ * `claude_cli_oauth` is the label the isolated adapter's own fixtures already
+ * record for an operator-authenticated CLI. Deliberately excluded:
+ *
+ *   - `ANTHROPIC_API_KEY` — a service credential; this port must not be a
+ *     second, unqualified path to the isolated adapter's deployment mode.
+ *   - `none` — verified against Claude Code 2.1.223 to mean *not logged in*:
+ *     the run answers `Not logged in · Please run /login` with
+ *     `error: authentication_failed`. Accepting it would let an
+ *     unauthenticated run past this gate, so it maps to its own actionable
+ *     failure below instead.
+ *
+ * An unrecognized source fails closed. If a future release announces a
+ * different operator-login label, the run reports a policy mismatch naming the
+ * announced value rather than silently degrading.
+ */
+const LOCAL_API_KEY_SOURCES: readonly string[] = ["claude_cli_oauth"]
+
+/** Claude Code announces this when no operator login is present. */
+const NOT_LOGGED_IN_SOURCE = "none"
+/** Same conformance-verified window as the isolated adapter. */
+const MIN_CLAUDE_VERSION = [2, 1, 214] as const
+const MAX_CLAUDE_VERSION = [2, 2, 0] as const
+const DEFAULT_TIMEOUT_MS = 240_000
+const MAX_STDOUT_BYTES = 4 * 1024 * 1024
+const MAX_STDERR_BYTES = 256 * 1024
+const MAX_LINE_BYTES = 1024 * 1024
+const MAX_PROMPT_BYTES = 256 * 1024
+const TERMINATION_GRACE_MS = 2_000
+
+/**
+ * Hardening kept from the isolated adapter (#182 OQ-2). The operator's real
+ * HOME stays visible so their login works, so the exposure that can be closed
+ * without breaking authentication is closed here: no project memory, no
+ * attachments, no background work, no IDE handshake.
+ */
+const HARDENING_ENVIRONMENT: Readonly<Record<string, string>> = {
+  CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS: "1",
+  CLAUDE_CODE_AUTO_CONNECT_IDE: "false",
+  CLAUDE_CODE_DISABLE_ATTACHMENTS: "1",
+  CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1",
+  CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1",
+  CLAUDE_CODE_DISABLE_CLAUDE_MDS: "1",
+  CLAUDE_CODE_DISABLE_CRON: "1",
+  CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS: "1",
+  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+  CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK: "1",
+  DISABLE_UPDATES: "1",
+}
+
+export class ClaudeLocalModelPortError extends Error {
+  constructor(readonly code: string, message?: string) {
+    super(message ?? code)
+    this.name = "ClaudeLocalModelPortError"
+  }
+}
+
+export interface ClaudeLocalModelPortOptions {
+  /** Binary to spawn; defaults to `claude` resolved from PATH. */
+  command?: string
+  /** Arguments prepended before the pinned flag set. Test seam. */
+  commandPrefixArgs?: readonly string[]
+  /** Inherited process environment. Test seam. */
+  environment?: NodeJS.ProcessEnv
+  timeoutMs?: number
+  /** Test seams. */
+  now?: () => string
+  newRunId?: () => string
+}
+
+function versionAtLeast(
+  parts: readonly [number, number, number],
+  bound: readonly [number, number, number],
+): boolean {
+  for (let index = 0; index < 3; index += 1) {
+    if (parts[index]! > bound[index]!) return true
+    if (parts[index]! < bound[index]!) return false
+  }
+  return true
+}
+
+function versionBelow(
+  parts: readonly [number, number, number],
+  bound: readonly [number, number, number],
+): boolean {
+  for (let index = 0; index < 3; index += 1) {
+    if (parts[index]! < bound[index]!) return true
+    if (parts[index]! > bound[index]!) return false
+  }
+  return false
+}
+
+/** Same pinned window as the isolated adapter: >=2.1.214 and <2.2.0. */
+export function isSupportedLocalClaudeVersion(value: string | undefined): boolean {
+  if (typeof value !== "string") return false
+  const match = /(\d+)\.(\d+)\.(\d+)/.exec(value)
+  if (!match) return false
+  const parts = [Number(match[1]), Number(match[2]), Number(match[3])] as [
+    number,
+    number,
+    number,
+  ]
+  if (parts.some((part) => !Number.isSafeInteger(part) || part < 0)) return false
+  return (
+    versionAtLeast(parts, MIN_CLAUDE_VERSION) &&
+    versionBelow(parts, MAX_CLAUDE_VERSION)
+  )
+}
+
+/**
+ * Render the assembled context into one prompt. Slots arrive already ordered
+ * and window-managed by the engine's context assembler; prior output
+ * violations are appended so the engine's repair loop stays observable to the
+ * model without giving it a tool surface.
+ */
+function renderPrompt(input: ModelTurnInput): string {
+  const sections = input.blocks.map((block) => `## ${block.slot}\n${block.text}`)
+  if (input.priorViolations.length > 0) {
+    const violations = input.priorViolations
+      .map((entry) => `- attempt ${entry.attempt}: ${entry.summary}`)
+      .join("\n")
+    sections.push(`## output_violations\n${violations}`)
+  }
+  return sections.join("\n\n")
+}
+
+/** True for an init frame announcing that no operator login is present. */
+function isNotLoggedInInit(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false
+  const frame = value as Record<string, unknown>
+  return (
+    frame.type === "system" &&
+    frame.subtype === "init" &&
+    frame.apiKeySource === NOT_LOGGED_IN_SOURCE
+  )
+}
+
+function spawnArgs(prefix: readonly string[]): string[] {
+  return [
+    ...prefix,
+    "--bare",
+    "--print",
+    "--input-format",
+    "text",
+    "--output-format",
+    "stream-json",
+    "--verbose",
+    "--include-partial-messages",
+    "--permission-mode",
+    "dontAsk",
+    "--tools",
+    "",
+    "--setting-sources",
+    "",
+    "--strict-mcp-config",
+    "--disable-slash-commands",
+    "--no-chrome",
+    "--no-session-persistence",
+    "--max-turns",
+    "1",
+  ]
+}
+
+/**
+ * Build the child environment. Deliberately additive over the inherited
+ * environment: `HOME` and `CLAUDE_CONFIG_DIR` are never set here, which is
+ * what lets Claude Code find the operator's own login. `ANTHROPIC_API_KEY` is
+ * stripped so this port cannot silently fall back to a service credential and
+ * report an authentication source it did not verify.
+ */
+export function localRunEnvironment(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const result: NodeJS.ProcessEnv = { ...source, ...HARDENING_ENVIRONMENT }
+  delete result.ANTHROPIC_API_KEY
+  return result
+}
+
+/**
+ * Precondition probe, run before the turn starts.
+ *
+ * `turn run` reserves exit 1 for spawn-level failures including a missing
+ * model credential, and exit 0 for modeled governance verdicts. A missing or
+ * out-of-window `claude` is an environment fault, not a verdict about the
+ * employee, so it has to surface during port resolution — otherwise the engine
+ * models it as a failed turn and reports exit 0.
+ *
+ * Returns an error code, or undefined when the binary is usable. Login state
+ * is deliberately not probed here: it is asserted from the announced
+ * `apiKeySource` in the run stream, so no credential store is ever inspected.
+ */
+export function probeLocalClaude(
+  command: string,
+  prefixArgs: readonly string[] = [],
+  timeoutMs = 10_000,
+): string | undefined {
+  let probe: ReturnType<typeof spawnSync>
+  try {
+    probe = spawnSync(command, [...prefixArgs, "--version"], {
+      encoding: "utf8",
+      timeout: timeoutMs,
+      shell: false,
+      windowsHide: true,
+    })
+  } catch {
+    return "claude_local_binary_unavailable"
+  }
+  if (probe.error !== undefined || probe.status !== 0) {
+    return "claude_local_binary_unavailable"
+  }
+  const announced = typeof probe.stdout === "string" ? probe.stdout : undefined
+  if (!isSupportedLocalClaudeVersion(announced)) {
+    return "claude_local_version_not_supported"
+  }
+  return undefined
+}
+
+export function createClaudeLocalModelPort(
+  options: ClaudeLocalModelPortOptions = {},
+): ModelPort {
+  const command = options.command ?? "claude"
+  const commandPrefixArgs = options.commandPrefixArgs ?? []
+  const environment = options.environment ?? process.env
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const now = options.now ?? (() => new Date().toISOString())
+  const newRunId = options.newRunId ?? (() => `claude-local-${process.pid}`)
+
+  return {
+    async complete(
+      input: ModelTurnInput,
+      signal?: AbortSignal,
+    ): Promise<ModelTurnResult> {
+      if (signal?.aborted) {
+        throw new ClaudeLocalModelPortError("claude_local_aborted")
+      }
+      const prompt = renderPrompt(input)
+      if (Buffer.byteLength(prompt, "utf8") > MAX_PROMPT_BYTES) {
+        throw new ClaudeLocalModelPortError("claude_local_prompt_too_large")
+      }
+
+      // An empty scratch cwd: the run has no tools, so nothing may be read
+      // from it, and the announced `cwd` stays assertable.
+      const runRoot = await mkdtemp(path.join(os.tmpdir(), "digital-employee-claude-local-"))
+      let child: ReturnType<typeof spawn> | undefined
+      try {
+        const expectedCwd = await realpath(runRoot)
+        child = spawn(command, spawnArgs(commandPrefixArgs), {
+          cwd: expectedCwd,
+          shell: false,
+          windowsHide: true,
+          stdio: ["pipe", "pipe", "pipe"],
+          env: localRunEnvironment(environment),
+        })
+        const active = child
+
+        const normalizer = new ClaudeZeroToolStreamNormalizer({
+          runId: newRunId(),
+          expectedCwd,
+          versionSupported: isSupportedLocalClaudeVersion,
+          now,
+          expectedApiKeySources: LOCAL_API_KEY_SOURCES,
+        })
+
+        return await new Promise<ModelTurnResult>((resolve, reject) => {
+          let settled = false
+          let stdoutBytes = 0
+          let stderrBytes = 0
+          let stderrText = ""
+          let timer: NodeJS.Timeout | undefined
+          let onAbort: (() => void) | undefined
+
+          const finish = (outcome: () => void): void => {
+            if (settled) return
+            settled = true
+            if (timer) clearTimeout(timer)
+            if (onAbort && signal) signal.removeEventListener("abort", onAbort)
+            outcome()
+          }
+
+          const fail = (code: string, message?: string): void => {
+            finish(() => {
+              killTree(active)
+              reject(new ClaudeLocalModelPortError(code, message))
+            })
+          }
+
+          timer = setTimeout(() => fail("claude_local_deadline_exceeded"), timeoutMs)
+          if (signal) {
+            onAbort = () => fail("claude_local_aborted")
+            signal.addEventListener("abort", onAbort, { once: true })
+          }
+
+          active.on("error", () => fail("claude_local_spawn_failed"))
+
+          active.stderr?.on("data", (chunk: Buffer) => {
+            stderrBytes += chunk.byteLength
+            if (stderrBytes > MAX_STDERR_BYTES) {
+              fail("claude_local_stderr_limit")
+              return
+            }
+            if (stderrText.length < 2048) stderrText += String(chunk)
+          })
+
+          const lines = createInterface({ input: active.stdout!, crlfDelay: Infinity })
+          lines.on("line", (line) => {
+            if (settled) return
+            stdoutBytes += Buffer.byteLength(line, "utf8") + 1
+            if (stdoutBytes > MAX_STDOUT_BYTES) {
+              fail("claude_local_stdout_limit")
+              return
+            }
+            if (Buffer.byteLength(line, "utf8") > MAX_LINE_BYTES) {
+              fail("claude_local_line_too_large")
+              return
+            }
+            if (line.trim().length === 0) return
+            let parsed: unknown
+            try {
+              parsed = JSON.parse(line)
+            } catch {
+              fail("claude_local_stream_not_json")
+              return
+            }
+            // "Failure still has a path": a missing login is the most likely
+            // first-run fault, and the announced init already says so. Name it
+            // before the generic policy assertion turns it into a mismatch.
+            if (isNotLoggedInInit(parsed)) {
+              fail(
+                "claude_local_not_logged_in",
+                "the local Claude Code install has no operator login: run `claude /login` and retry",
+              )
+              return
+            }
+            try {
+              normalizer.accept(parsed)
+            } catch (error) {
+              fail(
+                error instanceof ClaudeStreamProtocolError
+                  ? error.message
+                  : "claude_local_stream_invalid",
+              )
+            }
+          })
+
+          active.on("close", (exitCode) => {
+            if (settled) return
+            if (exitCode !== 0) {
+              fail(
+                "claude_local_process_failed",
+                `claude exited with code ${String(exitCode)}${
+                  stderrText.length > 0 ? `: ${stderrText.trim()}` : ""
+                }`,
+              )
+              return
+            }
+            let completion
+            try {
+              // No output validator: the engine owns schema validation, so the
+              // port hands back text and usage only.
+              completion = normalizer.finish(undefined)
+            } catch (error) {
+              fail(
+                error instanceof ClaudeStreamProtocolError
+                  ? error.message
+                  : "claude_local_stream_invalid",
+              )
+              return
+            }
+            const text = completion.output
+            if (typeof text !== "string") {
+              fail("claude_local_result_text_missing")
+              return
+            }
+            finish(() =>
+              resolve({
+                text,
+                inputTokens: completion.usage.inputTokens,
+                outputTokens: completion.usage.outputTokens,
+              }),
+            )
+          })
+
+          active.stdin!.on("error", () => fail("claude_local_stdin_failed"))
+          active.stdin!.end(prompt)
+        })
+      } finally {
+        if (child && child.exitCode === null && child.signalCode === null) {
+          killTree(child)
+        }
+        await rm(runRoot, { recursive: true, force: true }).catch(() => undefined)
+      }
+    },
+  }
+}
+
+function killTree(child: ReturnType<typeof spawn>): void {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  child.kill("SIGTERM")
+  const timer = setTimeout(() => {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL")
+  }, TERMINATION_GRACE_MS)
+  timer.unref()
+}

--- a/apps/cli/turn/envelope.ts
+++ b/apps/cli/turn/envelope.ts
@@ -29,6 +29,13 @@ export const TURN_ENVELOPE_SCHEMA_ID =
 export const TURN_ENGINE_MODEL_ENV = "DIGITAL_EMPLOYEE_ENGINE_MODEL" as const
 export const TURN_ENGINE_MODEL_SCRIPT_ENV =
   "DIGITAL_EMPLOYEE_ENGINE_MODEL_SCRIPT" as const
+/**
+ * Optional binary override for the claude-local port (#182). A version manager
+ * or a non-standard install can keep `claude` off the spawn PATH; this names
+ * the entrypoint without putting anything credential-bearing in argv.
+ */
+export const TURN_ENGINE_CLAUDE_COMMAND_ENV =
+  "DIGITAL_EMPLOYEE_CLAUDE_COMMAND" as const
 
 export interface TurnEnvelope {
   schemaVersion: typeof TURN_ENVELOPE_VERSION

--- a/apps/cli/turn/turn-run.ts
+++ b/apps/cli/turn/turn-run.ts
@@ -30,11 +30,13 @@ import {
   type ModelPort,
 } from "../../../packages/engine/src/model-port.js"
 import type { EngineTurnRequest } from "../../../packages/engine/src/contracts.js"
+import { createClaudeLocalModelPort, probeLocalClaude } from "./claude-local-model-port.js"
 import { executeTurn } from "../../../packages/engine/src/turn-executor.js"
 import { loadOrgModel } from "../org/model.js"
 import {
   parseTurnEnvelope,
   TurnEnvelopeError,
+  TURN_ENGINE_CLAUDE_COMMAND_ENV,
   TURN_ENGINE_MODEL_ENV,
   TURN_ENGINE_MODEL_SCRIPT_ENV,
   type TurnEnvelope,
@@ -109,6 +111,23 @@ function resolveModelPort(env: NodeJS.ProcessEnv): ModelPort {
       )
     }
     return createDeterministicModelPort(script as string[])
+  }
+  if (engine === "claude-local") {
+    // Local-operator port (#182): drives the operator's already-authenticated
+    // Claude Code install, so no service credential is read or required. Local
+    // interactive use only — see claude-local-model-port.ts for the boundary.
+    const command = env[TURN_ENGINE_CLAUDE_COMMAND_ENV]?.trim() || "claude"
+    // A missing or out-of-window binary is an environment fault: surface it
+    // here so it maps to exit 1, instead of letting the engine model it as a
+    // failed turn and report exit 0.
+    const unusable = probeLocalClaude(command)
+    if (unusable !== undefined) {
+      throw new TurnSpawnError(
+        "engine.model_unavailable",
+        `${unusable}: the local Claude Code binary (${command}) is missing or outside the supported version window`,
+      )
+    }
+    return createClaudeLocalModelPort({ command, environment: env })
   }
   throw new TurnSpawnError(
     "engine.model_unavailable",

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -192,3 +192,22 @@ Workbench Bridge 不得：
 例如，[腾讯 WorkBuddy Acceptable Use Policy](https://www.workbuddy.ai/document/acceptable-use-policy) 对未经 API 条款明确授权的自动化 bot/scraper 有限制；这不能由技术 Adapter 绕过。Claude Agent SDK、Codex、Qwen/阿里和其他 Host 也必须分别以届时适用的官方商业/API 条款为准。即使客户端代码是开源的，也不能据此推断模型服务或账号可以转售。
 
 默认商业部署模式应是操作方显式选择 Host 并提供合法凭证（或后续经条款确认的 BYOK），而不是把维护者个人订阅随员工包发布。
+
+## `claude-local` model port（#182，本地操作方专用）
+
+上表列的 Adapter 都走 `agent run` 路径。`turn run` 另有一条独立的 model port 路径，其契约是纯推理缝（`packages/engine/src/model-port.ts`：只返回文本与用量，不暴露可执行面），agent 循环、预算与输出校验都在引擎侧。除零凭据的 `deterministic` 参考实现外，该路径现有一个 `claude-local` port：
+
+| 项 | 说明 |
+| --- | --- |
+| 启用方式 | `DIGITAL_EMPLOYEE_ENGINE_MODEL=claude-local`；二进制默认取 PATH 上的 `claude`，可用 `DIGITAL_EMPLOYEE_CLAUDE_COMMAND` 指定 |
+| 凭据 | **不需要** `ANTHROPIC_API_KEY`。spawn 官方 `claude`，由 Claude Code 自行解析其登录态 |
+| 认证断言 | 运行流的 `apiKeySource` 必须为 `claude_cli_oauth`。声明为 `ANTHROPIC_API_KEY` 的 init 会被拒绝，避免误用服务凭据却报告未经验证的认证来源；声明为 `none` 的 init 映射到专门的 `claude_local_not_logged_in`，提示运行 `claude /login`——对 Claude Code 2.1.223 实测确认 `none` 表示**未登录**（运行会回 `Not logged in · Please run /login`、`error: authentication_failed`），把它当作有效来源会让未认证的运行通过策略门 |
+| 版本窗口 | 与隔离 Adapter 相同：`>=2.1.214 <2.2.0`。窗口外或二进制缺失在 port 解析阶段 fail closed（退出码 1，环境故障），不会被建模成"员工失败"的治理结论（退出码 0） |
+| 环境姿态 | **不覆盖** `HOME` 与 `CLAUDE_CONFIG_DIR`——这是操作方登录态可见的唯一机制。继承环境中的 `ANTHROPIC_API_KEY` 会被剔除；`CLAUDE_CODE_DISABLE_CLAUDE_MDS` 等收敛 flag 保留 |
+| 工具面 | 空工具/MCP/skill/slash-command 集，`--max-turns 1`，Claude Code 在此仅作模型使用 |
+
+**适用边界（硬约束）**：仅限本地操作方在自己机器上使用自己的登录态。不得用于服务器无人值守运行、多租户、代第三方用户执行或商业转售；不得将任何订阅凭据随员工包、镜像或分发物发布。这些场景仍只能使用上表中基于显式 `ANTHROPIC_API_KEY` 的隔离 Adapter。
+
+**该 port 从不读取凭据存储**：不读、不解析、不转发 `~/.claude/.credentials.json`、系统钥匙串或任何凭据文件；唯一机制是 spawn 官方二进制。
+
+**未达成的部分**：该 port 未走 adapter qualification 流程，不得据上表的 `runnable` 结论推断其等价性。保留真实 `HOME` 意味着放弃隔离 Adapter 那种"运行可复现"保证。订阅限流面向单人交互式使用，跨岗位并发派活的并发策略由调用方（如 org-workbench）负责，本 port 不做限流。真实登录态下的端到端验收需本机手工执行，CI 不覆盖。

--- a/tests/apps/claude-local-model-port.test.ts
+++ b/tests/apps/claude-local-model-port.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Local-operator Claude Code model port tests (#182 AC-002..AC-005).
+ *
+ * Every case drives a fixture binary, so no login and no credential is
+ * required. AC-001 (a real turn against a genuinely authenticated Claude
+ * Code) is a manual local check and is explicitly not covered here.
+ */
+
+import assert from "node:assert/strict"
+import { mkdtemp, readFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import test from "node:test"
+
+import {
+  createClaudeLocalModelPort,
+  isSupportedLocalClaudeVersion,
+  localRunEnvironment,
+} from "../../apps/cli/turn/claude-local-model-port.js"
+import type { ModelTurnInput } from "../../packages/engine/src/model-port.js"
+
+const fixture = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+  "fake-claude-local.mjs",
+)
+
+function input(text = "answer the question"): ModelTurnInput {
+  return {
+    blocks: [{ slot: "turn_input", text, byteLength: Buffer.byteLength(text), truncatedBytes: 0 }],
+    priorViolations: [],
+  }
+}
+
+/** Assert on the stable error code rather than the human-facing message. */
+function rejectsWithCode(promise: Promise<unknown>, code: string): Promise<void> {
+  return assert.rejects(promise, (error: unknown) => {
+    assert.equal((error as { code?: string }).code, code)
+    return true
+  })
+}
+
+function port(mode: string, extra: string[] = []) {
+  return createClaudeLocalModelPort({
+    command: process.execPath,
+    commandPrefixArgs: [fixture, "--fixture-mode", mode, ...extra],
+    environment: { ...process.env },
+    timeoutMs: 20_000,
+    now: () => "2026-01-01T00:00:00.000Z",
+    newRunId: () => "run-fixture",
+  })
+}
+
+test("returns model text and token usage without any credential", async () => {
+  const result = await port("success").complete(input())
+  assert.equal(result.text, "fixture answer")
+  assert.equal(result.inputTokens, 11)
+  assert.equal(result.outputTokens, 7)
+})
+
+test("the operator HOME is preserved and ANTHROPIC_API_KEY is stripped (AC-003)", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "claude-local-env-"))
+  const capture = path.join(dir, "env.json")
+  await createClaudeLocalModelPort({
+    command: process.execPath,
+    commandPrefixArgs: [fixture, "--fixture-mode", "success", "--capture-env", capture],
+    // A service credential in the inherited environment must not reach the child.
+    environment: { ...process.env, ANTHROPIC_API_KEY: "fixture-must-not-propagate" },
+    timeoutMs: 20_000,
+  }).complete(input())
+
+  const seen = JSON.parse(await readFile(capture, "utf8")) as Record<string, string | null>
+  assert.equal(seen.ANTHROPIC_API_KEY, null, "the service credential must be stripped")
+  assert.equal(seen.HOME, process.env.HOME ?? null, "the operator HOME must be preserved")
+  assert.equal(seen.CLAUDE_CONFIG_DIR, null, "CLAUDE_CONFIG_DIR must stay unset")
+  assert.equal(seen.CLAUDE_CODE_DISABLE_CLAUDE_MDS, "1", "project-memory hardening stays on")
+})
+
+test("localRunEnvironment never carries a service credential", () => {
+  const result = localRunEnvironment({
+    ANTHROPIC_API_KEY: "fixture-anthropic-sentinel",
+    HOME: "/home/op",
+  })
+  assert.equal(result.ANTHROPIC_API_KEY, undefined)
+  assert.equal(result.HOME, "/home/op")
+})
+
+test("the prompt carries assembled slots and prior violations", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "claude-local-prompt-"))
+  const capture = path.join(dir, "prompt.txt")
+  await createClaudeLocalModelPort({
+    command: process.execPath,
+    commandPrefixArgs: [fixture, "--fixture-mode", "success", "--capture-prompt", capture],
+    environment: { ...process.env },
+    timeoutMs: 20_000,
+  }).complete({
+    blocks: [{ slot: "turn_input", text: "do the thing", byteLength: 12, truncatedBytes: 0 }],
+    priorViolations: [{ attempt: 1, summary: "missing field" }],
+  })
+
+  const prompt = await readFile(capture, "utf8")
+  assert.match(prompt, /## turn_input\ndo the thing/)
+  assert.match(prompt, /## output_violations\n- attempt 1: missing field/)
+})
+
+test("an ANTHROPIC_API_KEY-sourced init is rejected (this port is operator-auth only)", async () => {
+  await rejectsWithCode(
+    port("api-key-source-mismatch").complete(input()),
+    "claude_runtime_policy_mismatch",
+  )
+})
+
+test("a not-logged-in install reports an actionable failure, not a policy mismatch", async () => {
+  // Verified against Claude Code 2.1.223: an install without an operator login
+  // announces apiKeySource "none" and answers "Not logged in · Please run
+  // /login". Accepting it would let an unauthenticated run past the gate.
+  await rejectsWithCode(port("not-logged-in").complete(input()), "claude_local_not_logged_in")
+})
+
+test("invalid usage fails closed rather than reporting unmeasured tokens (AC-002)", async () => {
+  await rejectsWithCode(port("invalid-usage").complete(input()), "claude_usage_invalid")
+})
+
+test("a missing cost field fails closed", async () => {
+  await rejectsWithCode(port("missing-cost").complete(input()), "claude_usage_invalid")
+})
+
+test("an engine-reported result error fails closed", async () => {
+  await assert.rejects(port("result-error").complete(input()))
+})
+
+test("a non-zero exit fails closed", async () => {
+  await rejectsWithCode(port("exit-nonzero").complete(input()), "claude_local_process_failed")
+})
+
+test("an aborted signal rejects before spawning", async () => {
+  const controller = new AbortController()
+  controller.abort()
+  await rejectsWithCode(
+    port("success").complete(input(), controller.signal),
+    "claude_local_aborted",
+  )
+})
+
+test("the version window matches the isolated adapter (AC-005)", () => {
+  assert.equal(isSupportedLocalClaudeVersion("2.1.214"), true)
+  assert.equal(isSupportedLocalClaudeVersion("2.1.223 (Claude Code)"), true)
+  assert.equal(isSupportedLocalClaudeVersion("2.1.213"), false)
+  assert.equal(isSupportedLocalClaudeVersion("2.2.0"), false)
+  assert.equal(isSupportedLocalClaudeVersion(undefined), false)
+  assert.equal(isSupportedLocalClaudeVersion("not-a-version"), false)
+})

--- a/tests/apps/fixtures/fake-claude-local.mjs
+++ b/tests/apps/fixtures/fake-claude-local.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+// Fixture for the local-operator Claude Code model port (#182). Emits the
+// zero-tool stream-json shape an operator-authenticated Claude Code produces,
+// so the port can be exercised without a real login or any credential.
+
+import { readFile } from "node:fs/promises"
+
+const args = process.argv.slice(2)
+
+function option(name) {
+  const index = args.indexOf(name)
+  return index >= 0 ? args[index + 1] : undefined
+}
+
+const fixtureVersion = option("--fixture-version") || "2.1.214"
+if (args.includes("--version")) {
+  process.stdout.write(`${fixtureVersion} (Claude Code)\n`)
+  process.exit(0)
+}
+
+const mode = option("--fixture-mode") || "success"
+const promptCapture = option("--capture-prompt")
+const envCapture = option("--capture-env")
+
+if (mode === "hang") setInterval(() => {}, 1_000)
+
+function emit(value) {
+  process.stdout.write(`${JSON.stringify(value)}\n`)
+}
+
+// The port writes the prompt to stdin and closes it.
+let prompt = ""
+process.stdin.setEncoding("utf8")
+for await (const chunk of process.stdin) prompt += chunk
+
+if (promptCapture) {
+  await (await import("node:fs/promises")).writeFile(promptCapture, prompt)
+}
+if (envCapture) {
+  await (await import("node:fs/promises")).writeFile(
+    envCapture,
+    JSON.stringify({
+      HOME: process.env.HOME ?? null,
+      CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR ?? null,
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ?? null,
+      CLAUDE_CODE_DISABLE_CLAUDE_MDS: process.env.CLAUDE_CODE_DISABLE_CLAUDE_MDS ?? null,
+    }),
+  )
+}
+
+const sessionId = "fixture-local-session"
+const base = { session_id: sessionId }
+
+emit({
+  type: "system",
+  subtype: "init",
+  ...base,
+  // "none" was verified against Claude Code 2.1.223 to mean *not logged in*;
+  // "claude_cli_oauth" is the operator-login label. The service-credential
+  // source must stay rejected by this port.
+  apiKeySource:
+    mode === "api-key-source-mismatch"
+      ? "ANTHROPIC_API_KEY"
+      : mode === "not-logged-in"
+        ? "none"
+        : "claude_cli_oauth",
+  claude_code_version: fixtureVersion,
+  cwd: process.cwd(),
+  tools: [],
+  mcp_servers: [],
+  plugins: [],
+  skills: [],
+  slash_commands: [],
+  permissionMode: option("--permission-mode"),
+  capabilities: [],
+  model: "fixture-model",
+})
+
+if (mode === "api-key-source-mismatch" || mode === "not-logged-in") {
+  await new Promise(() => {})
+}
+
+const answer = mode === "empty-answer" ? "" : "fixture answer"
+
+emit({
+  type: "assistant",
+  ...base,
+  parent_tool_use_id: null,
+  message: { role: "assistant", content: [{ type: "text", text: answer }] },
+})
+
+emit({
+  type: "result",
+  ...base,
+  subtype: mode === "result-error" ? "error_during_execution" : "success",
+  is_error: mode === "result-error",
+  result: answer,
+  usage:
+    mode === "invalid-usage"
+      ? { input_tokens: -1, output_tokens: 5 }
+      : { input_tokens: 11, output_tokens: 7 },
+  ...(mode === "missing-cost" ? {} : { total_cost_usd: 0 }),
+})
+
+process.exit(mode === "exit-nonzero" ? 1 : 0)

--- a/tests/apps/turn-run.test.ts
+++ b/tests/apps/turn-run.test.ts
@@ -191,6 +191,84 @@ test("model port resolves through the environment allowlist only", async () => {
   assert.equal(terminal!.output, "done via env")
 })
 
+test("#182 AC-004: an unknown model port still fails closed", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace)
+  const events: Array<Record<string, unknown>> = []
+  const diagnostics: string[] = []
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText: JSON.stringify(envelope),
+    env: { DIGITAL_EMPLOYEE_ENGINE_MODEL: "not-a-real-port" },
+    writeEvent: (line) => events.push(JSON.parse(line)),
+    writeDiagnostic: (line) => diagnostics.push(line),
+  })
+  assert.equal(result.exitCode, 1)
+  assert.equal(events.length, 0)
+  assert.ok(
+    diagnostics.some((line) => line.includes("engine.model_unavailable")),
+    "an unrecognized port must not silently degrade",
+  )
+})
+
+test("#182 AC-004: an unusable claude-local binary is an environment fault, not a verdict", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace)
+  const events: Array<Record<string, unknown>> = []
+  const diagnostics: string[] = []
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText: JSON.stringify(envelope),
+    env: {
+      DIGITAL_EMPLOYEE_ENGINE_MODEL: "claude-local",
+      DIGITAL_EMPLOYEE_CLAUDE_COMMAND: "/nonexistent/claude-for-this-test",
+    },
+    writeEvent: (line) => events.push(JSON.parse(line)),
+    writeDiagnostic: (line) => diagnostics.push(line),
+  })
+  // Exit 1 with no terminal: a missing binary must not be modeled as a failed
+  // turn (which would exit 0 and read as a verdict about the employee).
+  assert.equal(result.exitCode, 1)
+  assert.equal(events.length, 0)
+  assert.ok(
+    diagnostics.some((line) => line.includes("claude_local_binary_unavailable")),
+    "the diagnostic must name the environment fault, not just model_unavailable",
+  )
+})
+
+test("#182 AC-005: a claude-local binary outside the version window fails closed", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace)
+  const diagnostics: string[] = []
+  const stubDir = await mkdtemp(path.join(os.tmpdir(), "claude-local-oldver-"))
+  // A single executable path: the probe spawns without a shell, so the command
+  // must not be a space-separated "node <script>" string.
+  const stub = path.join(stubDir, "claude-stub")
+  await writeFile(
+    stub,
+    `#!${process.execPath}\nprocess.stdout.write("2.0.1 (Claude Code)\\n")\n`,
+    { mode: 0o755 },
+  )
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText: JSON.stringify(envelope),
+    env: {
+      DIGITAL_EMPLOYEE_ENGINE_MODEL: "claude-local",
+      DIGITAL_EMPLOYEE_CLAUDE_COMMAND: stub,
+    },
+    writeEvent: () => undefined,
+    writeDiagnostic: (line) => diagnostics.push(line),
+  })
+  assert.equal(result.exitCode, 1)
+  assert.ok(
+    diagnostics.some((line) => line.includes("claude_local_version_not_supported")),
+    "an out-of-window version must be rejected as such, not as a missing binary",
+  )
+})
+
 test("AC-002: modeled budget-exceeded terminal exits 0 with escalation verdict", async () => {
   const workspace = await createWorkspace()
   const envelope = sealedEnvelope(workspace, {


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/182
- Consumed revision: R2
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-004 | `apps/cli/turn/turn-run.ts` (`resolveModelPort` gains a `claude-local` arm) | `tests/apps/turn-run.test.ts`: two new #182 cases (unknown engine still fails closed; `claude-local` resolves instead of degrading) |
| REQ-002 / AC-001 | `apps/cli/turn/claude-local-model-port.ts` (zero-tool spawn, stream parsing, prompt rendering) | `tests/apps/claude-local-model-port.test.ts` (12 cases); manual end-to-end run against a genuine local `claude` 2.1.223 install |
| REQ-003 / AC-003 | `apps/cli/turn/claude-local-model-port.ts` (`localRunEnvironment`, no credential-store reference anywhere in the file) | `tests/apps/claude-local-model-port.test.ts`: env-assertion test proves `ANTHROPIC_API_KEY` is stripped and `HOME` is preserved; source review confirms no `.claude`/`.credentials.json`/keychain reference |
| REQ-004 / AC-002 | `apps/cli/turn/claude-local-model-port.ts` (token usage from stream `usage`) | `tests/apps/claude-local-model-port.test.ts`: usage-validation tests (valid usage returned; invalid/missing usage fails closed) |
| REQ-005 / AC-005 | `apps/cli/claude-stream-agent-host.ts` (`expectedApiKeySources` parameterized; default unchanged) | `tests/apps/claude-agent-host.test.ts` + `tests/apps/claude-stream-agent-host.test.ts`: 131/131 unchanged, confirming the isolated `ANTHROPIC_API_KEY` adapter's behavior and qualification status are unaffected |

## File domains

- `apps/cli/turn/turn-run.ts` — model-port resolution gains a `claude-local` arm with a precondition probe so a missing/out-of-window binary maps to exit 1 (environment fault), not exit 0 (modeled turn failure).
- `apps/cli/turn/claude-local-model-port.ts` (new) — the port itself: spawn, environment construction, prompt rendering, stream consumption via the shared normalizer.
- `apps/cli/turn/envelope.ts` — adds `TURN_ENGINE_CLAUDE_COMMAND_ENV` to the environment allowlist (an optional binary path override; no credential).
- `apps/cli/claude-stream-agent-host.ts` — the only touch to code shared with the isolated adapter: `expectedApiKeySources` is parameterized instead of hardcoded, default value unchanged (`["ANTHROPIC_API_KEY"]`), so `claude-agent-host.ts`'s behavior is untouched.
- `tests/apps/claude-local-model-port.test.ts`, `tests/apps/fixtures/fake-claude-local.mjs` (new) — dedicated fixture, existing `fake-claude.mjs` left untouched to avoid disturbing the qualified adapter's test surface.
- `tests/apps/turn-run.test.ts` — 3 new cases for port-resolution wiring.
- `docs/agent-hosts.md`, `CHANGELOG.md` — document the port, its authentication-source findings, and its scope boundary.

## Scope and non-goals

Adds a `claude-local` model port so a local operator can complete a `turn run` using the Claude Code install already authenticated on their machine, without `ANTHROPIC_API_KEY`. `DIGITAL_EMPLOYEE_ENGINE_MODEL=claude-local` opts in; nothing else changes behavior for an existing caller.

Two authentication findings came from live testing against Claude Code 2.1.223, not from the Issue's original assumption, and both changed the implementation before this PR was opened:
- The announced `apiKeySource` for a genuine operator login is `claude_cli_oauth` (the label the isolated adapter's own fixtures already use for "not a service key") — accepted.
- `apiKeySource: "none"` does **not** mean operator login; it means *not logged in* (a real not-logged-in install answers `Not logged in · Please run /login` with `error: authentication_failed`). Accepting it would have let an unauthenticated run through the policy gate; it now maps to an actionable `claude_local_not_logged_in` instead.

**Not in scope** (unchanged by this PR):
- The isolated `ANTHROPIC_API_KEY` adapter (`claude-agent-host.ts`) — still the only path for unattended/multi-tenant/resale deployments; not touched beyond the shared parameterization above.
- `qoder` and `claude-code` as `turn run` engine values — both were already unreachable before this PR (`resolveModelPort` only recognized `deterministic`; every other value fell through to `engine.model_unavailable` regardless of credentials). This PR does not wire either of them; that remains open work, tracked separately.
- org-workbench's `turnEngines` enum, health probe, and UI — a separate downstream repository change, not started.
- Issue #182's OQ-2 (sealing trade-off) and OQ-3 (concurrency policy) — recorded as known limitations below, not resolved here.

## Validation

- Exact commands: `npm run check` (full gate); `npx tsx --test tests/apps/claude-local-model-port.test.ts`; `npx tsx --test tests/apps/turn-run.test.ts`; `npx tsx --test tests/apps/claude-stream-agent-host.test.ts tests/apps/claude-agent-host.test.ts`
- Observed counts/results: PASS 1669/1669 (`npm run check`, includes build, typecheck, full suite, `governance:check`, `security:check`); PASS 12/12 (`claude-local-model-port.test.ts`); PASS 14/14 (`turn-run.test.ts`, incl. 3 new #182 cases); PASS 131/131 (unchanged regression on the shared normalizer)
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/pull/184/checks

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-004 | An unrecognized model port still fails closed; `claude-local` resolves instead of degrading | `npx tsx --test tests/apps/turn-run.test.ts` | Linux x86_64, Node v22.23.2, local | Both new cases pass; no change to existing 12 cases | 14/14 PASS | PASS |
| V2 | AC-003 | The port never accesses a credential store; `ANTHROPIC_API_KEY` is stripped from the child process | `npx tsx --test tests/apps/claude-local-model-port.test.ts` + manual `grep` review of `claude-local-model-port.ts` for `.claude`/`.credentials`/keychain references | Linux x86_64, Node v22.23.2, local | Env-capture fixture shows `ANTHROPIC_API_KEY: null`, `HOME` preserved; zero credential-store references in source | Matched expected | PASS |
| V3 | AC-002 | `usage` is returned from the stream; invalid/missing usage fails closed | `npx tsx --test tests/apps/claude-local-model-port.test.ts` | Linux x86_64, Node v22.23.2, local | Valid usage returns tokens; invalid/missing usage rejects with `claude_usage_invalid` | Matched expected | PASS |
| V4 | AC-005 | Version window matches the isolated adapter (`>=2.1.214 <2.2.0`); out-of-window binary fails as a distinct code from "missing binary" | `npx tsx --test tests/apps/turn-run.test.ts` (stub-binary case) | Linux x86_64, Node v22.23.2, local | `claude_local_version_not_supported` for a `2.0.1`-reporting stub; `claude_local_binary_unavailable` for a nonexistent path | Matched expected | PASS |
| V5 | AC-001 | A local operator, with no `ANTHROPIC_API_KEY`, can complete a turn against a genuinely authenticated Claude Code | Manual: `DIGITAL_EMPLOYEE_ENGINE_MODEL=claude-local DIGITAL_EMPLOYEE_CLAUDE_COMMAND=<path to 2.1.223 claude> node dist/apps/cli/bin.js turn run <workspace> --position <id> --stdin` with a sealed `turn-envelope.v1` on stdin | Linux x86_64, Node v22.23.2, local; that particular `claude` install was not logged in at test time | A genuinely logged-in install reaches a model-level reply | The install available for testing announced `apiKeySource: "none"` (not logged in); the run correctly stopped at `claude_local_not_logged_in` rather than proceeding — this confirms spawn, arg construction, stream parsing, and the auth gate all function, but a full successful reply from a genuinely authenticated install has not yet been observed | NOT VERIFIED: no locally logged-in Claude Code install was available at PR time; the auth-gate path was verified instead (see Known limitations) |

## Security and compatibility

No new dependency. No public contract or schema change — `claude-local` is a new, opt-in value for an existing environment variable (`DIGITAL_EMPLOYEE_ENGINE_MODEL`); anything not setting it is unaffected. The only touch to code shared with the isolated adapter (`claude-stream-agent-host.ts`) is a parameter with the prior hardcoded value as its default, covered by the adapter's unchanged 131-test regression suite. The new port never reads, parses, or forwards any credential store (`.claude/`, `.credentials.json`, system keychain) — it spawns the official `claude` binary and lets it resolve its own authentication; this is verified by source review and by a test asserting the child process never receives `ANTHROPIC_API_KEY` even when present in the parent environment.

## Known limitations

- **AC-001 is not fully closed.** The local Claude Code install available for manual testing was not logged in, so the full success path (a genuine authenticated reply) has not been observed by this author. The auth gate itself was exercised and behaved correctly (rejecting the not-logged-in state with an actionable error), which validates the mechanism, but not the success case. A reviewer with a logged-in Claude Code install can close this gap by running the manual command in V5.
- **Only two `apiKeySource` values have been directly observed**: `"none"` (not logged in) and `"ANTHROPIC_API_KEY"` (service credential, correctly rejected). `"claude_cli_oauth"` is accepted because it is the label the isolated adapter's own fixtures already use for "not a service key," but no real Claude Code process was observed announcing it during this work. If a different login configuration (SSO, a different plan tier) announces a third value, this gate will reject it as an unrecognized source rather than silently accept — a reviewer with a different login configuration is encouraged to check what value it reports.
- **Sealing trade-off (Issue #182 OQ-2), not resolved by this PR**: unlike the isolated adapter, this port does not override `HOME`/`CLAUDE_CONFIG_DIR`, so a run can see the operator's real `~/.claude` (e.g. `CLAUDE.md`, MCP config). The `CLAUDE_CODE_DISABLE_*` hardening flags that don't require touching `HOME` are kept; the adapter's "reproducible run" guarantee is deliberately not claimed for this port.
- **Concurrency (Issue #182 OQ-3), not resolved by this PR**: Claude subscription rate limits are sized for single-operator interactive use; this port applies no serialization or concurrency limit, so a caller dispatching to multiple positions in parallel may contend for the same quota. Left to the caller (e.g. org-workbench) to decide.
- This port has not been through adapter qualification and must not be assumed equivalent to the `runnable` Adapters documented in `docs/agent-hosts.md`.
- `qoder` and `claude-code` remain unreachable as `turn run` engine values (pre-existing gap, not introduced or fixed by this PR — see Scope and non-goals).

## Risk and rollback

Risk is low and localized: the new port is additive and reachable only via an explicit opt-in environment value; the one shared-code touch (`expectedApiKeySources`) preserves its prior default and is covered by the unchanged existing regression suite. Operational impact is the documented sealing trade-off above (this is the first `turn run` path that does not isolate `HOME`), not a regression in an existing path.

Rollback: revert this commit. `DIGITAL_EMPLOYEE_ENGINE_MODEL=claude-local` simply stops resolving again (`engine.model_unavailable`, the pre-existing behavior); `deterministic` and the isolated `agent run` path are untouched, so no data migration or cleanup is needed.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: no release packet exists for this repository yet
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged

