### PR TITLE
feat(engine): approval three-event contract, Option 1 terminal-and-resume (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- engine.v1 gains the approval three-event contract (#187 REQ-001..REQ-005,
+  Option 1 terminal-and-resume): additive events `approval.requested`,
+  `approval.granted`, `approval.denied` alongside the existing five event
+  shapes (single source `packages/engine/src/contracts.ts`). A turn
+  declaring a write action at the capability gate must carry a validated
+  `write-approval.v1` preview (`state=preview_validated`); without it the
+  turn fails closed (`engine.approval_preview_invalid`), aligned with the
+  `undeclared_tool` / `approval_not_configured` guard semantics. The
+  requesting turn settles as `run.failed` with `engine.approval_required`
+  (`retryable=true`); the operator verdict returns through the sealed
+  envelope of the next turn (`pendingApproval` on the engine request) and is
+  consumed before any model consumption — granted proceeds, denied settles
+  `engine.approval_denied` (`retryable=false`, no downgrade to an unapproved
+  write), and an expired or malformed verdict fails closed with
+  `engine.approval_expired`. Approval settlements reuse the existing
+  terminal-reason enumeration and are distinguished by error code; turn
+  evidence carries the approval chain reference (`approvalRef`) so a denied
+  terminal keeps its approval reference and terminal reason. The
+  `pendingApproval` plumbing on the `turn-envelope.v1` spawn surface is a
+  separate follow-up; no in-run inbound channel is introduced and the
+  fail-closed posture of #178 is unchanged.
 - `turn run` gains a `qoder` model port (#185 REQ-001..REQ-005), so an
   operator holding a lawfully obtained `QODER_PERSONAL_ACCESS_TOKEN` can
   complete a turn through the conformance-verified isolated Qoder adapter

--- a/docs/engine-codex-semantic-mapping.md
+++ b/docs/engine-codex-semantic-mapping.md
@@ -1,10 +1,10 @@
 # engine.v1 ↔ codex Op/Event 语义映射（clean-room 设计文档）
 
-状态：设计参照文档（landed；§4 approval.* 词表行以草案形态先行，随 issue #187 审批契约实施 PR 定稿并同 PR 更新本文）
+状态：设计参照文档（landed；§4 approval.* 词表行已随 issue #187 审批契约实施 PR 定稿）
 日期：2026-08-25
 作者：技术 P9
 指令来源：战略 CEO（胡总定 github.com/openai/codex 为参照系）
-配套契约：approval 三事件契约（terminal-and-resume，Option 1），草案见 issue #187 讨论，实施时落库
+配套契约：approval 三事件契约（terminal-and-resume，Option 1）已实施——词表单一来源 contracts.ts，结算码 engine.approval_required / engine.approval_denied / engine.approval_expired / engine.approval_preview_invalid
 
 ## 0. Clean-room 声明
 
@@ -52,15 +52,17 @@ contracts.ts 已声明 TerminalReason 是本仓自有枚举、不是外部枚举
 | cancelled | TurnAborted / Op::SuspendTurnAndShutdown |
 | engine_internal_error | StreamError / Error |
 
-## 4. approval 语义对位（本 slice 新增词表，详见配套草案）
+## 4. approval 语义对位（已实施词表，单一来源 contracts.ts）
 
-| engine.v1（草案） | codex 参照形态 | 差异说明 |
+| engine.v1（已实施） | codex 参照形态 | 差异说明 |
 | --- | --- | --- |
-| approval.requested | EventMsg::ExecApprovalRequest、ApplyPatchApprovalRequest、ElicitationRequest（部分） | codex 按动作类型分多个事件并带 call_id/approval_id 双层标识；engine 用单一事件 + 单层 approvalId + action.kind 判别 |
-| approval.granted | Op::ExecApproval 携带 ReviewDecision::Approved / ApprovedForSession | codex 是入站回注；engine 是恢复 turn 的出站权威记录（单向模型决定） |
-| approval.denied | Op::ExecApproval 携带 ReviewDecision::Denied / Abort | codex 的 Abort（放弃整个会话回合）不单独建模；engine deny 后按 approval_denied 结算 |
+| approval.requested | EventMsg::ExecApprovalRequest、ApplyPatchApprovalRequest、ElicitationRequest（部分） | codex 按动作类型分多个事件并带 call_id/approval_id 双层标识；engine 用单一事件 + 单层 approvalId + action.kind 判别。请求 turn 以 run.failed(engine.approval_required, retryable=true) 结算；preview 前置 fail-closed（engine.approval_preview_invalid） |
+| approval.granted | Op::ExecApproval 携带 ReviewDecision::Approved / ApprovedForSession | codex 是入站回注；engine 是恢复 turn 的出站权威记录（单向模型决定），裁决经下一次密封 envelope 的 pendingApproval 传入，消费在任何 model 消耗之前 |
+| approval.denied | Op::ExecApproval 携带 ReviewDecision::Denied / Abort | codex 的 Abort（放弃整个会话回合）不单独建模；engine deny 后按 engine.approval_denied（retryable=false）结算，不降级为未审批写入，证据记录携带 approvalRef |
 | （不做） | ReviewDecision::ApprovedExecpolicyAmendment（批准并修订策略） | 策略修订超出本 slice；engine 侧策略变更走组织模型决议链，不走运行时事件 |
 | （不做） | EventMsg::GuardianAssessment（安全评估中间层） | 非目标；engine 的 fail-closed 由 policy 投影承担 |
+
+结算语义注记：approval 族终态复用既有 TerminalReason 枚举（cancelled，操作方可见的受治理停止），不新增终态原因；过期/缺失/畸形裁决统一 fail-closed 于 engine.approval_expired，与 denied 同族但错误码可区分（便于上报统计）。
 
 ## 5. 明确不借的形态（非目标清单）
 

--- a/packages/engine/src/approval.ts
+++ b/packages/engine/src/approval.ts
@@ -1,0 +1,78 @@
+/**
+ * Turn approval gate (#187, Option 1 terminal-and-resume).
+ *
+ * The engine stays one-directional: the requesting turn settles as a
+ * retryable failure carrying `approval.requested`; the operator verdict
+ * returns through the sealed envelope of the next turn run and is consumed
+ * here, before any model consumption, as `approval.granted` /
+ * `approval.denied`. There is no in-run inbound channel.
+ *
+ * Default policy (frozen by the #187 R2 decision, issuecomment-5409280515):
+ * a write action requires an explicit operator verdict. This module has no
+ * auto-grant path; changing the default requires a recorded product
+ * decision (#187 AC-002).
+ *
+ * All approval settlement reuses the existing TerminalReason enumeration;
+ * the approval lifecycle is carried by distinct error codes, not new
+ * terminal reasons.
+ */
+
+import { WRITE_APPROVAL_VERSION } from "../../core/src/write-approval.js"
+
+import type {
+  TurnApprovalActionInput,
+  TurnPendingApprovalInput,
+} from "./contracts.js"
+
+export const APPROVAL_REQUIRED_CODE = "engine.approval_required"
+export const APPROVAL_DENIED_CODE = "engine.approval_denied"
+export const APPROVAL_EXPIRED_CODE = "engine.approval_expired"
+export const APPROVAL_PREVIEW_INVALID_CODE = "engine.approval_preview_invalid"
+
+export interface ApprovalPreviewGateResult {
+  allowed: boolean
+  code?: string
+  message?: string
+}
+
+/**
+ * Preview-first gate (#187 AC-001): an approval request is only expressible
+ * on top of a write-approval.v1 preview in state preview_validated. Any
+ * other shape fails closed, aligned with the undeclared_tool /
+ * approval_not_configured guard semantics of the write-approval vocabulary.
+ */
+export function previewGateAllows(
+  action: TurnApprovalActionInput,
+): ApprovalPreviewGateResult {
+  const preview = action.preview
+  if (preview.version !== WRITE_APPROVAL_VERSION) {
+    return {
+      allowed: false,
+      code: APPROVAL_PREVIEW_INVALID_CODE,
+      message: `approval request requires a ${WRITE_APPROVAL_VERSION} preview, got ${preview.version}`,
+    }
+  }
+  if (preview.state !== "preview_validated") {
+    return {
+      allowed: false,
+      code: APPROVAL_PREVIEW_INVALID_CODE,
+      message: `approval request requires a preview in state preview_validated, got ${preview.state}`,
+    }
+  }
+  return { allowed: true }
+}
+
+/**
+ * Expiry check for a resume-turn verdict (#187 AC-005). Missing expiresAt
+ * means the verdict is bounded only by the resume turn's own deadline;
+ * an unparseable bound fails closed as expired.
+ */
+export function pendingApprovalExpired(
+  pending: TurnPendingApprovalInput,
+  nowMs: number,
+): boolean {
+  if (pending.expiresAt === undefined) return false
+  const parsed = Date.parse(pending.expiresAt)
+  if (Number.isNaN(parsed)) return true
+  return nowMs > parsed
+}

--- a/packages/engine/src/contracts.ts
+++ b/packages/engine/src/contracts.ts
@@ -65,6 +65,42 @@ export type EngineEvent =
       type: "run.failed"
       error: EngineTerminalError
     })
+  // Approval gate vocabulary (#187, Option 1 terminal-and-resume). Additive:
+  // the five existing event shapes are unchanged. `requested` settles the
+  // requesting run as a retryable failure; `granted`/`denied` are the resume
+  // run's authoritative records of the operator verdict being consumed at the
+  // trust boundary — records, not the authorization itself, which still
+  // comes from the policy projection. Hard ordering rule: within a run,
+  // granted/denied presuppose a matching requested (emitted in this run or
+  // inherited from the referenced request turn).
+  | (EngineEventBase & {
+      type: "approval.requested"
+      /** Stable across the request turn and the resume turn. */
+      approvalId: string
+      action: {
+        kind: TurnApprovalActionKind
+        /** Bounded human-readable description, <= 1 KiB. */
+        description: string
+        /** Command/path/host/tool name, <= 512 B. */
+        target?: string
+      }
+      reason?: string
+      /** ISO 8601; defaults to being bounded by the run deadline. */
+      expiresAt?: string
+    })
+  | (EngineEventBase & {
+      type: "approval.granted"
+      approvalId: string
+      grantedBy: "operator"
+      /** once = this action only; run = same-kind actions within this run. */
+      scope: "once" | "run"
+    })
+  | (EngineEventBase & {
+      type: "approval.denied"
+      approvalId: string
+      deniedBy: "operator"
+      reason?: string
+    })
 
 export function isTerminalEngineEvent(
   event: EngineEvent,
@@ -90,6 +126,49 @@ export interface PositionContextInput {
   spec?: string
 }
 
+/** Capability-gate action kinds for approval requests (#187). */
+export type TurnApprovalActionKind = "exec" | "write" | "network" | "tool"
+
+/**
+ * Bounded reference to the write-approval.v1 preview that must precede any
+ * approval request (#187 AC-001): a write action without a validated
+ * preview fails closed.
+ */
+export interface TurnApprovalPreviewRef {
+  /** Must equal write-approval.v1. */
+  version: string
+  previewId: string
+  previewDigest: string
+  /** Must equal preview_validated. */
+  state: string
+}
+
+export interface TurnApprovalActionInput {
+  kind: TurnApprovalActionKind
+  /** Bounded human-readable description, <= 1 KiB. */
+  description: string
+  /** Command/path/host/tool name, <= 512 B. */
+  target?: string
+  preview: TurnApprovalPreviewRef
+}
+
+/**
+ * Operator verdict carried by the resume turn (#187 Option 1). The verdict
+ * arrives through the sealed envelope of the next turn run; there is no
+ * in-run inbound channel.
+ */
+export interface TurnPendingApprovalInput {
+  /** Must match the approvalId of the referenced approval.requested. */
+  approvalId: string
+  decision: "granted" | "denied"
+  decidedBy: "operator"
+  /** Defaults to "once" when granted. */
+  scope?: "once" | "run"
+  reason?: string
+  /** ISO 8601; a verdict past this bound fails closed as expired. */
+  expiresAt?: string
+}
+
 export interface EngineTurnRequest {
   workspaceRef: string
   positionId: string
@@ -112,6 +191,19 @@ export interface EngineTurnRequest {
   positionBudget?: PositionBudgetDeclaration
   taskId?: string
   dayKey?: string
+  /**
+   * Write action declared at the capability gate (#187). Requires a
+   * validated write-approval.v1 preview; the requesting turn settles as a
+   * retryable failure carrying approval.requested. Mutually exclusive with
+   * pendingApproval.
+   */
+  approvalAction?: TurnApprovalActionInput
+  /**
+   * Operator verdict for a previously requested approval (#187 Option 1),
+   * consumed by the resume turn before any model consumption. Mutually
+   * exclusive with approvalAction.
+   */
+  pendingApproval?: TurnPendingApprovalInput
 }
 
 const MAX_ID_LENGTH = 256
@@ -205,7 +297,136 @@ export function validateTurnRequest(
     assertBoundedId(request.taskId, "taskId")
     assertBoundedId(request.dayKey, "dayKey")
   }
+  validateApprovalRequestFields(request)
   return request
+}
+
+const APPROVAL_ACTION_KINDS: ReadonlySet<string> = new Set([
+  "exec",
+  "write",
+  "network",
+  "tool",
+])
+const APPROVAL_DESCRIPTION_MAX_BYTES = 1024
+const APPROVAL_TARGET_MAX_BYTES = 512
+
+function assertBoundedText(
+  value: unknown,
+  label: string,
+  maxBytes: number,
+): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new EngineRequestError(
+      "engine.input_invalid",
+      `${label} must be a non-empty string`,
+    )
+  }
+  if (Buffer.byteLength(value, "utf8") > maxBytes) {
+    throw new EngineRequestError(
+      "engine.input_invalid",
+      `${label} exceeds the bounded size`,
+    )
+  }
+  return value
+}
+
+function assertOptionalTimestamp(value: unknown, label: string): void {
+  if (value === undefined) return
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    throw new EngineRequestError(
+      "engine.input_invalid",
+      `${label} must be a valid ISO 8601 timestamp`,
+    )
+  }
+}
+
+/**
+ * Fail-closed shape checks for the #187 approval gate fields. The request
+ * turn (approvalAction) and the resume turn (pendingApproval) are mutually
+ * exclusive: carrying both violates the request-then-verdict ordering and
+ * rejects before any model consumption.
+ */
+function validateApprovalRequestFields(request: EngineTurnRequest): void {
+  const { approvalAction, pendingApproval } = request
+  if (approvalAction !== undefined && pendingApproval !== undefined) {
+    throw new EngineRequestError(
+      "engine.input_invalid",
+      "approvalAction and pendingApproval are mutually exclusive within one turn",
+    )
+  }
+  if (approvalAction !== undefined) {
+    if (!APPROVAL_ACTION_KINDS.has(approvalAction.kind)) {
+      throw new EngineRequestError(
+        "engine.input_invalid",
+        "approvalAction.kind must be one of exec, write, network, tool",
+      )
+    }
+    assertBoundedText(
+      approvalAction.description,
+      "approvalAction.description",
+      APPROVAL_DESCRIPTION_MAX_BYTES,
+    )
+    if (approvalAction.target !== undefined) {
+      assertBoundedText(
+        approvalAction.target,
+        "approvalAction.target",
+        APPROVAL_TARGET_MAX_BYTES,
+      )
+    }
+    const preview = approvalAction.preview
+    if (preview === null || typeof preview !== "object") {
+      throw new EngineRequestError(
+        "engine.input_invalid",
+        "approvalAction.preview must be an object",
+      )
+    }
+    assertBoundedId(preview.previewId, "approvalAction.preview.previewId")
+    assertBoundedId(
+      preview.previewDigest,
+      "approvalAction.preview.previewDigest",
+    )
+    assertBoundedId(preview.version, "approvalAction.preview.version")
+    assertBoundedId(preview.state, "approvalAction.preview.state")
+  }
+  if (pendingApproval !== undefined) {
+    assertBoundedId(pendingApproval.approvalId, "pendingApproval.approvalId")
+    if (
+      pendingApproval.decision !== "granted" &&
+      pendingApproval.decision !== "denied"
+    ) {
+      throw new EngineRequestError(
+        "engine.input_invalid",
+        "pendingApproval.decision must be granted or denied",
+      )
+    }
+    if (pendingApproval.decidedBy !== "operator") {
+      throw new EngineRequestError(
+        "engine.input_invalid",
+        "pendingApproval.decidedBy must be operator",
+      )
+    }
+    if (
+      pendingApproval.scope !== undefined &&
+      pendingApproval.scope !== "once" &&
+      pendingApproval.scope !== "run"
+    ) {
+      throw new EngineRequestError(
+        "engine.input_invalid",
+        "pendingApproval.scope must be once or run when present",
+      )
+    }
+    if (pendingApproval.reason !== undefined) {
+      assertBoundedText(
+        pendingApproval.reason,
+        "pendingApproval.reason",
+        APPROVAL_DESCRIPTION_MAX_BYTES,
+      )
+    }
+    assertOptionalTimestamp(
+      pendingApproval.expiresAt,
+      "pendingApproval.expiresAt",
+    )
+  }
 }
 
 export function terminalError(

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -14,8 +14,22 @@ export type {
   EngineTurnRequest,
   PositionContextInput,
   TerminalReason,
+  TurnApprovalActionInput,
+  TurnApprovalActionKind,
+  TurnApprovalPreviewRef,
   TurnBudget,
+  TurnPendingApprovalInput,
 } from "./contracts.js"
+
+export {
+  APPROVAL_DENIED_CODE,
+  APPROVAL_EXPIRED_CODE,
+  APPROVAL_PREVIEW_INVALID_CODE,
+  APPROVAL_REQUIRED_CODE,
+  pendingApprovalExpired,
+  previewGateAllows,
+} from "./approval.js"
+export type { ApprovalPreviewGateResult } from "./approval.js"
 
 export {
   CONTEXT_ASSEMBLY_VERSION,
@@ -98,6 +112,7 @@ export {
 export type {
   EvidenceSinkPort,
   InMemoryEvidenceSink,
+  TurnEvidenceApprovalRef,
   TurnEvidenceBudget,
   TurnEvidenceRecord,
   TurnEvidenceTerminal,

--- a/packages/engine/src/turn-evidence.ts
+++ b/packages/engine/src/turn-evidence.ts
@@ -32,6 +32,18 @@ export interface TurnEvidenceTerminal {
   errorCode?: string
 }
 
+/**
+ * Approval chain link for turns settled through the #187 approval gate.
+ * Bounded identifiers only — verdict text and action descriptions stay out
+ * of evidence. A denied settlement must carry this reference together with
+ * the terminal reason (#187 AC-003).
+ */
+export interface TurnEvidenceApprovalRef {
+  approvalId: string
+  previewId?: string
+  outcome: "requested" | "granted" | "denied" | "expired"
+}
+
 export interface TurnEvidenceRecord {
   schemaVersion: typeof TURN_EVIDENCE_VERSION
   evidenceId: string
@@ -47,6 +59,7 @@ export interface TurnEvidenceRecord {
   budget: TurnEvidenceBudget
   terminal: TurnEvidenceTerminal
   escalationRef?: string
+  approvalRef?: TurnEvidenceApprovalRef
   /** Assembly manifest digest from context-assembly.v1. */
   assemblyManifestDigest: string
   timeBounds: {

--- a/packages/engine/src/turn-executor.ts
+++ b/packages/engine/src/turn-executor.ts
@@ -294,14 +294,24 @@ export async function* executeTurn(
         approvalId: pendingApproval.approvalId,
         outcome: "expired",
       }
-      await writeEvidence(
-        {
-          status: "failed",
-          reason: "cancelled",
-          errorCode: APPROVAL_EXPIRED_CODE,
-        },
-        null,
-      )
+      try {
+        await writeEvidence(
+          {
+            status: "failed",
+            reason: "cancelled",
+            errorCode: APPROVAL_EXPIRED_CODE,
+          },
+          null,
+        )
+      } catch {
+        yield fail(
+          "engine.internal_error",
+          "approval settlement side effects failed",
+          "engine_internal_error",
+          false,
+        )
+        return
+      }
       yield fail(
         APPROVAL_EXPIRED_CODE,
         "pending approval verdict is expired or unusable; fail closed, re-issue the verdict",
@@ -312,11 +322,29 @@ export async function* executeTurn(
     }
     if (pendingApproval.decision === "denied") {
       // Denied terminal (#187 AC-003): no automatic retry, no downgrade to
-      // an unapproved write. Evidence precedes the terminal and carries the
-      // denied approval reference together with the terminal reason.
+      // an unapproved write. Evidence precedes the event and the terminal so
+      // an unrecorded denial can never masquerade as a clean settlement.
       approvalRef = {
         approvalId: pendingApproval.approvalId,
         outcome: "denied",
+      }
+      try {
+        await writeEvidence(
+          {
+            status: "failed",
+            reason: "cancelled",
+            errorCode: APPROVAL_DENIED_CODE,
+          },
+          null,
+        )
+      } catch {
+        yield fail(
+          "engine.internal_error",
+          "approval settlement side effects failed",
+          "engine_internal_error",
+          false,
+        )
+        return
       }
       yield {
         type: "approval.denied",
@@ -328,14 +356,6 @@ export async function* executeTurn(
           ? { reason: pendingApproval.reason }
           : {}),
       }
-      await writeEvidence(
-        {
-          status: "failed",
-          reason: "cancelled",
-          errorCode: APPROVAL_DENIED_CODE,
-        },
-        null,
-      )
       yield fail(
         APPROVAL_DENIED_CODE,
         "operator denied the approval; the turn settles without retry",
@@ -365,14 +385,24 @@ export async function* executeTurn(
       // validated write-approval.v1 preview cannot express an approval
       // request, aligned with undeclared_tool / approval_not_configured
       // guard semantics.
-      await writeEvidence(
-        {
-          status: "failed",
-          reason: "engine_internal_error",
-          errorCode: gate.code,
-        },
-        null,
-      )
+      try {
+        await writeEvidence(
+          {
+            status: "failed",
+            reason: "engine_internal_error",
+            errorCode: gate.code,
+          },
+          null,
+        )
+      } catch {
+        yield fail(
+          "engine.internal_error",
+          "approval settlement side effects failed",
+          "engine_internal_error",
+          false,
+        )
+        return
+      }
       yield fail(gate.code!, gate.message!, "engine_internal_error", false)
       return
     }
@@ -381,6 +411,24 @@ export async function* executeTurn(
       approvalId,
       previewId: approvalAction.preview.previewId,
       outcome: "requested",
+    }
+    try {
+      await writeEvidence(
+        {
+          status: "failed",
+          reason: "cancelled",
+          errorCode: APPROVAL_REQUIRED_CODE,
+        },
+        null,
+      )
+    } catch {
+      yield fail(
+        "engine.internal_error",
+        "approval settlement side effects failed",
+        "engine_internal_error",
+        false,
+      )
+      return
     }
     yield {
       type: "approval.requested",
@@ -398,14 +446,6 @@ export async function* executeTurn(
         ? { expiresAt: request.deadline }
         : {}),
     }
-    await writeEvidence(
-      {
-        status: "failed",
-        reason: "cancelled",
-        errorCode: APPROVAL_REQUIRED_CODE,
-      },
-      null,
-    )
     yield fail(
       APPROVAL_REQUIRED_CODE,
       "turn stopped at the capability gate awaiting an operator approval verdict; resume with a turn carrying pendingApproval",

--- a/packages/engine/src/turn-executor.ts
+++ b/packages/engine/src/turn-executor.ts
@@ -10,6 +10,14 @@ import {
   type BudgetUsage,
 } from "./budget.js"
 import {
+  APPROVAL_DENIED_CODE,
+  APPROVAL_EXPIRED_CODE,
+  APPROVAL_PREVIEW_INVALID_CODE,
+  APPROVAL_REQUIRED_CODE,
+  pendingApprovalExpired,
+  previewGateAllows,
+} from "./approval.js"
+import {
   terminalError,
   validateTurnRequest,
   ENGINE_VERSION,
@@ -37,6 +45,7 @@ import {
   digestOutputValue,
   TURN_EVIDENCE_VERSION,
   type EvidenceSinkPort,
+  type TurnEvidenceApprovalRef,
   type TurnEvidenceRecord,
 } from "./turn-evidence.js"
 
@@ -94,6 +103,7 @@ export async function* executeTurn(
   const runId = typeof rawRequest.runId === "string" ? rawRequest.runId : ""
   const startedAt = timestamp(now)
   let terminated = false
+  let approvalRef: TurnEvidenceApprovalRef | undefined
 
   const fail = (
     code: string,
@@ -225,6 +235,7 @@ export async function* executeTurn(
       },
       terminal,
       ...(escalationRef !== undefined ? { escalationRef } : {}),
+      ...(approvalRef !== undefined ? { approvalRef } : {}),
       assemblyManifestDigest: assembled.manifest.digest,
       timeBounds: { startedAt, completedAt: timestamp(now) },
     }
@@ -266,6 +277,142 @@ export async function* executeTurn(
       return
     }
     yield fail(REASON_TO_CODE[terminalReason], message, terminalReason)
+  }
+
+  // --- Approval gate (#187, Option 1 terminal-and-resume) ---
+  // Runs before any model consumption. The resume turn consumes the
+  // operator verdict carried by its sealed envelope; the request turn
+  // settles as a retryable failure carrying approval.requested. Approval
+  // settlement reuses the existing TerminalReason enumeration ("cancelled":
+  // a governed, operator-visible stop) and is distinguished by error code —
+  // no new terminal reasons are introduced.
+  const pendingApproval = request.pendingApproval
+  const approvalAction = request.approvalAction
+  if (pendingApproval !== undefined) {
+    if (pendingApprovalExpired(pendingApproval, now().getTime())) {
+      approvalRef = {
+        approvalId: pendingApproval.approvalId,
+        outcome: "expired",
+      }
+      await writeEvidence(
+        {
+          status: "failed",
+          reason: "cancelled",
+          errorCode: APPROVAL_EXPIRED_CODE,
+        },
+        null,
+      )
+      yield fail(
+        APPROVAL_EXPIRED_CODE,
+        "pending approval verdict is expired or unusable; fail closed, re-issue the verdict",
+        "cancelled",
+        false,
+      )
+      return
+    }
+    if (pendingApproval.decision === "denied") {
+      // Denied terminal (#187 AC-003): no automatic retry, no downgrade to
+      // an unapproved write. Evidence precedes the terminal and carries the
+      // denied approval reference together with the terminal reason.
+      approvalRef = {
+        approvalId: pendingApproval.approvalId,
+        outcome: "denied",
+      }
+      yield {
+        type: "approval.denied",
+        runId,
+        timestamp: timestamp(now),
+        approvalId: pendingApproval.approvalId,
+        deniedBy: "operator",
+        ...(pendingApproval.reason !== undefined
+          ? { reason: pendingApproval.reason }
+          : {}),
+      }
+      await writeEvidence(
+        {
+          status: "failed",
+          reason: "cancelled",
+          errorCode: APPROVAL_DENIED_CODE,
+        },
+        null,
+      )
+      yield fail(
+        APPROVAL_DENIED_CODE,
+        "operator denied the approval; the turn settles without retry",
+        "cancelled",
+        false,
+      )
+      return
+    }
+    // Granted: the event is the authoritative record of the verdict being
+    // consumed at the trust boundary, emitted before executing the action.
+    approvalRef = {
+      approvalId: pendingApproval.approvalId,
+      outcome: "granted",
+    }
+    yield {
+      type: "approval.granted",
+      runId,
+      timestamp: timestamp(now),
+      approvalId: pendingApproval.approvalId,
+      grantedBy: "operator",
+      scope: pendingApproval.scope ?? "once",
+    }
+  } else if (approvalAction !== undefined) {
+    const gate = previewGateAllows(approvalAction)
+    if (!gate.allowed) {
+      // Preview-first fail-closed (#187 AC-001): a write action without a
+      // validated write-approval.v1 preview cannot express an approval
+      // request, aligned with undeclared_tool / approval_not_configured
+      // guard semantics.
+      await writeEvidence(
+        {
+          status: "failed",
+          reason: "engine_internal_error",
+          errorCode: gate.code,
+        },
+        null,
+      )
+      yield fail(gate.code!, gate.message!, "engine_internal_error", false)
+      return
+    }
+    const approvalId = newId()
+    approvalRef = {
+      approvalId,
+      previewId: approvalAction.preview.previewId,
+      outcome: "requested",
+    }
+    yield {
+      type: "approval.requested",
+      runId,
+      timestamp: timestamp(now),
+      approvalId,
+      action: {
+        kind: approvalAction.kind,
+        description: approvalAction.description,
+        ...(approvalAction.target !== undefined
+          ? { target: approvalAction.target }
+          : {}),
+      },
+      ...(request.deadline !== undefined
+        ? { expiresAt: request.deadline }
+        : {}),
+    }
+    await writeEvidence(
+      {
+        status: "failed",
+        reason: "cancelled",
+        errorCode: APPROVAL_REQUIRED_CODE,
+      },
+      null,
+    )
+    yield fail(
+      APPROVAL_REQUIRED_CODE,
+      "turn stopped at the capability gate awaiting an operator approval verdict; resume with a turn carrying pendingApproval",
+      "cancelled",
+      true,
+    )
+    return
   }
 
   try {

--- a/tests/engine/approval-events.test.ts
+++ b/tests/engine/approval-events.test.ts
@@ -291,3 +291,81 @@ test("#187 AC-004: approval settlements reuse the existing terminal-reason vocab
     assert.equal(knownReasons.has(terminal[0]!.error.terminalReason), true)
   }
 })
+
+test("#187 hardening: oversized pendingApproval.reason rejects at the boundary", async () => {
+  const { events } = await collect(
+    baseRequest({
+      pendingApproval: pendingApproval({ reason: "x".repeat(2048) }),
+    }),
+    ["should never run"],
+  )
+  const terminal = events.filter(isTerminalEngineEvent)
+  assert.equal(terminal.length, 1)
+  if (terminal[0]!.type === "run.failed") {
+    assert.equal(terminal[0]!.error.code, "engine.input_invalid")
+  } else {
+    assert.fail("expected run.failed")
+  }
+  assert.equal(
+    events.some((event) => event.type.startsWith("approval.")),
+    false,
+  )
+})
+
+test("#187 hardening: evidence persists before the approval.denied event", async () => {
+  const order: string[] = []
+  const evidenceSink = {
+    async write() {
+      order.push("evidence")
+    },
+  }
+  const events: EngineEvent[] = []
+  for await (const event of executeTurn(
+    baseRequest({
+      pendingApproval: pendingApproval({ decision: "denied" }),
+    }),
+    {
+      model: createDeterministicModelPort(["never"]),
+      now: FIXED_NOW,
+      evidenceSink,
+    },
+  )) {
+    if (event.type === "approval.denied") order.push("event")
+    events.push(event)
+  }
+  assert.deepEqual(order, ["evidence", "event"])
+})
+
+test("#187 hardening: failing evidence sink settles engine.internal_error fail closed", async () => {
+  const evidenceSink = {
+    async write(): Promise<void> {
+      throw new Error("evidence sink unavailable")
+    },
+  }
+  const events: EngineEvent[] = []
+  for await (const event of executeTurn(
+    baseRequest({
+      pendingApproval: pendingApproval({ decision: "denied" }),
+    }),
+    {
+      model: createDeterministicModelPort(["never"]),
+      now: FIXED_NOW,
+      evidenceSink,
+    },
+  )) {
+    events.push(event)
+  }
+  const terminal = events.filter(isTerminalEngineEvent)
+  assert.equal(terminal.length, 1)
+  if (terminal[0]!.type === "run.failed") {
+    assert.equal(terminal[0]!.error.code, "engine.internal_error")
+    assert.equal(terminal[0]!.error.retryable, false)
+    assert.equal(terminal[0]!.error.terminalReason, "engine_internal_error")
+  } else {
+    assert.fail("expected run.failed")
+  }
+  assert.equal(
+    events.some((event) => event.type.startsWith("approval.")),
+    false,
+  )
+})

--- a/tests/engine/approval-events.test.ts
+++ b/tests/engine/approval-events.test.ts
@@ -1,0 +1,293 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  APPROVAL_DENIED_CODE,
+  APPROVAL_EXPIRED_CODE,
+  APPROVAL_PREVIEW_INVALID_CODE,
+  APPROVAL_REQUIRED_CODE,
+  createDeterministicModelPort,
+  createInMemoryEvidenceSink,
+  executeTurn,
+  isTerminalEngineEvent,
+} from "../../packages/engine/src/index.js"
+import type {
+  EngineEvent,
+  EngineTurnRequest,
+  TurnApprovalActionInput,
+  TurnPendingApprovalInput,
+} from "../../packages/engine/src/index.js"
+
+const FIXED_NOW = () => new Date("2026-08-23T00:00:00.000Z")
+
+function validPreviewRef(overrides: Record<string, string> = {}) {
+  return {
+    version: "write-approval.v1",
+    previewId: "preview-1",
+    previewDigest: "sha256:ab12",
+    state: "preview_validated",
+    ...overrides,
+  }
+}
+
+function approvalAction(
+  overrides: Partial<TurnApprovalActionInput> = {},
+): TurnApprovalActionInput {
+  return {
+    kind: "write",
+    description: "Update the roadmap milestone table",
+    target: "docs/roadmap.md",
+    preview: validPreviewRef(),
+    ...overrides,
+  }
+}
+
+function pendingApproval(
+  overrides: Partial<TurnPendingApprovalInput> = {},
+): TurnPendingApprovalInput {
+  return {
+    approvalId: "approval-1",
+    decision: "granted",
+    decidedBy: "operator",
+    ...overrides,
+  }
+}
+
+function baseRequest(overrides: Partial<EngineTurnRequest> = {}): EngineTurnRequest {
+  return {
+    workspaceRef: "ws-1",
+    positionId: "repo-owner",
+    turnId: "turn-1",
+    runId: "run-1",
+    input: "Apply the milestone update.",
+    budget: { maxIterations: 2 },
+    ...overrides,
+  }
+}
+
+async function collect(request: EngineTurnRequest, script: string[] = []) {
+  const evidenceSink = createInMemoryEvidenceSink()
+  const model = createDeterministicModelPort(script)
+  const events: EngineEvent[] = []
+  for await (const event of executeTurn(request, {
+    model,
+    now: FIXED_NOW,
+    evidenceSink,
+    newId: () => "approval-1",
+  })) {
+    events.push(event)
+  }
+  return { events, evidence: evidenceSink.records }
+}
+
+test("#187 AC-001: request turn with a validated preview emits approval.requested and settles retryable", async () => {
+  const { events, evidence } = await collect(
+    baseRequest({
+      approvalAction: approvalAction(),
+      deadline: "2026-08-23T01:00:00.000Z",
+    }),
+  )
+  assert.deepEqual(
+    events.map((event) => event.type),
+    ["run.started", "approval.requested", "run.failed"],
+  )
+  const requested = events[1]!
+  assert.equal(requested.type, "approval.requested")
+  if (requested.type === "approval.requested") {
+    assert.equal(requested.approvalId, "approval-1")
+    assert.equal(requested.action.kind, "write")
+    assert.equal(requested.action.target, "docs/roadmap.md")
+    assert.equal(requested.expiresAt, "2026-08-23T01:00:00.000Z")
+  }
+  const terminal = events[2]!
+  assert.equal(terminal.type, "run.failed")
+  if (terminal.type === "run.failed") {
+    assert.equal(terminal.error.code, APPROVAL_REQUIRED_CODE)
+    assert.equal(terminal.error.retryable, true)
+    assert.equal(terminal.error.terminalReason, "cancelled")
+  }
+  // No model consumption before the gate settles.
+  assert.equal(events.some((event) => event.type === "model.delta"), false)
+  assert.equal(evidence.length, 1)
+  assert.deepEqual(evidence[0]!.approvalRef, {
+    approvalId: "approval-1",
+    previewId: "preview-1",
+    outcome: "requested",
+  })
+})
+
+test("#187 AC-001: write without a validated preview fails closed", async () => {
+  for (const preview of [
+    validPreviewRef({ state: "preview_pending" }),
+    validPreviewRef({ version: "write-approval.v0" }),
+  ]) {
+    const { events } = await collect(
+      baseRequest({ approvalAction: approvalAction({ preview }) }),
+    )
+    assert.equal(events.some((event) => event.type === "approval.requested"), false)
+    const terminal = events.filter(isTerminalEngineEvent)
+    assert.equal(terminal.length, 1)
+    assert.equal(terminal[0]!.type, "run.failed")
+    if (terminal[0]!.type === "run.failed") {
+      assert.equal(terminal[0]!.error.code, APPROVAL_PREVIEW_INVALID_CODE)
+      assert.equal(terminal[0]!.error.retryable, false)
+    }
+  }
+})
+
+test("#187 AC-003: denied verdict settles a denied terminal with evidence and no retry", async () => {
+  const { events, evidence } = await collect(
+    baseRequest({
+      pendingApproval: pendingApproval({
+        decision: "denied",
+        reason: "out of scope for this release",
+      }),
+    }),
+    ["should never run"],
+  )
+  assert.deepEqual(
+    events.map((event) => event.type),
+    ["run.started", "approval.denied", "run.failed"],
+  )
+  const denied = events[1]!
+  if (denied.type === "approval.denied") {
+    assert.equal(denied.approvalId, "approval-1")
+    assert.equal(denied.deniedBy, "operator")
+    assert.equal(denied.reason, "out of scope for this release")
+  } else {
+    assert.fail("expected approval.denied")
+  }
+  const terminal = events[2]!
+  if (terminal.type === "run.failed") {
+    assert.equal(terminal.error.code, APPROVAL_DENIED_CODE)
+    assert.equal(terminal.error.retryable, false)
+    assert.equal(terminal.error.terminalReason, "cancelled")
+  } else {
+    assert.fail("expected run.failed")
+  }
+  // Denied terminal never consumes the model: no downgrade to an unapproved write.
+  assert.equal(events.some((event) => event.type === "model.delta"), false)
+  assert.equal(evidence.length, 1)
+  assert.deepEqual(evidence[0]!.approvalRef, {
+    approvalId: "approval-1",
+    outcome: "denied",
+  })
+  assert.equal(evidence[0]!.terminal.errorCode, APPROVAL_DENIED_CODE)
+})
+
+test("#187 AC-003: granted verdict records consumption before executing, then completes", async () => {
+  const { events, evidence } = await collect(
+    baseRequest({ pendingApproval: pendingApproval({ scope: "run" }) }),
+    ["done"],
+  )
+  const types = events
+    .map((event) => event.type)
+    .filter((type) => type !== "usage")
+  assert.deepEqual(types, [
+    "run.started",
+    "approval.granted",
+    "model.delta",
+    "run.completed",
+  ])
+  const granted = events[1]!
+  if (granted.type === "approval.granted") {
+    assert.equal(granted.grantedBy, "operator")
+    assert.equal(granted.scope, "run")
+  } else {
+    assert.fail("expected approval.granted")
+  }
+  const terminal = events[events.length - 1]!
+  assert.equal(terminal.type, "run.completed")
+  assert.equal(evidence[0]!.approvalRef?.outcome, "granted")
+  assert.equal(evidence[0]!.terminal.reason, "goal_met")
+})
+
+test("#187 AC-003: granted verdict defaults scope to once", async () => {
+  const { events } = await collect(
+    baseRequest({ pendingApproval: pendingApproval() }),
+    ["done"],
+  )
+  const granted = events.find((event) => event.type === "approval.granted")
+  if (granted?.type === "approval.granted") {
+    assert.equal(granted.scope, "once")
+  } else {
+    assert.fail("expected approval.granted")
+  }
+})
+
+test("#187 AC-005: expired verdict fails closed, distinguishable from denied", async () => {
+  const { events, evidence } = await collect(
+    baseRequest({
+      pendingApproval: pendingApproval({
+        decision: "granted",
+        expiresAt: "2026-08-22T23:59:59.000Z",
+      }),
+    }),
+    ["should never run"],
+  )
+  assert.equal(events.some((event) => event.type === "approval.granted"), false)
+  const terminal = events.filter(isTerminalEngineEvent)
+  assert.equal(terminal.length, 1)
+  if (terminal[0]!.type === "run.failed") {
+    // Same terminal family as denied (cancelled), distinct error code.
+    assert.equal(terminal[0]!.error.code, APPROVAL_EXPIRED_CODE)
+    assert.notEqual(terminal[0]!.error.code, APPROVAL_DENIED_CODE)
+    assert.equal(terminal[0]!.error.terminalReason, "cancelled")
+    assert.equal(terminal[0]!.error.retryable, false)
+  } else {
+    assert.fail("expected run.failed")
+  }
+  assert.equal(evidence[0]!.approvalRef?.outcome, "expired")
+})
+
+test("#187 ordering: request turn and resume turn fields are mutually exclusive", async () => {
+  const evidenceSink = createInMemoryEvidenceSink()
+  const events: EngineEvent[] = []
+  for await (const event of executeTurn(
+    baseRequest({
+      approvalAction: approvalAction(),
+      pendingApproval: pendingApproval(),
+    }),
+    {
+      model: createDeterministicModelPort(["never"]),
+      now: FIXED_NOW,
+      evidenceSink,
+    },
+  )) {
+    events.push(event)
+  }
+  const terminal = events.filter(isTerminalEngineEvent)
+  assert.equal(terminal.length, 1)
+  if (terminal[0]!.type === "run.failed") {
+    assert.equal(terminal[0]!.error.code, "engine.input_invalid")
+  } else {
+    assert.fail("expected run.failed")
+  }
+  assert.equal(
+    events.some((event) => event.type.startsWith("approval.")),
+    false,
+  )
+})
+
+test("#187 AC-004: approval settlements reuse the existing terminal-reason vocabulary", async () => {
+  const { events } = await collect(
+    baseRequest({ approvalAction: approvalAction() }),
+  )
+  const terminal = events.filter(isTerminalEngineEvent)
+  assert.equal(terminal.length, 1)
+  if (terminal[0]!.type === "run.failed") {
+    // No new TerminalReason value is introduced for the approval lifecycle.
+    const knownReasons = new Set([
+      "goal_met",
+      "invalid_output_exhausted",
+      "turn_budget_exceeded",
+      "position_budget_exceeded",
+      "iteration_cap",
+      "doom_loop",
+      "deadline_exceeded",
+      "cancelled",
+      "engine_internal_error",
+    ])
+    assert.equal(knownReasons.has(terminal[0]!.error.terminalReason), true)
+  }
+})


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/187
- Consumed revision: R2
- R2 decision: issuecomment-5409280515 (decidedAt 2026-08-25T10:46:59Z; status ready, technicalOwner 技术 P9)
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | `packages/engine/src/contracts.ts` + `packages/engine/src/approval.ts` (`approvalAction` request shape and `previewGateAllows`: only a write-approval.v1 preview in state preview_validated can express an approval request; anything else fails closed) | `tests/engine/approval-events.test.ts` "#187 AC-001: write without a validated preview fails closed" — preview_pending and wrong-version variants both reject with `engine.approval_preview_invalid`, no approval.requested emitted |
| REQ-002 / AC-002 | `packages/engine/src/approval.ts` header + CHANGELOG entry (default policy frozen by the R2 decision: a write action requires an explicit operator verdict; no auto-grant path exists; changing the default requires a recorded product decision) | Decision record issuecomment-5409280515 reviewed; source audit confirms granted is reachable only via an operator pendingApproval verdict — no implicit default branch |
| REQ-003 / AC-003 | `packages/engine/src/turn-executor.ts` denied path + `packages/engine/src/turn-evidence.ts` `approvalRef` (denied verdict settles `engine.approval_denied` retryable=false with zero model consumption; evidence carries the denied approval reference and terminal reason) | "#187 AC-003: denied verdict settles a denied terminal with evidence and no retry" — event order, retryable=false, absence of model.delta, evidence approvalRef and terminal errorCode all asserted |
| REQ-004 / AC-004 | `packages/engine/src/contracts.ts` (three additive approval events on the engine.v1 vocabulary; settlements reuse the existing TerminalReason enumeration and are distinguished by error codes) + `docs/engine-codex-semantic-mapping.md` §4 updated in this same PR | "#187 AC-004: approval settlements reuse the existing terminal-reason vocabulary"; preview states reuse the write-approval.v1 vocabulary (`preview_validated`), no synonym vocabulary introduced |
| REQ-005 / AC-005 | `packages/engine/src/approval.ts` `pendingApprovalExpired` + executor expired path (expired/missing/malformed verdicts fail closed as `engine.approval_expired`, same terminal family as denied but with a distinct code) | "#187 AC-005: expired verdict fails closed, distinguishable from denied" — retryable=false, no granted/denied event emitted |

## File domains

- `packages/engine/src/contracts.ts` (+221) — three additive events (`approval.requested` / `approval.granted` / `approval.denied`) on the `EngineEvent` union; `TurnApprovalActionInput` / `TurnPendingApprovalInput` request types; fail-closed shape validation in `validateTurnRequest` (mutual exclusion, bounded description 1 KiB / target 512 B, enum and timestamp checks).
- `packages/engine/src/approval.ts` (new, 78) — gate module: settlement code constants, `previewGateAllows` (preview-first fail-closed), `pendingApprovalExpired`, default-policy statement.
- `packages/engine/src/turn-executor.ts` (+187) — approval gate before any model consumption: resume-turn verdict consumption (expired / denied / granted) and request-turn preview-first settlement, evidence-first ordering with fail-closed `try/catch` around every settlement evidence write.
- `packages/engine/src/turn-evidence.ts` (+13) — optional bounded `approvalRef` chain link on the evidence record.
- `packages/engine/src/index.ts` (+15) — additive exports only.
- `tests/engine/approval-events.test.ts` (new, 371) — E3 fixtures for all five AC paths plus ordering, vocabulary guards, and fail-closed hardening (oversized reason, evidence-before-event ordering, sink-failure settlement).
- `CHANGELOG.md` (+21), `docs/engine-codex-semantic-mapping.md` (§4 finalized in the same PR per the single-source discipline).

## Scope and non-goals

Implements the #187 R2-frozen approval three-event contract under Option 1 (terminal-and-resume): the engine stays one-directional — the requesting turn settles as a retryable failure carrying `approval.requested`, and the operator verdict is consumed at the gate of the resume turn before any model consumption. The codex mapping document §4 is finalized in this same PR per the vocabulary-change-with-mapping-doc discipline.

**Not in scope** (explicitly separate):
- `pendingApproval` plumbing on the `turn-envelope.v1` spawn surface (CEO queue item ②, separate PR consuming its own revision). Until it lands, the resume path is exercised at the engine request level only.
- Option 2 (in-run pause + inbound channel) — rejected by the R2 decision and suspended.
- New TerminalReason values — none added; approval settlements reuse `cancelled` and are distinguished by error code.
- Tool-dispatch wiring — the read-only core has no tool loop; this slice delivers the vocabulary and gate that a future dispatch surface will call.

## Validation

- Exact commands: `npm run build` ; `npx tsx --test tests/engine/approval-events.test.ts` ; `npx tsx --test tests/engine/*.test.ts` ; `npm test`
- Observed counts/results: PASS 1688/1688 full suite (`npm test`, head e20d374, macOS arm64, Node v24.13.0); PASS 11/11 `approval-events.test.ts`; PASS 59/59 engine group; build clean
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/pull/191/checks

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 / AC-001 | Write action without a validated preview fails closed; validated preview emits approval.requested and settles retryable | `npx tsx --test tests/engine/approval-events.test.ts` | macOS arm64, Node v24.13.0, head e20d374 | preview_pending / wrong-version reject with `engine.approval_preview_invalid`; valid preview yields requested + `engine.approval_required` retryable=true with no model consumption | both AC-001 cases PASS within 11/11 | PASS |
| V2 | REQ-003 / AC-003 | Denied verdict settles a denied terminal with no retry, no downgrade, evidence carries the denied approval reference | same test file, "#187 AC-003: denied verdict..." case | 同上 | event order run.started → approval.denied → run.failed; retryable=false; zero model.delta; evidence approvalRef outcome=denied + terminal errorCode | matched, PASS within 11/11 | PASS |
| V3 | REQ-005 / AC-005 | Expired verdict fails closed, same family as denied but distinguishable | same test file, "#187 AC-005: ..." case | 同上 | `engine.approval_expired` ≠ `engine.approval_denied`, terminalReason cancelled, retryable=false, evidence outcome=expired | matched, PASS within 11/11 | PASS |
| V4 | REQ-004 / AC-004 | Approval settlements reuse the existing terminal-reason vocabulary; no new TerminalReason value | same test file, "#187 AC-004: ..." case + diff review of contracts.ts TerminalReason union | 同上 | terminalReason within the pre-existing 9-value set; union unchanged | matched, PASS within 11/11 | PASS |
| V5 | REQ-002 / AC-002 | Default policy decision is recorded and the code has no auto-grant path | review of R2 decision issuecomment-5409280515 + source audit of `approval.ts` / `turn-executor.ts` | head e20d374 | decision record exists; granted reachable only via operator pendingApproval | decision recorded 2026-08-25T10:46:59Z; no auto-grant branch found | PASS |

## Security and compatibility

Additive vocabulary only: the five existing engine.v1 event shapes, `isTerminalEngineEvent`, `validateTurnRequest` existing behavior, and all frozen contracts (`turn-envelope.v1`, the spawn surface) are untouched; `apps/cli` is not modified at all. No new dependency, no credential surface, no schema migration. The gate preserves and extends the fail-closed posture of #178: every malformed, expired, or unpreviewed path rejects before any model consumption, and granted/denied are records of a verdict, not authorization itself — authorization remains with the policy projection. The one-directional sealed-envelope model is unchanged: the verdict channel is the next turn's sealed envelope (plumbing lands in the separate queue-item-② PR), never an in-run inbound channel. Evidence records carry bounded identifiers only (approvalId, previewId, outcome) — no verdict text or action descriptions enter evidence.

## Known limitations

- The resume path is proven at the engine request level; `turn-envelope.v1` does not yet carry `pendingApproval` (separate PR, queue item ②), so an operator verdict cannot reach the spawn surface over stdin until that lands.
- E4 live evidence is not required by the R2 evidence plan; this slice is evidenced at E3 (automated fixtures).
- The gate fires when a caller declares `approvalAction`; since the read-only core has no tool dispatch loop yet, wiring the gate to a future dispatch surface is explicitly out of scope here.
- Approval waiting does not suspend deadlines: the resume turn carries its own budget and deadline (per the Option 1 design).

## Risk and rollback

Risk is low and localized: all changes are additive inside `packages/engine`, reachable only through the two new opt-in request fields; existing callers that never set them observe identical behavior (proven by the 1688-test full suite). Rollback: revert the three commits; the vocabulary and gate disappear with no state, schema, or data impact.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: no release packet exists for this repository yet
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
