### PR TITLE
docs(roadmap): register D5 backlog (codex-aligned session & approval semantics)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -141,6 +141,19 @@ organization, and the engine grows a harness layer above the read-only core.
 **Non-goals:** channel expansion (Lark/WeCom), marketplace/transaction work,
 and full RBAC.
 
+
+## D5 backlog — Codex-aligned session and approval semantics (not scheduled)
+
+Backlog registered per CEO directive (2026-08-25); codex is the reference
+baseline. Both items hang on the org-workbench session lifecycle delivered by
+[org-workbench#14](https://github.com/fullstack-ai-infra/org-workbench/pull/14)
+(canonical [#12](https://github.com/fullstack-ai-infra/org-workbench/issues/12)).
+Non-gating for W1 and M2–M3; no gate date until scheduled.
+
+| Item | Deliverable | Dependency | Team |
+| --- | --- | --- | --- |
+| [D5-B1 #186](https://github.com/fullstack-ai-infra/digital-employee/issues/186) | Rollout-style session resume/fork semantics (codex-rollout aligned) | org-workbench#14 | Workbench/Session |
+| [D5-B2 #187](https://github.com/fullstack-ai-infra/digital-employee/issues/187) | In-turn approval interaction product semantics (when to prompt, default policy, denial terminal state), coupled with engine `approval.*` vocabulary | #165 engine, write-approval.v1 | Product/Engine |
 ## M4+ — Engine graph layer
 
 The engine S3 graph layer provides cross-position routing, parallelism and


### PR DESCRIPTION
## Summary

- Register D5 backlog section in `docs/roadmap.md`（M2–M3 与 M4+ 之间）：
  - **D5-B1** [#186](https://github.com/fullstack-ai-infra/digital-employee/issues/186)：rollout-style session resume/fork semantics（codex-rollout 对齐），挂 org-workbench session 生命周期 #12/#14
  - **D5-B2** [#187](https://github.com/fullstack-ai-infra/digital-employee/issues/187)：turn 内审批交互产品口径，与引擎 `approval.*` 词表（write-approval.v1）联动
- 两项均标注 non-gating for W1 and M2–M3，无排期门禁。

## Authorization trail

- 战略 CEO 登记任务（2026-08-25，codex 参照系为胡总定）；
- 验收口径草稿经 CEO 批准呈报（产品线 2026-08-25 草稿 `outputs/D5-backlog入表与验收口径-草稿-2026-08-25.md`）；
- 两条 canonical Issue 已按 requirement-record.v1 建立，status: needs-design，AC 口径待 R2 决策冻结。

## Test plan

- [x] 纯 docs 改动，无代码变更
- [ ] 独立评审确认：插入位置（M2–M3 / M4+ 之间）、链接（#186/#187、org-workbench#12/#14）、non-gating 表述无误
