### PR TITLE
feat(cli): pendingApproval verdict field on turn-envelope.v1 spawn surface (#193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `turn-envelope.v1` gains an optional `pendingApproval` field (#193
+  REQ-001..REQ-003) so an operator verdict for a previously requested
+  approval can reach the #187 engine gate through the spawn surface. The
+  field shape is the engine `TurnPendingApprovalInput` verbatim
+  (`approvalId` / `decision: granted|denied` / `decidedBy: operator` /
+  `scope: once|run` / `reason?` / `expiresAt?`) — no parallel vocabulary —
+  and `turn run` maps it into `EngineTurnRequest.pendingApproval` with zero
+  engine changes: the verdict settles exactly as #187 already merged it
+  (granted proceeds with `approval.granted` before any model consumption,
+  denied settles `engine.approval_denied` `retryable=false` with zero
+  consumption, expired fails closed with `engine.approval_expired`). The
+  envelope boundary is the first gate and fails closed per the #173 spawn
+  contract (exit 1 + stderr diagnostics before spawn); the engine
+  validation stays the byte-exact backstop. The schema is purely additive:
+  envelopes without the field behave identically.
 - engine.v1 gains the approval three-event contract (#187 REQ-001..REQ-005,
   Option 1 terminal-and-resume): additive events `approval.requested`,
   `approval.granted`, `approval.denied` alongside the existing five event

--- a/apps/cli/turn/envelope-schema.ts
+++ b/apps/cli/turn/envelope-schema.ts
@@ -78,10 +78,24 @@ export function buildTurnEnvelopeSchema(): Record<string, unknown> {
       taskId: boundedIdSchema(),
       dayKey: boundedIdSchema(),
       deadline: { type: "string" },
+      pendingApproval: { $ref: "#/$defs/pendingApproval" },
       envelopeDigest: { type: "string", minLength: 1 },
     },
     $defs: {
       budgetScope: budgetScopeSchema(),
+      pendingApproval: {
+        type: "object",
+        additionalProperties: false,
+        required: ["approvalId", "decision", "decidedBy"],
+        properties: {
+          approvalId: boundedIdSchema(),
+          decision: { enum: ["granted", "denied"] },
+          decidedBy: { const: "operator" },
+          scope: { enum: ["once", "run"] },
+          reason: { type: "string", minLength: 1, maxLength: 1024 },
+          expiresAt: { type: "string" },
+        },
+      },
     },
   }
 }

--- a/apps/cli/turn/envelope.ts
+++ b/apps/cli/turn/envelope.ts
@@ -16,7 +16,10 @@ import {
   validatePositionBudgetDeclaration,
   type PositionBudgetDeclaration,
 } from "../../../packages/engine/src/budget.js"
-import type { TurnBudget } from "../../../packages/engine/src/contracts.js"
+import type {
+  TurnBudget,
+  TurnPendingApprovalInput,
+} from "../../../packages/engine/src/contracts.js"
 
 export const TURN_ENVELOPE_VERSION = "turn-envelope.v1" as const
 export const TURN_ENVELOPE_SCHEMA_ID =
@@ -55,6 +58,12 @@ export interface TurnEnvelope {
   taskId?: string
   dayKey?: string
   deadline?: string
+  /**
+   * Operator verdict for a previously requested approval (#193, consuming
+   * the #187 Option 1 engine gate). Shape is the engine
+   * `TurnPendingApprovalInput` verbatim — no parallel vocabulary.
+   */
+  pendingApproval?: TurnPendingApprovalInput
   envelopeDigest: string
 }
 
@@ -69,6 +78,10 @@ export class TurnEnvelopeError extends Error {
 }
 
 const MAX_ID_LENGTH = 256
+// Mirrors the engine's bounded-text cap for approval verdict reasons
+// (contracts.ts APPROVAL_DESCRIPTION_MAX_BYTES); the envelope gate rejects
+// oversized verdicts before spawn, the engine stays the byte-exact backstop.
+const MAX_APPROVAL_REASON_BYTES = 1024
 
 function canonicalJson(value: unknown): unknown {
   if (value === null || typeof value !== "object") return value
@@ -210,6 +223,73 @@ export function parseTurnEnvelope(raw: unknown): TurnEnvelope {
     }
   }
 
+  // Operator verdict for the #187 approval gate (#193): first-gate,
+  // fail-closed shape checks mirroring the engine's
+  // validateApprovalRequestFields; engine validation remains the backstop.
+  let pendingApproval: TurnPendingApprovalInput | undefined
+  if (raw.pendingApproval !== undefined) {
+    if (!isRecord(raw.pendingApproval)) {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "pendingApproval must be a JSON object",
+      )
+    }
+    const approvalId = assertBoundedId(
+      raw.pendingApproval.approvalId,
+      "pendingApproval.approvalId",
+    )
+    const decision = raw.pendingApproval.decision
+    if (decision !== "granted" && decision !== "denied") {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "pendingApproval.decision must be granted or denied",
+      )
+    }
+    if (raw.pendingApproval.decidedBy !== "operator") {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "pendingApproval.decidedBy must be operator",
+      )
+    }
+    const scope = raw.pendingApproval.scope
+    if (scope !== undefined && scope !== "once" && scope !== "run") {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "pendingApproval.scope must be once or run when present",
+      )
+    }
+    const reason = raw.pendingApproval.reason
+    if (
+      reason !== undefined &&
+      (typeof reason !== "string" ||
+        reason.trim().length === 0 ||
+        Buffer.byteLength(reason, "utf8") > MAX_APPROVAL_REASON_BYTES)
+    ) {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "pendingApproval.reason must be a non-empty string within the bounded size",
+      )
+    }
+    const expiresAt = raw.pendingApproval.expiresAt
+    if (
+      expiresAt !== undefined &&
+      (typeof expiresAt !== "string" || Number.isNaN(Date.parse(expiresAt)))
+    ) {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "pendingApproval.expiresAt must be a valid ISO 8601 timestamp",
+      )
+    }
+    pendingApproval = {
+      approvalId,
+      decision,
+      decidedBy: "operator",
+      ...(scope !== undefined ? { scope } : {}),
+      ...(reason !== undefined ? { reason: reason as string } : {}),
+      ...(expiresAt !== undefined ? { expiresAt } : {}),
+    }
+  }
+
   if (typeof raw.envelopeDigest !== "string" || raw.envelopeDigest.length === 0) {
     throw new TurnEnvelopeError(
       "engine.envelope_invalid",
@@ -235,6 +315,7 @@ export function parseTurnEnvelope(raw: unknown): TurnEnvelope {
       ? { positionBudget, taskId, dayKey }
       : {}),
     ...(raw.deadline !== undefined ? { deadline: raw.deadline as string } : {}),
+    ...(pendingApproval !== undefined ? { pendingApproval } : {}),
     envelopeDigest: raw.envelopeDigest,
   }
 }

--- a/apps/cli/turn/turn-run.ts
+++ b/apps/cli/turn/turn-run.ts
@@ -276,6 +276,9 @@ export async function runTurn(options: TurnRunOptions): Promise<TurnRunResult> {
     ...(envelope.deadline !== undefined
       ? { deadline: envelope.deadline }
       : {}),
+    ...(envelope.pendingApproval !== undefined
+      ? { pendingApproval: envelope.pendingApproval }
+      : {}),
   }
 
   const escalationSink = createInMemoryEscalationSink()

--- a/configs/turn-envelope.schema.json
+++ b/configs/turn-envelope.schema.json
@@ -78,6 +78,9 @@
     "deadline": {
       "type": "string"
     },
+    "pendingApproval": {
+      "$ref": "#/$defs/pendingApproval"
+    },
     "envelopeDigest": {
       "type": "string",
       "minLength": 1
@@ -98,6 +101,45 @@
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 1000000000
+        }
+      }
+    },
+    "pendingApproval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "approvalId",
+        "decision",
+        "decidedBy"
+      ],
+      "properties": {
+        "approvalId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "decision": {
+          "enum": [
+            "granted",
+            "denied"
+          ]
+        },
+        "decidedBy": {
+          "const": "operator"
+        },
+        "scope": {
+          "enum": [
+            "once",
+            "run"
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "expiresAt": {
+          "type": "string"
         }
       }
     }

--- a/tests/apps/turn-envelope-schema.test.ts
+++ b/tests/apps/turn-envelope-schema.test.ts
@@ -98,3 +98,52 @@ test("computeEnvelopeDigest is canonical: key order does not matter", () => {
   const b = computeEnvelopeDigest({ a: { c: [1, 2], d: 2 }, b: 1 })
   assert.equal(a, b)
 })
+
+test("#193: a sealed pendingApproval verdict is accepted at the envelope boundary", () => {
+  const envelope = parseTurnEnvelope(
+    sealedEnvelope({
+      pendingApproval: {
+        approvalId: "appr-1",
+        decision: "granted",
+        decidedBy: "operator",
+        scope: "once",
+        expiresAt: "2026-08-26T00:00:00.000Z",
+      },
+    }),
+  )
+  assert.equal(envelope.pendingApproval?.approvalId, "appr-1")
+  assert.equal(envelope.pendingApproval?.decision, "granted")
+})
+
+test("#193 AC-005: malformed pendingApproval shapes reject before consumption", () => {
+  const malformed: Array<Record<string, unknown>> = [
+    { approvalId: "appr-1", decision: "maybe", decidedBy: "operator" },
+    { approvalId: "appr-1", decision: "granted", decidedBy: "someone-else" },
+    { decision: "granted", decidedBy: "operator" },
+    {
+      approvalId: "appr-1",
+      decision: "granted",
+      decidedBy: "operator",
+      scope: "session",
+    },
+    {
+      approvalId: "appr-1",
+      decision: "denied",
+      decidedBy: "operator",
+      reason: "x".repeat(1025),
+    },
+    {
+      approvalId: "appr-1",
+      decision: "granted",
+      decidedBy: "operator",
+      expiresAt: "not-a-timestamp",
+    },
+  ]
+  for (const pendingApproval of malformed) {
+    assert.throws(
+      () => parseTurnEnvelope(sealedEnvelope({ pendingApproval })),
+      (error: unknown) =>
+        (error as { code?: string }).code === "engine.input_invalid",
+    )
+  }
+})

--- a/tests/apps/turn-run.test.ts
+++ b/tests/apps/turn-run.test.ts
@@ -518,3 +518,185 @@ test("#185 AC-003: a missing qodercli binary is an environment fault, not a verd
     diagnostics.some((line) => line.includes("qoder_binary_unavailable")),
   )
 })
+
+// #193: pendingApproval verdict fixtures — the five envelope forms
+// (granted / denied / expired / malformed / absent) settling through the
+// already-merged #187 engine gate with zero new engine changes.
+
+test("#193 AC-001: granted verdict emits approval.granted before any model consumption", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, {
+    pendingApproval: {
+      approvalId: "appr-granted-1",
+      decision: "granted",
+      decidedBy: "operator",
+      scope: "once",
+    },
+  })
+  let modelCalls = 0
+  let modelCallsAtGranted = -1
+  const events: Array<Record<string, unknown>> = []
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText: JSON.stringify(envelope),
+    model: {
+      async complete() {
+        modelCalls += 1
+        return { text: "write executed under approval" }
+      },
+    },
+    writeEvent: (line) => {
+      const event = JSON.parse(line) as Record<string, unknown>
+      events.push(event)
+      if (event.type === "approval.granted") modelCallsAtGranted = modelCalls
+    },
+    writeDiagnostic: () => undefined,
+  })
+  assert.equal(result.exitCode, 0)
+  assert.equal(
+    modelCallsAtGranted,
+    0,
+    "approval.granted must precede any model consumption",
+  )
+  assert.equal(modelCalls, 1)
+  const granted = events.find((event) => event.type === "approval.granted")
+  assert.ok(granted)
+  assert.equal(granted!.approvalId, "appr-granted-1")
+  const grantedIndex = events.indexOf(granted!)
+  const terminal = events.find((event) => event.type === "run.completed")
+  assert.ok(terminal)
+  assert.ok(events.indexOf(terminal!) > grantedIndex)
+})
+
+test("#193 AC-002: denied verdict settles non-retryable with zero model consumption", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, {
+    pendingApproval: {
+      approvalId: "appr-denied-1",
+      decision: "denied",
+      decidedBy: "operator",
+      reason: "out of window",
+    },
+  })
+  let modelCalls = 0
+  const events: Array<Record<string, unknown>> = []
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText: JSON.stringify(envelope),
+    model: {
+      async complete() {
+        modelCalls += 1
+        return { text: "never" }
+      },
+    },
+    writeEvent: (line) => events.push(JSON.parse(line)),
+    writeDiagnostic: () => undefined,
+  })
+  assert.equal(result.exitCode, 0)
+  assert.equal(result.terminalEmitted, true)
+  assert.equal(modelCalls, 0)
+  const deniedIndex = events.findIndex(
+    (event) => event.type === "approval.denied",
+  )
+  assert.ok(deniedIndex >= 0)
+  assert.equal(events[deniedIndex]!.reason, "out of window")
+  const terminal = events.find((event) => event.type === "run.failed")
+  assert.ok(terminal)
+  assert.ok(events.indexOf(terminal!) > deniedIndex)
+  const error = terminal!.error as {
+    code: string
+    retryable: boolean
+    terminalReason: string
+  }
+  assert.equal(error.code, "engine.approval_denied")
+  assert.equal(error.retryable, false)
+  assert.equal(error.terminalReason, "cancelled")
+})
+
+test("#193 AC-003: an expired verdict fails closed with exactly one trusted terminal", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, {
+    pendingApproval: {
+      approvalId: "appr-expired-1",
+      decision: "granted",
+      decidedBy: "operator",
+      expiresAt: "2020-01-01T00:00:00.000Z",
+    },
+  })
+  let modelCalls = 0
+  const events: Array<Record<string, unknown>> = []
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText: JSON.stringify(envelope),
+    model: {
+      async complete() {
+        modelCalls += 1
+        return { text: "never" }
+      },
+    },
+    writeEvent: (line) => events.push(JSON.parse(line)),
+    writeDiagnostic: () => undefined,
+  })
+  assert.equal(result.exitCode, 0)
+  assert.equal(modelCalls, 0)
+  const terminals = events.filter((event) => event.type === "run.failed")
+  assert.equal(terminals.length, 1)
+  const error = terminals[0]!.error as { code: string; retryable: boolean }
+  assert.equal(error.code, "engine.approval_expired")
+  assert.equal(error.retryable, false)
+})
+
+test("#193 AC-005: a malformed verdict rejects at the envelope boundary, exit 1", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, {
+    pendingApproval: {
+      approvalId: "appr-bad-1",
+      decision: "maybe",
+      decidedBy: "operator",
+    },
+  })
+  let modelCalls = 0
+  const events: Array<Record<string, unknown>> = []
+  const diagnostics: string[] = []
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText: JSON.stringify(envelope),
+    model: {
+      async complete() {
+        modelCalls += 1
+        return { text: "never" }
+      },
+    },
+    writeEvent: (line) => events.push(JSON.parse(line)),
+    writeDiagnostic: (line) => diagnostics.push(line),
+  })
+  assert.equal(result.exitCode, 1)
+  assert.equal(result.terminalEmitted, false)
+  assert.equal(events.length, 0)
+  assert.equal(modelCalls, 0)
+  assert.ok(
+    diagnostics.some((line) => line.includes("engine.input_invalid")),
+  )
+})
+
+test("#193 AC-004: an envelope without pendingApproval keeps current behavior", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace)
+  const { result, events } = await execute(
+    workspace,
+    JSON.stringify(envelope),
+    createDeterministicModelPort(["done without a verdict"]),
+  )
+  assert.equal(result.exitCode, 0)
+  assert.ok(events.some((event) => event.type === "run.completed"))
+  assert.ok(
+    !events.some((event) =>
+      String(event.type).startsWith("approval."),
+    ),
+    "no approval lifecycle events without a verdict field",
+  )
+})


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/193
- Consumed revision: R2
- R2 decision: issuecomment-5412958861 (decidedAt 2026-08-26; status ready, technicalOwner @PeterGuy326)
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | `configs/turn-envelope.schema.json` + `apps/cli/turn/envelope-schema.ts` ($defs/pendingApproval: field shape is engine `TurnPendingApprovalInput` verbatim — approvalId/decision/decidedBy required, scope/reason/expiresAt optional, additionalProperties false) + `apps/cli/turn/turn-run.ts` (conditional spread into `EngineTurnRequest.pendingApproval`) | `tests/apps/turn-envelope-schema.test.ts` and `tests/apps/turn-run.test.ts` — valid envelope with pendingApproval passes boundary validation and reaches the engine request intact |
| REQ-002 / AC-002 | `apps/cli/turn/turn-run.ts` verdict mapping (zero engine changes: denied settles via the #187-merged engine path) | "#193 AC-002: denied verdict settles non-retryable with zero model consumption" PASS |
| REQ-003 / AC-003 | same mapping path; expired verdict fails closed through the #187 `engine.approval_expired` settlement | "#193 AC-003: an expired verdict fails closed with exactly one trusted terminal" PASS |
| REQ-001 / AC-004 | schema purely additive; envelopes without the field keep byte-identical behavior | "#193 AC-004: an envelope without pendingApproval keeps current behavior" PASS + full-suite regression |
| REQ-001 / AC-005 | envelope boundary is the first gate per the #173 spawn contract (exit 1 + stderr diagnostics before spawn); engine validation stays the byte-exact backstop | "#193 AC-005: a malformed verdict rejects at the envelope boundary, exit 1" PASS |

## File domains

- `configs/turn-envelope.schema.json` (+42) — additive optional `pendingApproval` property + `$defs/pendingApproval` object (required approvalId/decision/decidedBy; decision enum granted/denied; decidedBy const operator; scope enum once/run; bounded reason 1 KiB).
- `apps/cli/turn/envelope-schema.ts` (+14) — builder mirrors the JSON schema exactly (single-source discipline).
- `apps/cli/turn/envelope.ts` (+83/−1) — boundary validation diagnostics for malformed verdicts, fail-closed before spawn.
- `apps/cli/turn/turn-run.ts` (+3) — conditional pass-through into `EngineTurnRequest.pendingApproval`; nothing else touched.
- `tests/apps/turn-envelope-schema.test.ts` (+49), `tests/apps/turn-run.test.ts` (+182) — AC-001..AC-005 coverage.
- `CHANGELOG.md` (+15).
- `packages/engine` is untouched (zero engine changes, per the R2 design constraint).

## Scope and non-goals

Delivers CEO queue item ② from #187: the operator verdict channel on the `turn-envelope.v1` spawn surface, closing the approval loop end-to-end. Settlement semantics are consumed from #187/#191 verbatim; this PR adds no vocabulary.

**Not in scope** (explicitly separate):
- Any engine change — the engine gate is already merged (#191) and is the byte-exact backstop.
- Hire/create-type operations on the spawn surface (expressiveness gap assessed separately, CEO receipt 2026-08-26).
- UI/organization-side wiring — org-workbench #33 harness consumes this revision independently.
- Issue closure — per the no-auto-close discipline the Issue is closed manually with a merge-ledger comment.

## Validation

- Exact commands: `npm ci` ; `npx tsx --test --test-concurrency=1 tests/apps/turn-envelope-schema.test.ts tests/apps/turn-run.test.ts` ; `npm run check`
- Observed counts/results: PASS 31/31 changed-file tests (AC-001..AC-005, head 1758325, macOS arm64, Node v24); PASS typecheck/build/governance/security on `npm run check`; full-suite test stage PASS on CI Node 20 and Node 24 (see check URLs). Local full-suite replay shows load-sensitive deploy-cli timing flakes reproduced on a clean main c1a6ced baseline worktree (same failure without this PR's changes) — characterized in Known limitations.
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/pull/195/checks

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 / AC-001 | Envelope with a valid pendingApproval passes the boundary and reaches the engine request verbatim | `npx tsx --test --test-concurrency=1 tests/apps/turn-run.test.ts` | macOS arm64, Node v24, head 1758325 | request.pendingApproval field-equal to the envelope field | matched within 31/31 | PASS |
| V2 | REQ-002 / AC-002 | Denied verdict settles non-retryable with zero model consumption | same file, "#193 AC-002" case | 同上 | `engine.approval_denied`, retryable=false, zero consumption | matched | PASS |
| V3 | REQ-003 / AC-003 | Expired verdict fails closed with exactly one trusted terminal | same file, "#193 AC-003" case | 同上 | `engine.approval_expired`, exactly one terminal | matched | PASS |
| V4 | REQ-001 / AC-004 | Envelope without pendingApproval behaves identically | same file, "#193 AC-004" case + full suite | 同上 | byte-identical request; suite green | matched; CI Node 20/24 green | PASS |
| V5 | REQ-001 / AC-005 | Malformed verdict rejects at the envelope boundary, exit 1, before spawn | same files, "#193 AC-005" case | 同上 | exit 1 + stderr diagnostics, no spawn | matched | PASS |

## Security and compatibility

Purely additive schema change: `pendingApproval` is optional and bounded (approvalId ≤256 B, reason ≤1 KiB, closed enums, `additionalProperties: false`); envelopes without it are byte-identical to pre-change behavior (proven by AC-004 + full suite). No new dependency, no credential surface, no migration. Fail-closed posture preserved on both layers: the envelope boundary rejects malformed verdicts before any spawn per the #173 contract, and the engine's byte-exact validation remains the backstop — neither layer swallows errors. No vocabulary is introduced: `approval.*` events and settlement codes remain single-sourced from the #187/#191 engine contracts.

## Known limitations

- Local full-suite replays under heavy machine load reproduce timing-sensitive deploy-cli flakes (`HTTP activation protocol fails closed...` etc.); the identical failure reproduces on a clean main c1a6ced baseline worktree built the same way, and CI (isolated load) is green for the test stage — characterized as pre-existing load flakes unrelated to this PR (changed-file intersection with deploy-cli is empty; `packages/engine` untouched).
- The verdict channel is exercised at the envelope/request level (E3 fixtures); no E4 live turn was required by the R2 evidence plan.
- Spawn-surface employee-creation expressiveness (hire semantics) is explicitly out of scope and tracked separately.

## Risk and rollback

Risk is low and localized: seven files on the `apps/cli/turn` + config surface, reachable only when an envelope carries the new optional field; all existing callers observe identical behavior. Rollback: revert the single commit 1758325; no state, schema-store, or data impact.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: no release packet exists for this repository yet
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
