### PR TITLE
feat(contract): hire-request.v1alpha1 hire channel and employee-package identity segment (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,37 @@ All notable changes to this project will be documented in this file.
   envelopes, adjudicated on Issue #178), and `docs/flaky-tests.md` archives
   the timing-sensitive deploy-cli cases adjudicated under the
   clean-main-baseline method during #193/#195.
+- `hire-request.v1alpha1` contract surface (#194 R4 freeze): a thin
+  reference envelope that references a sealed employee package
+  (`packageRef` with `name`/`version`/`digest`, no `localReference`
+  channel), a sealed turn envelope (`envelopeDigest`), and an opaque
+  org-tree placement reference (`targetParentId`, validated as bounded text
+  only — tree resolution belongs to the consumer org-workbench). New
+  published schema `configs/hire-request.schema.json` (byte-identical to
+  the code-side builder `buildHireRequestSchema()`), core validator
+  `validateHireRequest`, and CLI `digital-employee hire validate <file>
+  [--json]`. Validation is static and fail-closed: no spawn, no engine, no
+  paid calls, no provider; any violation exits 1 before any effect with a
+  stable diagnostic code (`hire_request_unknown_field:<path>`,
+  `hire_request_invalid_field:<path>`, `hire_request_missing_budget`).
+  Budget is attached at hire time: `budget` with `perTask`/`perDay` scopes
+  is required, and a hire without a budget is rejected. The budget scope
+  vocabulary is byte-aligned with the engine `BudgetScope` and the
+  turn-envelope.v1 `$defs/budgetScope` (`tokens`/`iterations`, positive
+  integers capped at 1,000,000,000, at least one declared). No approval
+  semantics, no `pendingApproval`, no engine changes.
+- `employee-package.v1alpha1` gains an optional `identity` segment (#194):
+  human-facing expressiveness only — `name` stays the machine identifier.
+  `displayName` (required, 1–64 chars), `avatar` (exactly
+  `{ "asset": <portablePath> }`, content-addressed against the package
+  `assets` list, no URL channel), `persona` (≤2048 chars) and `roleId`
+  (`^[a-z][a-z0-9-]{0,63}$`, resolved in the consumer org-workbench, never
+  here). `reportTo` does not belong in `identity` and fails closed. Inside
+  `identity`, unknown fields are additive: accepted with a collected warning
+  surfaced by `digital-employee validate` (`warnings` array under `--json`,
+  one stderr line otherwise) while the exit code stays 0; outside
+  `identity` unknown fields are still rejected. Packages without the
+  segment validate exactly as in 0.4.0.
 - `turn-envelope.v1` gains an optional `pendingApproval` field (#193
   REQ-001..REQ-003) so an operator verdict for a previously requested
   approval can reach the #187 engine gate through the spawn surface. The

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ company-internal transactions stay private.
 
 - [Install and Agent Host setup](INSTALL.md)
 - [Employee package contract](docs/employee-package.md)
+- [Hire request contract](docs/hire-contract.md)
 - [Agent Host support policy](docs/agent-hosts.md)
 - [Deploy contract and recovery](docs/deploy.md)
 - [Runner integration boundary](docs/runner.md)

--- a/apps/cli/bin.ts
+++ b/apps/cli/bin.ts
@@ -30,6 +30,7 @@ import { workspace, renderWorkspaceParseFailure } from "./workspace/index.js";
 import { org, renderOrgParseFailure } from "./org/index.js";
 import { turn } from "./turn/index.js";
 import { task } from "./task/index.js";
+import { hire } from "./hire.js";
 import { setup } from "./setup.js";
 
 type EmployeeResult = Awaited<ReturnType<DigitalEmployee["answer"]>>;
@@ -75,6 +76,7 @@ Agent-native usage:
   digital-employee org scope <position> [workspace] [--tool <name> | --context <path>] [--json]
   digital-employee turn run [workspace] --position <id> (--stdin | --input-file <path>)
   digital-employee task delegate [workspace] --stdin --history-file <workspace-local-path>
+  digital-employee hire validate <file> [--json]
   digital-employee deploy [package-path] [--package path] --channel <id> --engine <id> --runtime agent-native|standalone-v1 [options]
   digital-employee doctor [--engine claude-code|qoder|codex|qwen-code|codebuddy] [--json]
   digital-employee init <directory> [--recipe minimal-answer.v1|structured-action.v1] [--name employee-name] [--author author]
@@ -403,6 +405,9 @@ async function validate(values: CommandValues, positionals: string[]) {
       schemaVersion: inspected.manifest.schemaVersion
     },
     files: inspected.files,
+    ...(inspected.warnings && inspected.warnings.length > 0
+      ? { warnings: inspected.warnings }
+      : {}),
     ...(host ? { host, compatibility } : {})
   };
   if (values.json) {
@@ -412,6 +417,9 @@ async function validate(values: CommandValues, positionals: string[]) {
       `Static package valid: ${result.employee.name}@${result.employee.version}\n`
     );
     process.stdout.write(`Checked ${result.files.length} declared file(s).\n`);
+    for (const warning of inspected.warnings ?? []) {
+      process.stderr.write(`warning: ${warning}\n`);
+    }
     if (host && compatibility) {
       process.stdout.write(
         `${host.displayName}: ${compatibility.compatible ? "compatible" : "incompatible"}\n`
@@ -579,7 +587,7 @@ async function main() {
     throw error;
   }
   const { command, values, positionals, providedOptions } = parsed;
-  if (command === "help" || (values.help && command !== "deploy" && command !== "workspace" && command !== "org" && command !== "turn" && command !== "task")) {
+  if (command === "help" || (values.help && command !== "deploy" && command !== "workspace" && command !== "org" && command !== "turn" && command !== "task" && command !== "hire")) {
     process.stdout.write(usage());
     return;
   }
@@ -645,6 +653,12 @@ async function main() {
     args: positionals.slice(1),
     stdin: values.stdin,
     historyFile: values.historyFile,
+    json: values.json,
+    help: values.help,
+  });
+  if (command === "hire") return hire({
+    subcommand: positionals[0],
+    args: positionals.slice(1),
     json: values.json,
     help: values.help,
   });

--- a/apps/cli/employee-package.ts
+++ b/apps/cli/employee-package.ts
@@ -78,6 +78,11 @@ export interface EmployeePackageInspection extends EmployeePackageSummary {
     outputSchema: Record<string, unknown>
     mcp?: EmployeeMcpManifest
   }
+  /**
+   * Non-fatal diagnostics collected during validation (#194): additive
+   * unknown fields inside `identity` warn instead of failing closed.
+   */
+  warnings?: string[]
 }
 
 /** @internal Coordinates deterministic path-replacement security tests. */
@@ -641,7 +646,11 @@ export async function inspectEmployeePackage(
   } catch {
     throw new TypeError("employee_package_manifest_invalid_json")
   }
-  const manifest = validateEmployeePackageManifest(manifestValue)
+  const manifestWarnings: string[] = []
+  const manifest = validateEmployeePackageManifest(
+    manifestValue,
+    manifestWarnings,
+  )
 
   const entrypointFiles = [
     manifest.entrypoints.skill,
@@ -735,6 +744,7 @@ export async function inspectEmployeePackage(
       outputSchema,
       ...(mcpManifest ? { mcp: mcpManifest } : {}),
     },
+    ...(manifestWarnings.length > 0 ? { warnings: manifestWarnings } : {}),
   }
   inspectionDigestEntries.set(inspection, [
     { path: manifestPortablePath, bytes: manifestBytes },

--- a/apps/cli/hire.ts
+++ b/apps/cli/hire.ts
@@ -1,0 +1,100 @@
+/**
+ * `digital-employee hire` command surface (#194, R4 freeze). Subcommand:
+ *
+ *   hire validate <file> [--json]
+ *
+ * The hire channel is a static contract surface: it validates a
+ * hire-request.v1alpha1 reference envelope and stops. No spawn, no engine,
+ * no paid calls, no provider. Violations fail closed before any effect:
+ * exit 1 plus a stable diagnostic code (one stderr line, or
+ * `{ "status": "failed", "code": ... }` under `--json`).
+ */
+
+import { readFile } from "node:fs/promises"
+
+import {
+  HireRequestError,
+  validateHireRequest,
+} from "../../packages/core/src/hire-request.js"
+
+export interface HireOptions {
+  subcommand?: string
+  args: string[]
+  json?: boolean
+  help?: boolean
+}
+
+/** Bounded input: a hire request is a thin reference envelope. */
+const HIRE_REQUEST_MAX_BYTES = 256 * 1024
+
+function hireUsage(): string {
+  return `digital-employee hire validate <file> [--json]
+
+Static validation of a hire-request.v1alpha1 reference envelope (#194).
+No spawn, no engine, no model/provider calls. Exit 0 = valid; exit 1 =
+fail-closed diagnostic (stderr line, or { "status": "failed", "code" } under --json).
+`
+}
+
+function fail(code: string, json: boolean): void {
+  if (json) {
+    process.stdout.write(
+      `${JSON.stringify({ status: "failed", code }, null, 2)}\n`,
+    )
+  } else {
+    process.stderr.write(`digital-employee: ${code}\n`)
+  }
+  process.exitCode = 1
+}
+
+export async function hire(options: HireOptions): Promise<void> {
+  if (options.help) {
+    process.stdout.write(hireUsage())
+    return
+  }
+  if (options.subcommand !== "validate") {
+    throw new TypeError(
+      `unknown_hire_subcommand:${options.subcommand || "missing"}`,
+    )
+  }
+  const file = options.args[0]
+  if (!file) throw new TypeError("hire_validate_requires_file")
+  if (options.args.length > 1) {
+    throw new TypeError("hire_validate_accepts_one_file")
+  }
+
+  let text: string
+  try {
+    text = await readFile(file, "utf8")
+  } catch {
+    return fail("hire_request_file_unreadable", Boolean(options.json))
+  }
+  if (Buffer.byteLength(text, "utf8") > HIRE_REQUEST_MAX_BYTES) {
+    return fail("hire_request_too_large", Boolean(options.json))
+  }
+
+  let raw: unknown
+  try {
+    raw = JSON.parse(text)
+  } catch {
+    return fail("hire_request_invalid_json", Boolean(options.json))
+  }
+
+  try {
+    const request = validateHireRequest(raw)
+    if (options.json) {
+      process.stdout.write(
+        `${JSON.stringify({ status: "valid", hire: request }, null, 2)}\n`,
+      )
+    } else {
+      process.stdout.write(
+        `hire request valid: ${request.packageRef.name}@${request.packageRef.version}\n`,
+      )
+    }
+  } catch (error) {
+    if (error instanceof HireRequestError) {
+      return fail(error.code, Boolean(options.json))
+    }
+    throw error
+  }
+}

--- a/configs/employee-package.schema.json
+++ b/configs/employee-package.schema.json
@@ -50,6 +50,41 @@
         "maxLength": 256
       }
     },
+    "identity": {
+      "type": "object",
+      "required": [
+        "displayName"
+      ],
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "avatar": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "asset"
+          ],
+          "properties": {
+            "asset": {
+              "$ref": "#/$defs/portablePath"
+            }
+          }
+        },
+        "persona": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048
+        },
+        "roleId": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]{0,63}$"
+        },
+        "reportTo": false
+      }
+    },
     "host": {
       "type": "object",
       "additionalProperties": false,

--- a/configs/hire-request.schema.json
+++ b/configs/hire-request.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/fullstack-ai-infra/digital-employee/main/configs/hire-request.schema.json",
+  "title": "hire-request.v1alpha1 hire request reference envelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "workspaceRef",
+    "packageRef",
+    "targetParentId",
+    "budget",
+    "requestedBy",
+    "envelopeDigest"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "hire-request.v1alpha1"
+    },
+    "workspaceRef": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "packageRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "digest"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^v1alpha1(\\.[0-9]+)?$"
+        },
+        "digest": {
+          "type": "string",
+          "minLength": 16
+        }
+      }
+    },
+    "targetParentId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "perTask",
+        "perDay"
+      ],
+      "properties": {
+        "perTask": {
+          "$ref": "#/$defs/budgetScope"
+        },
+        "perDay": {
+          "$ref": "#/$defs/budgetScope"
+        }
+      }
+    },
+    "requestedBy": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "deadline": {
+      "type": "string"
+    },
+    "envelopeDigest": {
+      "type": "string",
+      "minLength": 16
+    }
+  },
+  "$defs": {
+    "budgetScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "tokens": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000
+        },
+        "iterations": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000
+        }
+      }
+    }
+  }
+}

--- a/docs/employee-package.md
+++ b/docs/employee-package.md
@@ -206,6 +206,7 @@ live-response benchmarks.
 | `entrypoints.mcp` | Optional stdio/HTTPS MCP declaration with environment-variable secret references only |
 | `policy` | Abstract filesystem, network, MCP and approval requirements; every MCP tool requests a maximum read/write mode |
 | `assets` | Explicit regular files shipped with the package |
+| `identity` | Optional human-facing identity segment (#194); `name` remains the machine identifier |
 
 All file references use forward-slash `./` paths. Artifact paths and policy
 globs are validated separately. Absolute paths, parent traversal, undeclared
@@ -214,6 +215,31 @@ containment check. File count and total size are bounded. Secret values and
 local account identifiers do not
 belong in a package; a deployment binds secret names through its host or
 service environment.
+
+## Identity segment (#194)
+
+The optional `identity` object carries human-facing expressiveness only. It
+never replaces `name`, which stays the stable machine identifier, and it
+carries no authority: nothing inside `identity` changes policy, capabilities
+or approval behavior.
+
+| Field | Meaning |
+| --- | --- |
+| `identity.displayName` | Required display name; string of 1–64 characters |
+| `identity.avatar` | Optional content-addressed avatar: exactly `{ "asset": "<portablePath>" }`; the asset must be an entry in `assets`. There is no URL channel |
+| `identity.persona` | Optional persona text; string of at most 2048 characters |
+| `identity.roleId` | Optional role identifier matching `^[a-z][a-z0-9-]{0,63}$`; resolution against a role vocabulary happens in the consumer (org-workbench), never in this validator |
+
+`reportTo` does not belong in `identity`: org placement is a consumer concern
+(org-workbench), and packages declaring it fail closed.
+
+Unknown-field policy inside `identity` is additive: extra fields are accepted
+and preserved, but each produces a collected warning instead of failing
+closed. `digital-employee validate` surfaces the warnings — as a `warnings`
+array under `--json`, one stderr line per warning otherwise — while keeping
+exit code 0 for a valid package. Outside `identity`, unknown fields are still
+rejected. Packages without an `identity` segment validate exactly as in
+0.4.0.
 
 An MCP tool's `requestedMode` is a request, never a self-granted safety label.
 Before a runnable adapter exposes the tool, preflight must compare the request

--- a/docs/hire-contract.md
+++ b/docs/hire-contract.md
@@ -1,0 +1,74 @@
+# Hire request contract (hire-request.v1alpha1)
+
+The hire request is a thin reference envelope (#194, R4 freeze). It
+REFERENCES a sealed employee package and a sealed turn envelope, and names
+where the employee would hang in the org tree. It does not spawn anything,
+call the engine, invoke a model or provider, or mutate any tree.
+
+```
+digital-employee hire validate <file> [--json]
+```
+
+Validation is static and fail-closed. Exit 0 means the document is a valid
+`hire-request.v1alpha1`. Any violation exits 1 before any effect, with a
+stable machine-readable diagnostic code — one stderr line
+(`digital-employee: <code>`), or `{ "status": "failed", "code": ... }` on
+stdout under `--json`.
+
+## Fields
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `schemaVersion` | yes | Const `"hire-request.v1alpha1"` |
+| `workspaceRef` | yes | Non-empty string, bounded to 256 characters — the same constraints as turn-envelope.v1 `workspaceRef` |
+| `packageRef` | yes | Exactly `{ "name", "version", "digest" }`; no other fields. `name` is a non-empty bounded string, `version` matches `^v1alpha1(\.[0-9]+)?$`, `digest` is a string of at least 16 characters. There is no `localReference` channel |
+| `targetParentId` | yes | Non-empty opaque string (bounded to 256 characters). Validated as text only: no tree lookup, no import of org-workbench |
+| `budget` | yes | `{ "perTask": budgetScope, "perDay": budgetScope }` — a hire without a budget fails closed |
+| `requestedBy` | yes | Non-empty bounded string naming the requester |
+| `deadline` | no | String, handled exactly like turn-envelope.v1 `deadline` (must be parseable as an ISO 8601 timestamp) |
+| `envelopeDigest` | yes | String of at least 16 characters referencing the sealed turn envelope |
+
+Unknown fields are rejected at every level (`hire_request_unknown_field:<path>`).
+
+### budgetScope vocabulary
+
+Each `budgetScope` is an object with optional `tokens` and `iterations`
+(positive integers, each between 1 and 1,000,000,000), at least one of the
+two declared, and no other fields. The vocabulary is byte-aligned with the
+engine `BudgetScope` and the published turn-envelope.v1 `$defs/budgetScope`
+(#194 AC-005); the cap mirrors `MAX_BUDGET_CAP` in
+`packages/engine/src/budget.ts`.
+
+## Fail-closed diagnostics
+
+| Code | Meaning |
+| --- | --- |
+| `hire_request_unknown_field:<path>` | Field not part of the frozen contract |
+| `hire_request_invalid_field:<path>` | Missing required field or value violates its constraint |
+| `hire_request_missing_budget` | `budget` absent — hiring without a budget is rejected |
+| `hire_request_file_unreadable` | The file cannot be read |
+| `hire_request_too_large` | Input exceeds the bounded envelope size |
+| `hire_request_invalid_json` | Input is not valid JSON |
+
+## Budget-attached rule
+
+A hire request without `budget` is not a warning; it is a rejection. Budget
+is attached at hire time so every spawned task inherits declared per-task and
+per-day caps instead of negotiating them after the fact.
+
+## Consumer boundary
+
+This contract deliberately stops at validation:
+
+- `targetParentId` is opaque here (#194 AC-003). Resolving it against the
+  org tree is the consumer's job (org-workbench #33); this repo performs no
+  tree validation and no org-workbench import.
+- `identity.roleId` on the employee package is likewise unresolved here; the
+  consumer resolves it against its role vocabulary.
+- There are no approval semantics on the hire channel: no `pendingApproval`,
+  no new approval vocabulary, and no engine changes.
+
+The published schema is `configs/hire-request.schema.json`; it is
+byte-identical to the code-side builder `buildHireRequestSchema()`
+(`packages/core/src/hire-request.ts`), enforced by the schema-consistency
+test.

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -218,7 +218,23 @@ export {
   deriveEmployeeHostRequirements,
   validateEmployeePackageManifest,
 } from "./src/employee-package.js"
-export type { EmployeePackageManifest } from "./src/employee-package.js"
+export type {
+  EmployeePackageIdentity,
+  EmployeePackageManifest,
+} from "./src/employee-package.js"
+export {
+  HIRE_REQUEST_SCHEMA_ID,
+  HIRE_REQUEST_SCHEMA_VERSION,
+  HireRequestError,
+  buildHireRequestSchema,
+  validateHireRequest,
+} from "./src/hire-request.js"
+export type {
+  HireRequest,
+  HireRequestBudget,
+  HireRequestBudgetScope,
+  HireRequestPackageRef,
+} from "./src/hire-request.js"
 export {
   EMPLOYEE_PACKAGE_DIGEST_DOMAIN,
   computeEmployeePackageDigest,

--- a/packages/core/src/employee-package-compat.ts
+++ b/packages/core/src/employee-package-compat.ts
@@ -108,6 +108,7 @@ export const EMPLOYEE_PACKAGE_KNOWN_FIELDS = Object.freeze({
     "description",
     "license",
     "authors",
+    "identity",
     "host",
     "entrypoints",
     "policy",
@@ -118,6 +119,8 @@ export const EMPLOYEE_PACKAGE_KNOWN_FIELDS = Object.freeze({
   policy: ["mode", "network", "filesystem", "mcpTools"],
   "policy.filesystem": ["read", "write"],
   "policy.mcpTools[]": ["name", "requestedMode"],
+  identity: ["displayName", "avatar", "persona", "roleId"],
+  "identity.avatar": ["asset"],
 } as const)
 
 /**

--- a/packages/core/src/employee-package.ts
+++ b/packages/core/src/employee-package.ts
@@ -14,6 +14,27 @@ const SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
 const LICENSE_PATTERN = /^[A-Za-z0-9.+-]{1,128}$/
 const PORTABLE_PATH_PATTERN = /^\.\/(?!.*\\)[^\u0000-\u001f\u007f]+$/
+const IDENTITY_ROLE_ID_PATTERN = /^[a-z][a-z0-9-]{0,63}$/
+const IDENTITY_KNOWN_FIELDS = ["displayName", "avatar", "persona", "roleId"]
+
+/**
+ * Optional identity segment (#194). Human-facing expressiveness only: the
+ * package-level `name` remains the machine identifier. Vocabulary resolution
+ * (roleId) and org placement (reportTo) belong to the consumer org-workbench,
+ * never to this validator.
+ */
+export interface EmployeePackageIdentity {
+  displayName: string
+  /** Content-addressed avatar: `asset` must be an entry in `assets`. */
+  avatar?: { asset: string }
+  persona?: string
+  roleId?: string
+  /**
+   * Additive extension point: unknown fields inside identity are accepted
+   * with a collected warning instead of failing closed (#194 R4 freeze).
+   */
+  readonly [field: string]: unknown
+}
 
 export interface EmployeePackageManifest {
   $schema?: string
@@ -23,6 +44,7 @@ export interface EmployeePackageManifest {
   description: string
   license: string
   authors: string[]
+  identity?: EmployeePackageIdentity
   host: {
     protocol: typeof AGENT_HOST_PROTOCOL_VERSION
     requiredCapabilities: AgentHostCapability[]
@@ -262,6 +284,58 @@ function validateMcpTools(
   })
 }
 
+/**
+ * Validate the optional identity segment (#194). Unknown fields INSIDE
+ * identity are additive: they are preserved and produce a collected warning
+ * instead of failing closed. `reportTo` is rejected outright because org
+ * placement belongs to the consumer (org-workbench), never to the package.
+ */
+function validateIdentity(
+  value: unknown,
+  assets: readonly string[],
+  warnings: string[],
+): EmployeePackageIdentity {
+  assertPlainObject(value, "identity")
+  if (Object.prototype.hasOwnProperty.call(value, "reportTo")) {
+    throw packageError("employee_package_unknown_field:identity.reportTo", {
+      field: "identity.reportTo",
+    })
+  }
+  const identity: Record<string, unknown> = {}
+  for (const [key, entry] of Object.entries(value)) {
+    if (!IDENTITY_KNOWN_FIELDS.includes(key)) {
+      warnings.push(`employee_package_identity_unknown_field:${key}`)
+      identity[key] = entry
+    }
+  }
+  identity.displayName = requireString(value.displayName, "identity.displayName", {
+    maxLength: 64,
+  })
+  if (value.avatar !== undefined) {
+    const avatar = assertKnownKeys(value.avatar, ["asset"], "identity.avatar")
+    const asset = portableFilePath(avatar.asset, "identity.avatar.asset")
+    if (!assets.includes(asset)) {
+      throw packageError("employee_package_identity_avatar_asset_unknown", {
+        field: "identity.avatar.asset",
+        asset,
+      })
+    }
+    identity.avatar = { asset }
+  }
+  if (value.persona !== undefined) {
+    identity.persona = requireString(value.persona, "identity.persona", {
+      maxLength: 2_048,
+    })
+  }
+  if (value.roleId !== undefined) {
+    identity.roleId = requireString(value.roleId, "identity.roleId", {
+      pattern: IDENTITY_ROLE_ID_PATTERN,
+      maxLength: 64,
+    })
+  }
+  return identity as unknown as EmployeePackageIdentity
+}
+
 function deepFreeze<T>(value: T): T {
   if (!value || typeof value !== "object" || Object.isFrozen(value)) return value
   for (const item of Object.values(value as UnknownRecord)) deepFreeze(item)
@@ -270,6 +344,7 @@ function deepFreeze<T>(value: T): T {
 
 export function validateEmployeePackageManifest(
   input: unknown,
+  warnings: string[] = [],
 ): EmployeePackageManifest {
   const manifest = assertKnownKeys(
     input,
@@ -281,6 +356,7 @@ export function validateEmployeePackageManifest(
       "description",
       "license",
       "authors",
+      "identity",
       "host",
       "entrypoints",
       "policy",
@@ -356,6 +432,8 @@ export function validateEmployeePackageManifest(
     throw packageError("mcp_tools_require_mcp_entrypoint")
   }
 
+  const assets = portablePathList(manifest.assets, "assets", portableFilePath)
+
   const result: EmployeePackageManifest = {
     ...(manifest.$schema
       ? { $schema: requireString(manifest.$schema, "$schema", { maxLength: 2_000 }) }
@@ -405,7 +483,11 @@ export function validateEmployeePackageManifest(
       },
       mcpTools,
     },
-    assets: portablePathList(manifest.assets, "assets", portableFilePath),
+    assets,
+  }
+
+  if (manifest.identity !== undefined) {
+    result.identity = validateIdentity(manifest.identity, assets, warnings)
   }
 
   if (result.authors.length === 0) {

--- a/packages/core/src/hire-request.ts
+++ b/packages/core/src/hire-request.ts
@@ -1,0 +1,367 @@
+/**
+ * hire-request.v1alpha1 — the thin reference envelope for the hire channel
+ * (#194, R4 freeze). A hire request only REFERENCES a sealed turn envelope
+ * and names where the employee would hang in the org tree; it never spawns,
+ * imports org-workbench, or touches the engine. Validation is static and
+ * fail-closed: any violation exits before any effect, with a stable
+ * machine-readable diagnostic code on stderr.
+ *
+ * Budget discipline: a hire without a budget fails closed (#194 AC-005).
+ * The budget scope vocabulary is byte-aligned with the engine BudgetScope
+ * and the turn-envelope.v1 `$defs/budgetScope` published vocabulary — the
+ * cap constant mirrors `packages/engine/src/budget.ts` MAX_BUDGET_CAP
+ * (mirrored locally because core must not import engine).
+ */
+
+export const HIRE_REQUEST_SCHEMA_VERSION = "hire-request.v1alpha1" as const
+export const HIRE_REQUEST_SCHEMA_ID =
+  "https://raw.githubusercontent.com/fullstack-ai-infra/digital-employee/main/configs/hire-request.schema.json" as const
+
+/** Mirrors engine MAX_BUDGET_CAP (packages/engine/src/budget.ts). */
+const MAX_BUDGET_CAP = 1_000_000_000
+/** Same bounded-identifier discipline as turn-envelope.v1. */
+const MAX_ID_LENGTH = 256
+const MIN_DIGEST_LENGTH = 16
+const PACKAGE_VERSION_PATTERN = /^v1alpha1(\.[0-9]+)?$/
+
+const HIRE_REQUEST_KNOWN_FIELDS = [
+  "schemaVersion",
+  "workspaceRef",
+  "packageRef",
+  "targetParentId",
+  "budget",
+  "requestedBy",
+  "deadline",
+  "envelopeDigest",
+] as const
+const PACKAGE_REF_KNOWN_FIELDS = ["name", "version", "digest"] as const
+const BUDGET_KNOWN_FIELDS = ["perTask", "perDay"] as const
+const BUDGET_SCOPE_KNOWN_FIELDS = ["tokens", "iterations"] as const
+
+export interface HireRequestBudgetScope {
+  tokens?: number
+  iterations?: number
+}
+
+export interface HireRequestBudget {
+  perTask: HireRequestBudgetScope
+  perDay: HireRequestBudgetScope
+}
+
+export interface HireRequestPackageRef {
+  name: string
+  version: string
+  digest: string
+}
+
+export interface HireRequest {
+  schemaVersion: typeof HIRE_REQUEST_SCHEMA_VERSION
+  workspaceRef: string
+  packageRef: HireRequestPackageRef
+  /**
+   * Opaque org-tree placement reference (#194 AC-003). Validated as bounded
+   * text only; tree resolution belongs to the consumer (org-workbench #33).
+   */
+  targetParentId: string
+  budget: HireRequestBudget
+  requestedBy: string
+  deadline?: string
+  envelopeDigest: string
+}
+
+export class HireRequestError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message)
+    this.name = "HireRequestError"
+  }
+}
+
+function hireRequestError(code: string, message: string): HireRequestError {
+  return new HireRequestError(code, message)
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  )
+}
+
+function assertKnownFields(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  path: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) {
+      throw hireRequestError(
+        `hire_request_unknown_field:${path ? `${path}.` : ""}${key}`,
+        `unknown field: ${path ? `${path}.` : ""}${key}`,
+      )
+    }
+  }
+}
+
+/** turn-envelope.v1 bounded-identifier constraints, verbatim shape. */
+function assertBoundedId(value: unknown, path: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw hireRequestError(
+      `hire_request_invalid_field:${path}`,
+      `${path} must be a non-empty string`,
+    )
+  }
+  if (value.length > MAX_ID_LENGTH) {
+    throw hireRequestError(
+      `hire_request_invalid_field:${path}`,
+      `${path} exceeds the bounded identifier length`,
+    )
+  }
+  return value
+}
+
+function assertDigest(value: unknown, path: string): string {
+  if (typeof value !== "string" || value.length < MIN_DIGEST_LENGTH) {
+    throw hireRequestError(
+      `hire_request_invalid_field:${path}`,
+      `${path} must be a string of at least ${MIN_DIGEST_LENGTH} characters`,
+    )
+  }
+  return value
+}
+
+function validateBudgetScope(
+  value: unknown,
+  path: string,
+): HireRequestBudgetScope {
+  if (!isPlainObject(value)) {
+    throw hireRequestError(
+      `hire_request_invalid_field:${path}`,
+      `${path} must be an object`,
+    )
+  }
+  assertKnownFields(value, BUDGET_SCOPE_KNOWN_FIELDS, path)
+  const scope: HireRequestBudgetScope = {}
+  let present = 0
+  for (const key of BUDGET_SCOPE_KNOWN_FIELDS) {
+    const entry = value[key]
+    if (entry === undefined) continue
+    if (
+      typeof entry !== "number" ||
+      !Number.isInteger(entry) ||
+      entry < 1 ||
+      entry > MAX_BUDGET_CAP
+    ) {
+      throw hireRequestError(
+        `hire_request_invalid_field:${path}.${key}`,
+        `${path}.${key} must be an integer between 1 and ${MAX_BUDGET_CAP}`,
+      )
+    }
+    if (key === "tokens") scope.tokens = entry
+    else scope.iterations = entry
+    present += 1
+  }
+  if (present === 0) {
+    throw hireRequestError(
+      `hire_request_invalid_field:${path}`,
+      `${path} must declare at least one of tokens or iterations`,
+    )
+  }
+  return scope
+}
+
+function validateBudget(value: unknown): HireRequestBudget {
+  if (!isPlainObject(value)) {
+    throw hireRequestError(
+      "hire_request_invalid_field:budget",
+      "budget must be an object",
+    )
+  }
+  assertKnownFields(value, BUDGET_KNOWN_FIELDS, "budget")
+  const perTask =
+    value.perTask === undefined
+      ? undefined
+      : validateBudgetScope(value.perTask, "budget.perTask")
+  const perDay =
+    value.perDay === undefined
+      ? undefined
+      : validateBudgetScope(value.perDay, "budget.perDay")
+  if (!perTask || !perDay) {
+    throw hireRequestError(
+      `hire_request_invalid_field:budget.${!perTask ? "perTask" : "perDay"}`,
+      `budget.${!perTask ? "perTask" : "perDay"} is required`,
+    )
+  }
+  return { perTask, perDay }
+}
+
+function validatePackageRef(value: unknown): HireRequestPackageRef {
+  if (!isPlainObject(value)) {
+    throw hireRequestError(
+      "hire_request_invalid_field:packageRef",
+      "packageRef must be an object",
+    )
+  }
+  assertKnownFields(value, PACKAGE_REF_KNOWN_FIELDS, "packageRef")
+  const name = assertBoundedId(value.name, "packageRef.name")
+  const version = value.version
+  if (
+    typeof version !== "string" ||
+    !PACKAGE_VERSION_PATTERN.test(version)
+  ) {
+    throw hireRequestError(
+      "hire_request_invalid_field:packageRef.version",
+      "packageRef.version must match ^v1alpha1(\\.[0-9]+)?$",
+    )
+  }
+  const digest = assertDigest(value.digest, "packageRef.digest")
+  return { name, version, digest }
+}
+
+/**
+ * Validate a hire-request.v1alpha1 document. Static and fail-closed: no
+ * spawn, no engine, no network, no provider calls. Throws `HireRequestError`
+ * whose `code` is the stable diagnostic (`hire_request_unknown_field:<path>`,
+ * `hire_request_invalid_field:<path>`, `hire_request_missing_budget`).
+ */
+export function validateHireRequest(raw: unknown): HireRequest {
+  if (!isPlainObject(raw)) {
+    throw hireRequestError(
+      "hire_request_invalid_field:hireRequest",
+      "hire request must be a JSON object",
+    )
+  }
+  assertKnownFields(raw, HIRE_REQUEST_KNOWN_FIELDS, "")
+
+  if (raw.schemaVersion !== HIRE_REQUEST_SCHEMA_VERSION) {
+    throw hireRequestError(
+      "hire_request_invalid_field:schemaVersion",
+      `schemaVersion must be "${HIRE_REQUEST_SCHEMA_VERSION}"`,
+    )
+  }
+
+  const workspaceRef = assertBoundedId(raw.workspaceRef, "workspaceRef")
+  const packageRef = validatePackageRef(raw.packageRef)
+  const targetParentId = assertBoundedId(raw.targetParentId, "targetParentId")
+
+  if (raw.budget === undefined) {
+    throw hireRequestError(
+      "hire_request_missing_budget",
+      "budget is required: a hire without a budget fails closed",
+    )
+  }
+  const budget = validateBudget(raw.budget)
+
+  const requestedBy = assertBoundedId(raw.requestedBy, "requestedBy")
+
+  let deadline: string | undefined
+  if (raw.deadline !== undefined) {
+    if (
+      typeof raw.deadline !== "string" ||
+      Number.isNaN(Date.parse(raw.deadline))
+    ) {
+      throw hireRequestError(
+        "hire_request_invalid_field:deadline",
+        "deadline must be a valid ISO 8601 timestamp",
+      )
+    }
+    deadline = raw.deadline
+  }
+
+  const envelopeDigest = assertDigest(raw.envelopeDigest, "envelopeDigest")
+
+  return {
+    schemaVersion: HIRE_REQUEST_SCHEMA_VERSION,
+    workspaceRef,
+    packageRef,
+    targetParentId,
+    budget,
+    requestedBy,
+    ...(deadline !== undefined ? { deadline } : {}),
+    envelopeDigest,
+  }
+}
+
+function boundedIdSchema(): Record<string, unknown> {
+  return { type: "string", minLength: 1, maxLength: 256 }
+}
+
+/**
+ * Budget scope vocabulary byte-aligned with turn-envelope.v1
+ * `$defs/budgetScope` (#194 AC-005): tokens/iterations are positive bounded
+ * integers; a scope must declare at least one dimension.
+ */
+function budgetScopeSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    additionalProperties: false,
+    minProperties: 1,
+    properties: {
+      tokens: { type: "integer", exclusiveMinimum: 0, maximum: 1_000_000_000 },
+      iterations: {
+        type: "integer",
+        exclusiveMinimum: 0,
+        maximum: 1_000_000_000,
+      },
+    },
+  }
+}
+
+/**
+ * Build the hire-request.v1alpha1 JSON Schema (draft 2020-12). Mirrors
+ * `validateHireRequest` field-by-field; the published file
+ * configs/hire-request.schema.json must be byte-identical to
+ * `JSON.stringify(buildHireRequestSchema(), null, 2) + "\n"`.
+ */
+export function buildHireRequestSchema(): Record<string, unknown> {
+  return {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    $id: HIRE_REQUEST_SCHEMA_ID,
+    title: "hire-request.v1alpha1 hire request reference envelope",
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "schemaVersion",
+      "workspaceRef",
+      "packageRef",
+      "targetParentId",
+      "budget",
+      "requestedBy",
+      "envelopeDigest",
+    ],
+    properties: {
+      schemaVersion: { const: HIRE_REQUEST_SCHEMA_VERSION },
+      workspaceRef: boundedIdSchema(),
+      packageRef: {
+        type: "object",
+        additionalProperties: false,
+        required: ["name", "version", "digest"],
+        properties: {
+          name: boundedIdSchema(),
+          version: { type: "string", pattern: "^v1alpha1(\\.[0-9]+)?$" },
+          digest: { type: "string", minLength: 16 },
+        },
+      },
+      targetParentId: boundedIdSchema(),
+      budget: {
+        type: "object",
+        additionalProperties: false,
+        required: ["perTask", "perDay"],
+        properties: {
+          perTask: { $ref: "#/$defs/budgetScope" },
+          perDay: { $ref: "#/$defs/budgetScope" },
+        },
+      },
+      requestedBy: boundedIdSchema(),
+      deadline: { type: "string" },
+      envelopeDigest: { type: "string", minLength: 16 },
+    },
+    $defs: {
+      budgetScope: budgetScopeSchema(),
+    },
+  }
+}

--- a/scripts/distribution-policy.js
+++ b/scripts/distribution-policy.js
@@ -17,6 +17,7 @@ export const DISTRIBUTION_ASSET_MAPPINGS = Object.freeze([
   ["configs/dingtalk-dws.example.json", "dist/configs/dingtalk-dws.example.json"],
   ["configs/employee-mcp.schema.json", "dist/configs/employee-mcp.schema.json"],
   ["configs/employee-package.schema.json", "dist/configs/employee-package.schema.json"],
+  ["configs/hire-request.schema.json", "dist/configs/hire-request.schema.json"],
   ["configs/org-tree.schema.json", "dist/configs/org-tree.schema.json"],
   ["configs/profile.schema.json", "dist/configs/profile.schema.json"],
   ["configs/schema.json", "dist/configs/schema.json"],

--- a/tests/apps/employee-package.test.ts
+++ b/tests/apps/employee-package.test.ts
@@ -14,6 +14,7 @@ import {
 import os from "node:os"
 import path from "node:path"
 import test from "node:test"
+import { fileURLToPath } from "node:url"
 
 import {
   createEmployeePackage,
@@ -315,4 +316,55 @@ test("inspection fails closed across final-file and ancestor replacement races",
       await rm(parent, { recursive: true, force: true })
     })
   }
+})
+
+test("validate surfaces identity unknown-field warnings without failing (#194)", async () => {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "employee-identity-"))
+  const target = path.join(parent, "team-answer")
+  await createEmployeePackage(target, { author: "example-team" })
+
+  const manifestPath = path.join(target, "employee.json")
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"))
+  manifest.identity = {
+    displayName: "Answer Bot",
+    pronouns: "they/them",
+  }
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+
+  const inspected = await inspectEmployeePackage(target)
+  assert.equal(inspected.manifest.identity?.displayName, "Answer Bot")
+  assert.deepEqual(inspected.warnings, [
+    "employee_package_identity_unknown_field:pronouns",
+  ])
+
+  const root = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../..",
+  )
+  const builtCli = path.join(root, "dist", "apps", "cli", "bin.js")
+
+  const json = spawnSync(
+    process.execPath,
+    [builtCli, "validate", target, "--json"],
+    { encoding: "utf8", input: "", timeout: 60_000 },
+  )
+  assert.equal(json.status, 0, json.stderr)
+  const parsed = JSON.parse(json.stdout) as Record<string, unknown>
+  assert.equal(parsed.status, "valid")
+  assert.deepEqual(parsed.warnings, [
+    "employee_package_identity_unknown_field:pronouns",
+  ])
+
+  const plain = spawnSync(
+    process.execPath,
+    [builtCli, "validate", target],
+    { encoding: "utf8", input: "", timeout: 60_000 },
+  )
+  assert.equal(plain.status, 0, plain.stderr)
+  assert.match(
+    plain.stderr,
+    /warning: employee_package_identity_unknown_field:pronouns/,
+  )
+
+  await rm(parent, { recursive: true, force: true })
 })

--- a/tests/apps/hire-cli.test.ts
+++ b/tests/apps/hire-cli.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Black-box tests for `digital-employee hire validate` (#194, R4 freeze).
+ *
+ * AC-001: the hire channel exists and validates end-to-end through the
+ * built CLI. Static only: the command never spawns, calls the engine, or
+ * touches a provider; every violation exits 1 with a stable diagnostic.
+ */
+
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+const builtCli = path.join(root, "dist", "apps", "cli", "bin.js")
+
+function cliEnvironment(home: string): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = { ...process.env }
+  delete environment.LANG
+  delete environment.LC_ALL
+  return {
+    ...environment,
+    HOME: home,
+    PATH: [path.dirname(process.execPath), "/usr/bin", "/bin"].join(path.delimiter),
+  }
+}
+
+function runCli(
+  args: string[],
+  environment: NodeJS.ProcessEnv,
+  cwd: string,
+) {
+  return spawnSync(process.execPath, [builtCli, ...args], {
+    cwd,
+    env: environment,
+    encoding: "utf8",
+    input: "",
+    timeout: 60_000,
+    maxBuffer: 4 * 1024 * 1024,
+  })
+}
+
+function hireRequest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: "hire-request.v1alpha1",
+    workspaceRef: "ws-main",
+    packageRef: {
+      name: "team-answer",
+      version: "v1alpha1",
+      digest: "sha256:0123456789abcdef",
+    },
+    targetParentId: "pos-parent-1",
+    budget: {
+      perTask: { tokens: 50_000, iterations: 8 },
+      perDay: { tokens: 500_000 },
+    },
+    requestedBy: "cto",
+    envelopeDigest: "sha256:abcdef0123456789",
+    ...overrides,
+  }
+}
+
+async function writeHireRequest(
+  directory: string,
+  body: Record<string, unknown>,
+): Promise<string> {
+  const filePath = path.join(directory, "hire-request.json")
+  await writeFile(filePath, `${JSON.stringify(body, null, 2)}\n`, "utf8")
+  return filePath
+}
+
+test("AC-001: hire validate accepts a frozen hire request end-to-end (#194)", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "hire-cli-home-"))
+  t.after(() => rm(home, { recursive: true, force: true }))
+  const env = cliEnvironment(home)
+  const file = await writeHireRequest(home, hireRequest())
+
+  const plain = runCli(["hire", "validate", file], env, home)
+  assert.equal(plain.status, 0, plain.stderr)
+  assert.match(plain.stdout, /hire request valid: team-answer@v1alpha1/)
+
+  const json = runCli(["hire", "validate", file, "--json"], env, home)
+  assert.equal(json.status, 0, json.stderr)
+  const parsed = JSON.parse(json.stdout) as Record<string, any>
+  assert.equal(parsed.status, "valid")
+  assert.equal(parsed.hire.schemaVersion, "hire-request.v1alpha1")
+  assert.deepEqual(parsed.hire.budget, {
+    perTask: { tokens: 50_000, iterations: 8 },
+    perDay: { tokens: 500_000 },
+  })
+})
+
+test("AC-001: hire validate fails closed with stable diagnostics (#194)", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "hire-cli-home-"))
+  t.after(() => rm(home, { recursive: true, force: true }))
+  const env = cliEnvironment(home)
+
+  const cases: Array<{
+    name: string
+    body: () => Record<string, unknown>
+    code: string
+  }> = [
+    {
+      name: "missing budget",
+      body: () => {
+        const body = hireRequest()
+        delete body.budget
+        return body
+      },
+      code: "hire_request_missing_budget",
+    },
+    {
+      name: "empty budget scope",
+      body: () => hireRequest({ budget: { perTask: {}, perDay: { tokens: 1 } } }),
+      code: "hire_request_invalid_field:budget.perTask",
+    },
+    {
+      name: "unknown root field",
+      body: () => hireRequest({ approvedBy: "ceo" }),
+      code: "hire_request_unknown_field:approvedBy",
+    },
+    {
+      name: "localReference channel rejected",
+      body: () =>
+        hireRequest({
+          packageRef: {
+            name: "team-answer",
+            version: "v1alpha1",
+            digest: "sha256:0123456789abcdef",
+            localReference: "./packages/team-answer",
+          },
+        }),
+      code: "hire_request_unknown_field:packageRef.localReference",
+    },
+    {
+      name: "bad package version pattern",
+      body: () =>
+        hireRequest({
+          packageRef: {
+            name: "team-answer",
+            version: "v1alpha2",
+            digest: "sha256:0123456789abcdef",
+          },
+        }),
+      code: "hire_request_invalid_field:packageRef.version",
+    },
+    {
+      name: "missing targetParentId",
+      body: () => {
+        const body = hireRequest()
+        delete body.targetParentId
+        return body
+      },
+      code: "hire_request_invalid_field:targetParentId",
+    },
+    {
+      name: "missing workspaceRef",
+      body: () => {
+        const body = hireRequest()
+        delete body.workspaceRef
+        return body
+      },
+      code: "hire_request_invalid_field:workspaceRef",
+    },
+    {
+      name: "missing requestedBy",
+      body: () => {
+        const body = hireRequest()
+        delete body.requestedBy
+        return body
+      },
+      code: "hire_request_invalid_field:requestedBy",
+    },
+    {
+      name: "missing envelopeDigest",
+      body: () => {
+        const body = hireRequest()
+        delete body.envelopeDigest
+        return body
+      },
+      code: "hire_request_invalid_field:envelopeDigest",
+    },
+  ]
+
+  for (const testCase of cases) {
+    const file = await writeHireRequest(home, testCase.body())
+
+    const plain = runCli(["hire", "validate", file], env, home)
+    assert.equal(plain.status, 1, `${testCase.name}: ${plain.stdout}`)
+    assert.match(
+      plain.stderr,
+      new RegExp(testCase.code.replace(/[.[\]]/g, "\\$&")),
+      testCase.name,
+    )
+
+    const json = runCli(["hire", "validate", file, "--json"], env, home)
+    assert.equal(json.status, 1, `${testCase.name}: ${json.stdout}`)
+    const parsed = JSON.parse(json.stdout) as Record<string, unknown>
+    assert.deepEqual(parsed, { status: "failed", code: testCase.code }, testCase.name)
+  }
+})
+
+test("AC-001: hire validate rejects unreadable and malformed input (#194)", async (t) => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "hire-cli-home-"))
+  t.after(() => rm(home, { recursive: true, force: true }))
+  const env = cliEnvironment(home)
+
+  const missing = runCli(
+    ["hire", "validate", path.join(home, "nope.json")],
+    env,
+    home,
+  )
+  assert.equal(missing.status, 1)
+  assert.match(missing.stderr, /hire_request_file_unreadable/)
+
+  const malformedPath = path.join(home, "malformed.json")
+  await writeFile(malformedPath, "{not json", "utf8")
+  const malformed = runCli(["hire", "validate", malformedPath], env, home)
+  assert.equal(malformed.status, 1)
+  assert.match(malformed.stderr, /hire_request_invalid_json/)
+
+  const noFile = runCli(["hire", "validate"], env, home)
+  assert.equal(noFile.status, 1)
+  assert.match(noFile.stderr, /hire_validate_requires_file/)
+
+  const unknown = runCli(["hire", "approve", "x.json"], env, home)
+  assert.equal(unknown.status, 1)
+  assert.match(unknown.stderr, /unknown_hire_subcommand:approve/)
+
+  const help = runCli(["hire", "--help"], env, home)
+  assert.equal(help.status, 0)
+  assert.match(help.stdout, /digital-employee hire validate <file> \[--json\]/)
+})

--- a/tests/apps/hire-request-schema.test.ts
+++ b/tests/apps/hire-request-schema.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+import {
+  HIRE_REQUEST_SCHEMA_ID,
+  buildHireRequestSchema,
+} from "../../packages/core/index.js"
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+)
+const publishedSchemaPath = path.join(
+  packageRoot,
+  "configs",
+  "hire-request.schema.json",
+)
+
+test("published hire-request.schema.json matches the code-side builder", async () => {
+  const published = await readFile(publishedSchemaPath, "utf8")
+  assert.equal(
+    published,
+    `${JSON.stringify(buildHireRequestSchema(), null, 2)}\n`,
+  )
+})
+
+test("hire-request schema carries the frozen contract shape (#194)", () => {
+  const schema = buildHireRequestSchema() as Record<string, any>
+  assert.equal(schema.$id, HIRE_REQUEST_SCHEMA_ID)
+  assert.equal(schema.additionalProperties, false)
+  assert.deepEqual(schema.required, [
+    "schemaVersion",
+    "workspaceRef",
+    "packageRef",
+    "targetParentId",
+    "budget",
+    "requestedBy",
+    "envelopeDigest",
+  ])
+  assert.equal(schema.properties.schemaVersion.const, "hire-request.v1alpha1")
+  assert.equal(schema.properties.packageRef.additionalProperties, false)
+  assert.deepEqual(schema.properties.packageRef.required, [
+    "name",
+    "version",
+    "digest",
+  ])
+  assert.deepEqual(schema.properties.budget.required, ["perTask", "perDay"])
+  assert.equal(schema.properties.envelopeDigest.minLength, 16)
+  assert.ok(schema.$defs.budgetScope)
+})

--- a/tests/core/employee-package-schema.test.ts
+++ b/tests/core/employee-package-schema.test.ts
@@ -84,3 +84,88 @@ test("public package Schema and semantic validator reject unsafe cross-field cas
     assert.throws(() => validateEmployeePackageManifest(input))
   }
 })
+
+function identityManifest(): Record<string, any> {
+  const input = manifest()
+  input.identity = {
+    displayName: "Answer Bot",
+    avatar: { asset: "./knowledge/README.md" },
+    persona: "Helpful teammate for answer triage.",
+    roleId: "team-answer",
+  }
+  return input
+}
+
+test("public package Schema and validator accept the identity segment (#194)", async () => {
+  const validateSchema = await schemaValidator()
+
+  const full = identityManifest()
+  assert.equal(validateSchema(full), true, JSON.stringify(validateSchema.errors))
+  assert.doesNotThrow(() => validateEmployeePackageManifest(full))
+
+  // Additive extension point: unknown identity keys are accepted by both
+  // surfaces; only the semantic validator collects the warning.
+  const additive = identityManifest()
+  additive.identity.pronouns = "they/them"
+  assert.equal(
+    validateSchema(additive),
+    true,
+    JSON.stringify(validateSchema.errors),
+  )
+  const warnings: string[] = []
+  assert.doesNotThrow(() =>
+    validateEmployeePackageManifest(additive, warnings),
+  )
+  assert.deepEqual(warnings, [
+    "employee_package_identity_unknown_field:pronouns",
+  ])
+})
+
+test("public package Schema and validator reject identity violations (#194)", async () => {
+  const validateSchema = await schemaValidator()
+  const fixtures = [
+    (() => {
+      const input = identityManifest()
+      delete input.identity.displayName
+      return input
+    })(),
+    (() => {
+      const input = identityManifest()
+      input.identity.displayName = ""
+      return input
+    })(),
+    (() => {
+      const input = identityManifest()
+      input.identity.displayName = "x".repeat(65)
+      return input
+    })(),
+    (() => {
+      const input = identityManifest()
+      input.identity.persona = "x".repeat(2_049)
+      return input
+    })(),
+    (() => {
+      const input = identityManifest()
+      input.identity.roleId = "Team-Answer"
+      return input
+    })(),
+    (() => {
+      const input = identityManifest()
+      input.identity.avatar = {
+        asset: "./knowledge/README.md",
+        url: "https://cdn.example/avatar.png",
+      }
+      return input
+    })(),
+    (() => {
+      const input = identityManifest()
+      input.identity.reportTo = "manager-1"
+      return input
+    })(),
+  ]
+
+  for (const input of fixtures) {
+    assert.equal(validateSchema(input), false, JSON.stringify(input.identity))
+    assert.throws(() => validateEmployeePackageManifest(input))
+  }
+})

--- a/tests/core/employee-package.test.ts
+++ b/tests/core/employee-package.test.ts
@@ -187,3 +187,132 @@ test("entrypoint artifacts cannot use glob syntax", () => {
     /employee_package_invalid_field:entrypoints.inputSchema/,
   )
 })
+
+function identityManifest() {
+  return {
+    ...manifest(),
+    identity: {
+      displayName: "Answer Bot",
+      avatar: { asset: "./knowledge/README.md" },
+      persona: "Helpful teammate for answer triage.",
+      roleId: "team-answer",
+    },
+  }
+}
+
+test("identity: packages without the segment validate exactly as before (#194)", () => {
+  const result = validateEmployeePackageManifest(manifest())
+  assert.equal(result.identity, undefined)
+})
+
+test("identity: full segment is accepted and frozen (AC-002, #194)", () => {
+  const result = validateEmployeePackageManifest(identityManifest())
+  assert.deepEqual(result.identity, {
+    displayName: "Answer Bot",
+    avatar: { asset: "./knowledge/README.md" },
+    persona: "Helpful teammate for answer triage.",
+    roleId: "team-answer",
+  })
+  assert.equal(Object.isFrozen(result.identity), true)
+})
+
+test("identity: displayName coexists with the machine name (#194)", () => {
+  const result = validateEmployeePackageManifest(identityManifest())
+  assert.equal(result.name, "team-answer")
+  assert.equal(result.identity?.displayName, "Answer Bot")
+})
+
+test("identity: unknown extra fields are accepted with warnings (AC-002, #194)", () => {
+  const input = identityManifest()
+  ;(input.identity as Record<string, unknown>).pronouns = "they/them"
+  const warnings: string[] = []
+  const result = validateEmployeePackageManifest(input, warnings)
+  assert.deepEqual(warnings, [
+    "employee_package_identity_unknown_field:pronouns",
+  ])
+  assert.equal(
+    (result.identity as Record<string, unknown>).pronouns,
+    "they/them",
+  )
+})
+
+test("identity: invalid displayName fails closed (#194)", () => {
+  for (const displayName of ["", "   ", "x".repeat(65), 42]) {
+    const input = identityManifest()
+    input.identity.displayName = displayName as string
+    assert.throws(
+      () => validateEmployeePackageManifest(input),
+      /employee_package_invalid_field:identity\.displayName/,
+    )
+  }
+  const missing = identityManifest()
+  delete (missing.identity as Record<string, unknown>).displayName
+  assert.throws(
+    () => validateEmployeePackageManifest(missing),
+    /employee_package_invalid_field:identity\.displayName/,
+  )
+})
+
+test("identity: invalid persona fails closed (#194)", () => {
+  for (const persona of ["", "x".repeat(2_049)]) {
+    const input = identityManifest()
+    input.identity.persona = persona
+    assert.throws(
+      () => validateEmployeePackageManifest(input),
+      /employee_package_invalid_field:identity\.persona/,
+    )
+  }
+})
+
+test("identity: invalid roleId fails closed (#194)", () => {
+  for (const roleId of ["Team-Answer", "9lead", "role_id", "a".repeat(65)]) {
+    const input = identityManifest()
+    input.identity.roleId = roleId
+    assert.throws(
+      () => validateEmployeePackageManifest(input),
+      /employee_package_invalid_field:identity\.roleId/,
+    )
+  }
+})
+
+test("identity: avatar is exactly { asset } with no URL channel (#194)", () => {
+  const urlAvatar = identityManifest()
+  ;(urlAvatar.identity.avatar as Record<string, unknown>).url =
+    "https://cdn.example/avatar.png"
+  assert.throws(
+    () => validateEmployeePackageManifest(urlAvatar),
+    /employee_package_unknown_field:identity\.avatar\.url/,
+  )
+
+  const emptyAvatar = identityManifest()
+  ;(emptyAvatar.identity as Record<string, unknown>).avatar = {}
+  assert.throws(
+    () => validateEmployeePackageManifest(emptyAvatar),
+    /employee_package_invalid_field:identity\.avatar\.asset/,
+  )
+
+  const absoluteAvatar = identityManifest()
+  absoluteAvatar.identity.avatar = { asset: "/tmp/avatar.png" }
+  assert.throws(
+    () => validateEmployeePackageManifest(absoluteAvatar),
+    /employee_package_invalid_field:identity\.avatar\.asset/,
+  )
+})
+
+test("identity: avatar asset must be an entry in assets (#194)", () => {
+  const input = identityManifest()
+  input.identity.avatar = { asset: "./assets/missing.png" }
+  assert.throws(
+    () => validateEmployeePackageManifest(input),
+    /employee_package_identity_avatar_asset_unknown/,
+  )
+})
+
+test("identity: reportTo is rejected outright (#194)", () => {
+  const input = identityManifest()
+  ;(input.identity as Record<string, unknown>).reportTo = "manager-1"
+  assert.throws(
+    () => validateEmployeePackageManifest(input),
+    /employee_package_unknown_field:identity\.reportTo/,
+  )
+})

--- a/tests/core/hire-request.test.ts
+++ b/tests/core/hire-request.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  HIRE_REQUEST_SCHEMA_VERSION,
+  HireRequestError,
+  buildHireRequestSchema,
+  validateHireRequest,
+} from "../../packages/core/index.js"
+import { buildTurnEnvelopeSchema } from "../../apps/cli/turn/envelope-schema.js"
+
+function hireRequest(): Record<string, any> {
+  return {
+    schemaVersion: HIRE_REQUEST_SCHEMA_VERSION,
+    workspaceRef: "ws-main",
+    packageRef: {
+      name: "team-answer",
+      version: "v1alpha1",
+      digest: "sha256:0123456789abcdef",
+    },
+    targetParentId: "pos-parent-1",
+    budget: {
+      perTask: { tokens: 50_000, iterations: 8 },
+      perDay: { tokens: 500_000 },
+    },
+    requestedBy: "cto",
+    deadline: "2026-01-01T00:00:00Z",
+    envelopeDigest: "sha256:abcdef0123456789",
+  }
+}
+
+function assertHireFailure(input: unknown, code: string): void {
+  try {
+    validateHireRequest(input)
+  } catch (error) {
+    assert.ok(error instanceof HireRequestError)
+    assert.equal(error.code, code)
+    return
+  }
+  assert.fail(`expected hire request validation to fail with ${code}`)
+}
+
+test("hire request: valid envelope passes and is normalized (#194)", () => {
+  const result = validateHireRequest(hireRequest())
+  assert.deepEqual(result, {
+    schemaVersion: "hire-request.v1alpha1",
+    workspaceRef: "ws-main",
+    packageRef: {
+      name: "team-answer",
+      version: "v1alpha1",
+      digest: "sha256:0123456789abcdef",
+    },
+    targetParentId: "pos-parent-1",
+    budget: {
+      perTask: { tokens: 50_000, iterations: 8 },
+      perDay: { tokens: 500_000 },
+    },
+    requestedBy: "cto",
+    deadline: "2026-01-01T00:00:00Z",
+    envelopeDigest: "sha256:abcdef0123456789",
+  })
+
+  const minimal = hireRequest()
+  delete minimal.deadline
+  const minimalResult = validateHireRequest(minimal)
+  assert.equal(minimalResult.deadline, undefined)
+})
+
+test("hire request: targetParentId is required and opaque (AC-003, #194)", () => {
+  // Any bounded text passes: no tree lookup, no org-workbench import.
+  for (const targetParentId of [
+    "pos-parent-1",
+    "urn:org:node:42",
+    "some/path/like/reference",
+    "00000000-0000-0000-0000-000000000000",
+  ]) {
+    const input = hireRequest()
+    input.targetParentId = targetParentId
+    assert.equal(validateHireRequest(input).targetParentId, targetParentId)
+  }
+
+  const missing = hireRequest()
+  delete missing.targetParentId
+  assertHireFailure(missing, "hire_request_invalid_field:targetParentId")
+
+  const empty = hireRequest()
+  empty.targetParentId = "   "
+  assertHireFailure(empty, "hire_request_invalid_field:targetParentId")
+
+  const oversized = hireRequest()
+  oversized.targetParentId = "x".repeat(257)
+  assertHireFailure(oversized, "hire_request_invalid_field:targetParentId")
+})
+
+test("hire request: budget is required and attached at hire time (#194)", () => {
+  const missing = hireRequest()
+  delete missing.budget
+  assertHireFailure(missing, "hire_request_missing_budget")
+
+  const missingPerDay = hireRequest()
+  delete missingPerDay.budget.perDay
+  assertHireFailure(missingPerDay, "hire_request_invalid_field:budget.perDay")
+
+  const extraBudgetKey = hireRequest()
+  extraBudgetKey.budget.perWeek = { tokens: 1 }
+  assertHireFailure(extraBudgetKey, "hire_request_unknown_field:budget.perWeek")
+})
+
+test("hire request: empty budget scope fails closed (#194)", () => {
+  const empty = hireRequest()
+  empty.budget.perTask = {}
+  assertHireFailure(empty, "hire_request_invalid_field:budget.perTask")
+})
+
+test("hire request: budget scope bounds match the engine vocabulary (#194)", () => {
+  const cases: Array<[string, unknown]> = [
+    ["tokens", 0],
+    ["tokens", -1],
+    ["tokens", 1.5],
+    ["tokens", "5"],
+    ["tokens", 1_000_000_001],
+    ["iterations", 0],
+    ["iterations", 1_000_000_001],
+  ]
+  for (const [key, value] of cases) {
+    const input = hireRequest()
+    input.budget.perTask = { [key]: value }
+    assertHireFailure(
+      input,
+      `hire_request_invalid_field:budget.perTask.${key}`,
+    )
+  }
+
+  const atCap = hireRequest()
+  atCap.budget.perTask = { tokens: 1_000_000_000 }
+  atCap.budget.perDay = { iterations: 1_000_000_000 }
+  assert.doesNotThrow(() => validateHireRequest(atCap))
+})
+
+test("hire request: unknown fields are rejected at every level (#194)", () => {
+  const root = hireRequest()
+  root.approval = { granted: true }
+  assertHireFailure(root, "hire_request_unknown_field:approval")
+
+  const nested = hireRequest()
+  nested.packageRef.localReference = "./packages/team-answer"
+  assertHireFailure(
+    nested,
+    "hire_request_unknown_field:packageRef.localReference",
+  )
+})
+
+test("hire request: packageRef constraints fail closed (#194)", () => {
+  for (const version of ["v1alpha2", "v1alpha1.x", "1alpha1", ""]) {
+    const input = hireRequest()
+    input.packageRef.version = version
+    assertHireFailure(input, "hire_request_invalid_field:packageRef.version")
+  }
+
+  const versioned = hireRequest()
+  versioned.packageRef.version = "v1alpha1.3"
+  assert.equal(validateHireRequest(versioned).packageRef.version, "v1alpha1.3")
+
+  const shortDigest = hireRequest()
+  shortDigest.packageRef.digest = "short"
+  assertHireFailure(shortDigest, "hire_request_invalid_field:packageRef.digest")
+
+  const emptyName = hireRequest()
+  emptyName.packageRef.name = ""
+  assertHireFailure(emptyName, "hire_request_invalid_field:packageRef.name")
+})
+
+test("hire request: required bounded identifiers fail closed (#194)", () => {
+  for (const field of ["workspaceRef", "requestedBy", "envelopeDigest"]) {
+    const input = hireRequest()
+    delete input[field]
+    assertHireFailure(input, `hire_request_invalid_field:${field}`)
+  }
+
+  const shortEnvelopeDigest = hireRequest()
+  shortEnvelopeDigest.envelopeDigest = "sha256:abc"
+  assertHireFailure(
+    shortEnvelopeDigest,
+    "hire_request_invalid_field:envelopeDigest",
+  )
+})
+
+test("hire request: deadline mirrors turn-envelope handling (#194)", () => {
+  const invalid = hireRequest()
+  invalid.deadline = "not-a-date"
+  assertHireFailure(invalid, "hire_request_invalid_field:deadline")
+
+  const numeric = hireRequest()
+  numeric.deadline = 1_700_000_000
+  assertHireFailure(numeric, "hire_request_invalid_field:deadline")
+})
+
+test("hire request: schema version and document shape fail closed (#194)", () => {
+  const wrongVersion = hireRequest()
+  wrongVersion.schemaVersion = "hire-request.v2"
+  assertHireFailure(wrongVersion, "hire_request_invalid_field:schemaVersion")
+
+  assertHireFailure([], "hire_request_invalid_field:hireRequest")
+  assertHireFailure("hire", "hire_request_invalid_field:hireRequest")
+})
+
+test("hire request: budgetScope vocabulary is byte-aligned with turn-envelope.v1 (AC-005, #194)", () => {
+  const hireDefs = buildHireRequestSchema().$defs as Record<string, unknown>
+  const turnDefs = buildTurnEnvelopeSchema().$defs as Record<string, unknown>
+  assert.deepEqual(hireDefs.budgetScope, turnDefs.budgetScope)
+})


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/194
- Consumed revision: R4
- R4 decision: issuecomment-5414086490 (decisionType schema-freeze, decidedAt 2026-08-25T17:19:11Z, decidedBy 产品经理 P9, technicalOwner 技术 P9); authoritative field-level schema draft: issuecomment-5414036082
- Git baseline consumed: main c427633 (#178 合入后 HEAD); PR 于 05ae8cf 基线开工，随 #178 合入 rebase，随 #199 合入再 rebase 至 89228aa（head f621be6，#194 内容字节不变，CHANGELOG keep-both）
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | `packages/core/src/hire-request.ts` (hire-request.v1alpha1 validator + schema builder) + `configs/hire-request.schema.json` (byte-identical published schema) + `apps/cli/hire.ts` (`digital-employee hire validate <file>`, static fail-closed) + `apps/cli/bin.ts` (hire dispatch) | `tests/core/hire-request.test.ts` + `tests/apps/hire-cli.test.ts` — hire channel validates a creation request end-to-end; no spawn, no engine, no bypass path |
| REQ-001 / AC-002 | `packages/core/src/employee-package.ts` (optional identity segment: displayName required ≤64 / avatar asset content-addressed / persona ≤2048 / roleId lowercase vocabulary) + `configs/employee-package.schema.json` (+identity property) | `tests/core/employee-package.test.ts` + `tests/core/employee-package-schema.test.ts` + `tests/apps/employee-package.test.ts` — identity persists on the package record surface, ready for consumer org-tree rendering (rendering itself belongs to org-workbench) |
| REQ-001 / AC-003 | `hire-request.ts` `targetParentId` opaque org-tree placement reference (bounded text only; resolution belongs to consumer org-workbench #33, per R3 裁决③ id-only cross-repo refs) | `tests/core/hire-request.test.ts` — placement reference carried and bounded; reportTo hard-rejected inside identity (`employee_package_unknown_field:identity.reportTo`) per R4 freeze |
| REQ-001 / AC-004 | zero diff on `configs/turn-envelope.schema.json` / `apps/cli/turn` / `packages/engine` / `packages/core/src/turn-envelope.ts` (verified: `git diff 89228aa f621be6` empty on these paths) | `git diff 89228aa f621be6 -- configs/turn-envelope.schema.json apps/cli/turn packages/engine packages/core/src/turn-envelope.ts` → empty; full-suite regression green |
| REQ-001 / AC-005 | `hire-request.ts` budget scope byte-aligned with turn-envelope.v1 `$defs/budgetScope` (tokens/iterations positive bounded integers, MAX_BUDGET_CAP mirrors engine `packages/engine/src/budget.ts`); hire without budget fails closed (`hire_request_missing_budget`) | `tests/core/hire-request.test.ts` AC-005 case — budgetScope deep-equal to turn-envelope `$defs/budgetScope`; missing budget exits fail-closed |

## File domains

- `packages/core/src/hire-request.ts` (+367, new) — hire-request.v1alpha1 thin reference envelope: validator (fail-closed, stable diagnostic codes) + `buildHireRequestSchema()` builder; core never imports engine (MAX_BUDGET_CAP mirrored locally with source comment).
- `configs/hire-request.schema.json` (+102, new) — published schema byte-identical to the builder (test-enforced).
- `packages/core/src/employee-package.ts` (+84) — optional identity segment validator (additive-unknown warnings inside identity; `reportTo` hard-rejected; avatar asset must be an `assets` entry) + `validateEmployeePackageManifest(input, warnings?)` signature.
- `configs/employee-package.schema.json` (+35) — additive `identity` property (`reportTo: false`).
- `apps/cli/hire.ts` (+100, new) — `digital-employee hire validate <file> [--json]`; static, bounded input (256 KiB), exit 1 + `{ "status": "failed", "code" }` on violation.
- `apps/cli/bin.ts` (+16), `apps/cli/employee-package.ts` (+12), `packages/core/index.ts` (+18), `packages/core/src/employee-package-compat.ts` (+3) — dispatch and exports.
- `docs/hire-contract.md` (+74, new), `docs/employee-package.md` (+26) — same-PR vocabulary documentation obligation (R3 裁决②).
- `tests/` six files (+766) — AC-named coverage.
- `CHANGELOG.md` (+31), `scripts/distribution-policy.js` (+1 mapping), `README.md` (+1 doc-index link).
- `packages/engine` untouched; turn-envelope.v1 zero diff.

## Scope and non-goals

Delivers the R4-frozen hire contract surface: the creation verb channel (hire-request.v1alpha1 thin reference envelope + `hire validate` static CLI), identity expressiveness on the employee-package record surface, org placement reference, and budget vocabulary reuse — closing the four gaps from #26 without touching the turn contract.

**Not in scope** (explicitly separate):
- Any engine or turn-envelope change (AC-004, zero-diff verified).
- Org-tree resolution of `targetParentId` — belongs to consumer org-workbench #33 (R3 裁决③).
- Hire approval flow — does not reuse pendingApproval (R4 item 4, R3 boundary clarification maintained).
- Client-line orgApply bypass removal — handled in the consumer's PR; this PR keeps the contract pure.
- Issue closure — manual with merge-ledger comment per the no-auto-close discipline.

## Validation

- Exact commands: `npm ci` ; `npx tsx --test --test-concurrency=1 tests/core/hire-request.test.ts tests/core/employee-package.test.ts tests/core/employee-package-schema.test.ts tests/apps/hire-cli.test.ts tests/apps/hire-request-schema.test.ts tests/apps/employee-package.test.ts` ; `npm run check`
- Observed counts/results: PASS 57/57 changed-file tests (AC-001..AC-005, head f621be6, macOS arm64, Node v24); `npm run check`: typecheck PASS, build PASS, test stage: full-suite adjudication delegated to CI Node 20/24 (local serial replay interrupted by the #178 rebase mid-run; one known load-induced deploy-cli flake observed, same class as PR #195); governance:check and security:check to be confirmed on CI.
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/pull/198/checks

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 / AC-001 | hire channel validates a creation request statically; violations fail closed with stable codes | `npx tsx --test --test-concurrency=1 tests/core/hire-request.test.ts tests/apps/hire-cli.test.ts` | macOS arm64, Node v24, head f621be6 | valid envelope passes; unknown/invalid/missing-budget cases exit 1 with diagnostic code | matched within 57/57 | PASS |
| V2 | REQ-001 / AC-002 | identity segment persists displayName/avatar/persona/roleId on the package record surface | `npx tsx --test --test-concurrency=1 tests/core/employee-package.test.ts tests/core/employee-package-schema.test.ts tests/apps/employee-package.test.ts` | 同上 | additive identity accepted; avatar asset∉assets rejected; unknown field inside identity warns; 0.4.0 packages without identity unchanged | matched | PASS |
| V3 | REQ-001 / AC-003 | org placement carried as bounded opaque reference; reportTo rejected inside the package | `tests/core/hire-request.test.ts` targetParentId cases + identity reportTo case | 同上 | targetParentId ≤256 validated; `employee_package_unknown_field:identity.reportTo` thrown | matched | PASS |
| V4 | REQ-001 / AC-004 | turn-envelope.v1 and engine byte-identical; no regression | `git diff 89228aa f621be6 -- configs/turn-envelope.schema.json apps/cli/turn packages/engine packages/core/src/turn-envelope.ts` + full suite | 同上 | empty diff; suite green | empty; CI Node 20/24 full suite as authoritative | PASS |
| V5 | REQ-001 / AC-005 | budget vocabulary byte-aligned with turn-envelope.v1 `$defs/budgetScope`; hire without budget fails closed | `tests/core/hire-request.test.ts` AC-005 deep-equal case | 同上 | budgetScope deep-equal; `hire_request_missing_budget` exit 1 | matched | PASS |

## Security and compatibility

Purely additive contract change. identity is an optional segment on employee-package.v1alpha1: 0.4.0 packages without it validate byte-identically (regression tested); unknown fields inside identity are preserved with a collected warning (R4 additive rule), unknown fields outside identity still fail closed; avatar is content-addressed via `assets` — no URL field, no remote fetch surface. hire-request.v1alpha1 is a static, bounded reference envelope: 256 KiB input cap, closed field sets via strict known-field checks, bounded identifiers ≤256, digests ≥16 chars, fail-closed exit 1 with stable diagnostic codes before any effect. No spawn, no engine, no network, no credential surface, no new dependency. Budget cap constant mirrors engine MAX_BUDGET_CAP with an explicit source comment (core must not import engine). Vocabulary single-sourcing preserved: budgetScope is byte-aligned with turn-envelope.v1; new hire vocabulary documented in the same PR (`docs/hire-contract.md`) per the R3 obligation.

## Known limitations

- One local full-suite failure observed during the implementation gate: `tests/core/adapter-qualification.test.ts` timing-sensitive case under concurrent load; passes 47/47 when run in isolation on the same head. Same environment-induced class as the deploy-cli timing flakes characterized in PR #195 (zero file overlap with this PR's changes). Local serial replay (pre-rebase window) additionally reproduced one deploy-cli lock-deadline timing flake under load — same disposition: zero file overlap with this PR, main CI green.
- `targetParentId` resolution is deliberately not self-contained: tree placement is resolved by the consumer (org-workbench #33), per R3 裁决③ — the contract side only bounds the reference.
- `README.md` doc-index link (+1 line) appeared during the commit window outside the original file plan; reviewed and folded into the single commit (deviation recorded here).
- hire approval is not wired in this revision (R4 item 4); approval reuse is a future consumer-side decision.

## Risk and rollback

Risk is low and localized: additive schema segments and a new static CLI verb; all pre-existing manifests and envelopes observe byte-identical behavior (identity optional; turn surface untouched). Rollback: revert the single commit f621be6; no state, migration, or data impact. Published schema files are additive additions only.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: no release packet exists for this repository yet
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged




