### PR TITLE
feat(cli): pendingApproval verdict field on turn-envelope.v1 spawn surface (#193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `turn-envelope.v1` gains an optional `pendingApproval` field (#193
+  REQ-001..REQ-003) so an operator verdict for a previously requested
+  approval can reach the #187 engine gate through the spawn surface. The
+  field shape is the engine `TurnPendingApprovalInput` verbatim
+  (`approvalId` / `decision: granted|denied` / `decidedBy: operator` /
+  `scope: once|run` / `reason?` / `expiresAt?`) — no parallel vocabulary —
+  and `turn run` maps it into `EngineTurnRequest.pendingApproval` with zero
+  engine changes: the verdict settles exactly as #187 already merged it
+  (granted proceeds with `approval.granted` before any model consumption,
+  denied settles `engine.approval_denied` `retryable=false` with zero
+  consumption, expired fails closed with `engine.approval_expired`). The
+  envelope boundary is the first gate and fails closed per the #173 spawn
+  contract (exit 1 + stderr diagnostics before spawn); the engine
+  validation stays the byte-exact backstop. The schema is purely additive:
+  envelopes without the field behave identically.
 - engine.v1 gains the approval three-event contract (#187 REQ-001..REQ-005,
   Option 1 terminal-and-resume): additive events `approval.requested`,
   `approval.granted`, `approval.denied` alongside the existing five event

--- a/apps/cli/turn/envelope-schema.ts
+++ b/apps/cli/turn/envelope-schema.ts
@@ -78,10 +78,24 @@ export function buildTurnEnvelopeSchema(): Record<string, unknown> {
       taskId: boundedIdSchema(),
       dayKey: boundedIdSchema(),
       deadline: { type: "string" },
+      pendingApproval: { $ref: "#/$defs/pendingApproval" },
       envelopeDigest: { type: "string", minLength: 1 },
     },
     $defs: {
       budgetScope: budgetScopeSchema(),
+      pendingApproval: {
+        type: "object",
+        additionalProperties: false,
+        required: ["approvalId", "decision", "decidedBy"],
+        properties: {
+          approvalId: boundedIdSchema(),
+          decision: { enum: ["granted", "denied"] },
+          decidedBy: { const: "operator" },
+          scope: { enum: ["once", "run"] },
+          reason: { type: "string", minLength: 1, maxLength: 1024 },
+          expiresAt: { type: "string" },
+        },
+      },
     },
   }
 }

--- a/apps/cli/turn/envelope.ts
+++ b/apps/cli/turn/envelope.ts
@@ -16,7 +16,10 @@ import {
   validatePositionBudgetDeclaration,
   type PositionBudgetDeclaration,
 } from "../../../packages/engine/src/budget.js"
-import type { TurnBudget } from "../../../packages/engine/src/contracts.js"
+import type {
+  TurnBudget,
+  TurnPendingApprovalInput,
+} from "../../../packages/engine/src/contracts.js"
 
 export const TURN_ENVELOPE_VERSION = "turn-envelope.v1" as const
 export const TURN_ENVELOPE_SCHEMA_ID =
@@ -55,6 +58,12 @@ export interface TurnEnvelope {
   taskId?: string
   dayKey?: string
   deadline?: string
+  /**
+   * Operator verdict for a previously requested approval (#193, consuming
+   * the #187 Option 1 engine gate). Shape is the engine
+   * `TurnPendingApprovalInput` verbatim — no parallel vocabulary.
+   */
+  pendingApproval?: TurnPendingApprovalInput
   envelopeDigest: string
 }
 
@@ -69,6 +78,10 @@ export class TurnEnvelopeError extends Error {
 }
 
 const MAX_ID_LENGTH = 256
+// Mirrors the engine's bounded-text cap for approval verdict reasons
+// (contracts.ts APPROVAL_DESCRIPTION_MAX_BYTES); the envelope gate rejects
+// oversized verdicts before spawn, the engine stays the byte-exact backstop.
+const MAX_APPROVAL_REASON_BYTES = 1024
 
 function canonicalJson(value: unknown): unknown {
   if (value === null || typeof value !== "object") return value
@@ -210,6 +223,73 @@ export function parseTurnEnvelope(raw: unknown): TurnEnvelope {
     }
   }
 
+  // Operator verdict for the #187 approval gate (#193): first-gate,
+  // fail-closed shape checks mirroring the engine's
+  // validateApprovalRequestFields; engine validation remains the backstop.
+  let pendingApproval: TurnPendingApprovalInput | undefined
+  if (raw.pendingApproval !== undefined) {
+    if (!isRecord(raw.pendingApproval)) {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "pendingApproval must be a JSON object",
+      )
+    }
+    const approvalId = assertBoundedId(
+      raw.pendingApproval.approvalId,
+      "pendingApproval.approvalId",
+    )
+    const decision = raw.pendingApproval.decision
+    if (decision !== "granted" && decision !== "denied") {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "pendingApproval.decision must be granted or denied",
+      )
+    }
+    if (raw.pendingApproval.decidedBy !== "operator") {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "pendingApproval.decidedBy must be operator",
+      )
+    }
+    const scope = raw.pendingApproval.scope
+    if (scope !== undefined && scope !== "once" && scope !== "run") {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "pendingApproval.scope must be once or run when present",
+      )
+    }
+    const reason = raw.pendingApproval.reason
+    if (
+      reason !== undefined &&
+      (typeof reason !== "string" ||
+        reason.trim().length === 0 ||
+        Buffer.byteLength(reason, "utf8") > MAX_APPROVAL_REASON_BYTES)
+    ) {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "pendingApproval.reason must be a non-empty string within the bounded size",
+      )
+    }
+    const expiresAt = raw.pendingApproval.expiresAt
+    if (
+      expiresAt !== undefined &&
+      (typeof expiresAt !== "string" || Number.isNaN(Date.parse(expiresAt)))
+    ) {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        "pendingApproval.expiresAt must be a valid ISO 8601 timestamp",
+      )
+    }
+    pendingApproval = {
+      approvalId,
+      decision,
+      decidedBy: "operator",
+      ...(scope !== undefined ? { scope } : {}),
+      ...(reason !== undefined ? { reason: reason as string } : {}),
+      ...(expiresAt !== undefined ? { expiresAt } : {}),
+    }
+  }
+
   if (typeof raw.envelopeDigest !== "string" || raw.envelopeDigest.length === 0) {
     throw new TurnEnvelopeError(
       "engine.envelope_invalid",
@@ -235,6 +315,7 @@ export function parseTurnEnvelope(raw: unknown): TurnEnvelope {
       ? { positionBudget, taskId, dayKey }
       : {}),
     ...(raw.deadline !== undefined ? { deadline: raw.deadline as string } : {}),
+    ...(pendingApproval !== undefined ? { pendingApproval } : {}),
     envelopeDigest: raw.envelopeDigest,
   }
 }

--- a/apps/cli/turn/turn-run.ts
+++ b/apps/cli/turn/turn-run.ts
@@ -276,6 +276,9 @@ export async function runTurn(options: TurnRunOptions): Promise<TurnRunResult> {
     ...(envelope.deadline !== undefined
       ? { deadline: envelope.deadline }
       : {}),
+    ...(envelope.pendingApproval !== undefined
+      ? { pendingApproval: envelope.pendingApproval }
+      : {}),
   }
 
   const escalationSink = createInMemoryEscalationSink()

--- a/configs/turn-envelope.schema.json
+++ b/configs/turn-envelope.schema.json
@@ -78,6 +78,9 @@
     "deadline": {
       "type": "string"
     },
+    "pendingApproval": {
+      "$ref": "#/$defs/pendingApproval"
+    },
     "envelopeDigest": {
       "type": "string",
       "minLength": 1
@@ -98,6 +101,45 @@
           "type": "integer",
           "exclusiveMinimum": 0,
           "maximum": 1000000000
+        }
+      }
+    },
+    "pendingApproval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "approvalId",
+        "decision",
+        "decidedBy"
+      ],
+      "properties": {
+        "approvalId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "decision": {
+          "enum": [
+            "granted",
+            "denied"
+          ]
+        },
+        "decidedBy": {
+          "const": "operator"
+        },
+        "scope": {
+          "enum": [
+            "once",
+            "run"
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        },
+        "expiresAt": {
+          "type": "string"
         }
       }
     }

--- a/tests/apps/turn-envelope-schema.test.ts
+++ b/tests/apps/turn-envelope-schema.test.ts
@@ -98,3 +98,52 @@ test("computeEnvelopeDigest is canonical: key order does not matter", () => {
   const b = computeEnvelopeDigest({ a: { c: [1, 2], d: 2 }, b: 1 })
   assert.equal(a, b)
 })
+
+test("#193: a sealed pendingApproval verdict is accepted at the envelope boundary", () => {
+  const envelope = parseTurnEnvelope(
+    sealedEnvelope({
+      pendingApproval: {
+        approvalId: "appr-1",
+        decision: "granted",
+        decidedBy: "operator",
+        scope: "once",
+        expiresAt: "2026-08-26T00:00:00.000Z",
+      },
+    }),
+  )
+  assert.equal(envelope.pendingApproval?.approvalId, "appr-1")
+  assert.equal(envelope.pendingApproval?.decision, "granted")
+})
+
+test("#193 AC-005: malformed pendingApproval shapes reject before consumption", () => {
+  const malformed: Array<Record<string, unknown>> = [
+    { approvalId: "appr-1", decision: "maybe", decidedBy: "operator" },
+    { approvalId: "appr-1", decision: "granted", decidedBy: "someone-else" },
+    { decision: "granted", decidedBy: "operator" },
+    {
+      approvalId: "appr-1",
+      decision: "granted",
+      decidedBy: "operator",
+      scope: "session",
+    },
+    {
+      approvalId: "appr-1",
+      decision: "denied",
+      decidedBy: "operator",
+      reason: "x".repeat(1025),
+    },
+    {
+      approvalId: "appr-1",
+      decision: "granted",
+      decidedBy: "operator",
+      expiresAt: "not-a-timestamp",
+    },
+  ]
+  for (const pendingApproval of malformed) {
+    assert.throws(
+      () => parseTurnEnvelope(sealedEnvelope({ pendingApproval })),
+      (error: unknown) =>
+        (error as { code?: string }).code === "engine.input_invalid",
+    )
+  }
+})

--- a/tests/apps/turn-run.test.ts
+++ b/tests/apps/turn-run.test.ts
@@ -518,3 +518,185 @@ test("#185 AC-003: a missing qodercli binary is an environment fault, not a verd
     diagnostics.some((line) => line.includes("qoder_binary_unavailable")),
   )
 })
+
+// #193: pendingApproval verdict fixtures — the five envelope forms
+// (granted / denied / expired / malformed / absent) settling through the
+// already-merged #187 engine gate with zero new engine changes.
+
+test("#193 AC-001: granted verdict emits approval.granted before any model consumption", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, {
+    pendingApproval: {
+      approvalId: "appr-granted-1",
+      decision: "granted",
+      decidedBy: "operator",
+      scope: "once",
+    },
+  })
+  let modelCalls = 0
+  let modelCallsAtGranted = -1
+  const events: Array<Record<string, unknown>> = []
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText: JSON.stringify(envelope),
+    model: {
+      async complete() {
+        modelCalls += 1
+        return { text: "write executed under approval" }
+      },
+    },
+    writeEvent: (line) => {
+      const event = JSON.parse(line) as Record<string, unknown>
+      events.push(event)
+      if (event.type === "approval.granted") modelCallsAtGranted = modelCalls
+    },
+    writeDiagnostic: () => undefined,
+  })
+  assert.equal(result.exitCode, 0)
+  assert.equal(
+    modelCallsAtGranted,
+    0,
+    "approval.granted must precede any model consumption",
+  )
+  assert.equal(modelCalls, 1)
+  const granted = events.find((event) => event.type === "approval.granted")
+  assert.ok(granted)
+  assert.equal(granted!.approvalId, "appr-granted-1")
+  const grantedIndex = events.indexOf(granted!)
+  const terminal = events.find((event) => event.type === "run.completed")
+  assert.ok(terminal)
+  assert.ok(events.indexOf(terminal!) > grantedIndex)
+})
+
+test("#193 AC-002: denied verdict settles non-retryable with zero model consumption", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, {
+    pendingApproval: {
+      approvalId: "appr-denied-1",
+      decision: "denied",
+      decidedBy: "operator",
+      reason: "out of window",
+    },
+  })
+  let modelCalls = 0
+  const events: Array<Record<string, unknown>> = []
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText: JSON.stringify(envelope),
+    model: {
+      async complete() {
+        modelCalls += 1
+        return { text: "never" }
+      },
+    },
+    writeEvent: (line) => events.push(JSON.parse(line)),
+    writeDiagnostic: () => undefined,
+  })
+  assert.equal(result.exitCode, 0)
+  assert.equal(result.terminalEmitted, true)
+  assert.equal(modelCalls, 0)
+  const deniedIndex = events.findIndex(
+    (event) => event.type === "approval.denied",
+  )
+  assert.ok(deniedIndex >= 0)
+  assert.equal(events[deniedIndex]!.reason, "out of window")
+  const terminal = events.find((event) => event.type === "run.failed")
+  assert.ok(terminal)
+  assert.ok(events.indexOf(terminal!) > deniedIndex)
+  const error = terminal!.error as {
+    code: string
+    retryable: boolean
+    terminalReason: string
+  }
+  assert.equal(error.code, "engine.approval_denied")
+  assert.equal(error.retryable, false)
+  assert.equal(error.terminalReason, "cancelled")
+})
+
+test("#193 AC-003: an expired verdict fails closed with exactly one trusted terminal", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, {
+    pendingApproval: {
+      approvalId: "appr-expired-1",
+      decision: "granted",
+      decidedBy: "operator",
+      expiresAt: "2020-01-01T00:00:00.000Z",
+    },
+  })
+  let modelCalls = 0
+  const events: Array<Record<string, unknown>> = []
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText: JSON.stringify(envelope),
+    model: {
+      async complete() {
+        modelCalls += 1
+        return { text: "never" }
+      },
+    },
+    writeEvent: (line) => events.push(JSON.parse(line)),
+    writeDiagnostic: () => undefined,
+  })
+  assert.equal(result.exitCode, 0)
+  assert.equal(modelCalls, 0)
+  const terminals = events.filter((event) => event.type === "run.failed")
+  assert.equal(terminals.length, 1)
+  const error = terminals[0]!.error as { code: string; retryable: boolean }
+  assert.equal(error.code, "engine.approval_expired")
+  assert.equal(error.retryable, false)
+})
+
+test("#193 AC-005: a malformed verdict rejects at the envelope boundary, exit 1", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, {
+    pendingApproval: {
+      approvalId: "appr-bad-1",
+      decision: "maybe",
+      decidedBy: "operator",
+    },
+  })
+  let modelCalls = 0
+  const events: Array<Record<string, unknown>> = []
+  const diagnostics: string[] = []
+  const result = await runTurn({
+    workspace,
+    positionId: "repo-owner",
+    envelopeText: JSON.stringify(envelope),
+    model: {
+      async complete() {
+        modelCalls += 1
+        return { text: "never" }
+      },
+    },
+    writeEvent: (line) => events.push(JSON.parse(line)),
+    writeDiagnostic: (line) => diagnostics.push(line),
+  })
+  assert.equal(result.exitCode, 1)
+  assert.equal(result.terminalEmitted, false)
+  assert.equal(events.length, 0)
+  assert.equal(modelCalls, 0)
+  assert.ok(
+    diagnostics.some((line) => line.includes("engine.input_invalid")),
+  )
+})
+
+test("#193 AC-004: an envelope without pendingApproval keeps current behavior", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace)
+  const { result, events } = await execute(
+    workspace,
+    JSON.stringify(envelope),
+    createDeterministicModelPort(["done without a verdict"]),
+  )
+  assert.equal(result.exitCode, 0)
+  assert.ok(events.some((event) => event.type === "run.completed"))
+  assert.ok(
+    !events.some((event) =>
+      String(event.type).startsWith("approval."),
+    ),
+    "no approval lifecycle events without a verdict field",
+  )
+})


### PR DESCRIPTION
## WHY

Issue #193（CEO 裁决方案 B：#187 已闭环，pendingApproval 的 spawn 面接线独立成 issue）。#187/#191 合入了 engine 侧 approval 三事件契约（terminal-and-resume），但操作员裁决（granted/denied）目前没有任何方式从 spawn 面送达 engine gate——队列项②。本 PR 补上这条通路，使 approval 全链路闭环。

## WHAT

`turn-envelope.v1` 新增可选 `pendingApproval` 字段（REQ-001..REQ-003）：
- 字段形状即 engine `TurnPendingApprovalInput` 原样（`approvalId` / `decision: granted|denied` / `decidedBy: operator` / `scope: once|run` / `reason?` / `expiresAt?`）——无平行词表。
- `turn run` 将其映射进 `EngineTurnRequest.pendingApproval`，engine 零改动：裁决按 #187 已合入语义结算（granted 在任何 model 消耗前发 `approval.granted`；denied 结算 `engine.approval_denied` `retryable=false` 零消耗；expired 以 `engine.approval_expired` fail closed）。
- envelope 边界是第一道门，按 #173 spawn 契约 fail closed（exit 1 + stderr 诊断先于 spawn）；engine 校验保持 byte-exact 兜底。
- schema 纯增量：不带该字段的 envelope 行为完全不变。

## WHERE

- `configs/turn-envelope.schema.json` — schema 增量（唯一真源）
- `apps/cli/turn/envelope-schema.ts` / `envelope.ts` — 校验与映射
- `apps/cli/turn/turn-run.ts` — `EngineTurnRequest.pendingApproval` 接线
- `tests/apps/turn-envelope-schema.test.ts` / `turn-run.test.ts` — AC 用例
- `CHANGELOG.md`

engine 包零变更。

## HOW MUCH

7 文件 +387/−1。新增/改动测试 31/31 绿。

## DONE（对应 AC）

- AC-001 envelope 携带合法 pendingApproval 通过校验并送达 engine request ✔
- AC-002 denied 裁决以零 model 消耗不可重试结算 ✔
- AC-003 expired 裁决 fail closed 且恰有一个 trusted terminal ✔
- AC-004 不带 pendingApproval 的 envelope 行为不变 ✔
- AC-005 畸形裁决在 envelope 边界即拒，exit 1 ✔

## DON'T

- 不新增任何 engine 词表/事件（approval.* 词表仍单源 #187 contracts.ts）
- 不改 #187 已合入的结算语义
- 不引入 hire/create 类操作（spawn 面创建员工表达力缺口另立 #194 契约面）
- 不做 UI/组织侧接线（org-workbench #33 harness 自行消费本 revision）

## 证据

- 本地：改动文件相关测试 31/31 绿（tests/apps/turn-envelope-schema.test.ts + turn-run.test.ts）；全量门禁 typecheck/build/governance/security 段通过。
- deploy-cli 若干时序敏感用例（HTTP activation / lock deadline / descriptor lock / DingTalk timeout 类）本机复现失败，判定为负载相关既有 flake：①与本 PR 改动文件零交集；②main CI 近 5 次全绿（run 32867830529 等）；③干净 main worktree（c1a6ced，fresh npm ci + build）复跑同一文件复现同款失败——HTTP activation protocol fails closed（55.8s）、every explicit empty or whitespace deploy value（313.7s）、HTTP PID reuse with mismatched argv（5.5s）。
- CI：required checks 全绿方可合入。

## Consumed revision

本 PR 消费 digital-employee main c1a6ced（#192 合入后 HEAD）。

## 关联

Closes #193 · 前序 #187/#191（engine 契约）、#190（codex 映射）· 后续 org-workbench #33 harness 与本仓 #194 hire 契约面消费本 revision。