### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-26
+
 ### Added
 
 - `docs/releasing.md` codifies the version-bump semantics (#200): within 0.x,
@@ -229,6 +231,10 @@ All notable changes to this project will be documented in this file.
   and that each of the three adapters fails closed with its typed code,
   zero version-probe calls and no model spawn for invalid/`$async`/oversized
   Schemas; Schema-absent requests keep the existing unstructured behavior.
+  Relative to 0.4.0 the failure point for unsupported Schemas moves
+  forward: the run now fails closed at the shared preflight guard before
+  any side effect, instead of later inside adapter-specific probe or
+  terminal validation layers.
 - Issue #113 AC-004 evidence is hardened without changing any authority:
   Claude, Qwen and CodeBuddy projection tests now assert (as Qoder already
   did) that output-Schema bytes never reach process environment values or

--- a/fixtures/qualification/snapshots/v0.5.0.json
+++ b/fixtures/qualification/snapshots/v0.5.0.json
@@ -1,0 +1,76 @@
+{
+  "schema": "adapter-qualification-snapshot.v1",
+  "release": "0.5.0",
+  "hostId": "reference-stdio-host",
+  "hostVersion": "1.0.0",
+  "kitVersion": "1.3.0",
+  "fixtureCorpusDigest": "11ed4b0f464fd49581e7b2c91e0254e34adb60d69ad1d7d2afc68c7d1dc4706d",
+  "generatedAt": "2026-08-26T00:00:00Z",
+  "axes": {
+    "implemented": true,
+    "fixtureConformant": true,
+    "liveQualified": false
+  },
+  "domains": [
+    {
+      "domain": "capability_negotiation",
+      "status": "supported",
+      "passed": 1,
+      "failed": 0
+    },
+    {
+      "domain": "native_event_validation",
+      "status": "supported",
+      "passed": 1,
+      "failed": 0
+    },
+    {
+      "domain": "single_terminal_outcome",
+      "status": "supported",
+      "passed": 1,
+      "failed": 0
+    },
+    {
+      "domain": "deadline_cancel",
+      "status": "supported",
+      "passed": 1,
+      "failed": 0
+    },
+    {
+      "domain": "process_tree_cleanup",
+      "status": "supported",
+      "passed": 3,
+      "failed": 0
+    },
+    {
+      "domain": "credential_boundaries",
+      "status": "supported",
+      "passed": 1,
+      "failed": 0
+    },
+    {
+      "domain": "filesystem_network_enforcement",
+      "status": "supported",
+      "passed": 2,
+      "failed": 0
+    },
+    {
+      "domain": "tool_mcp_enforcement",
+      "status": "supported",
+      "passed": 2,
+      "failed": 0
+    },
+    {
+      "domain": "output_schema",
+      "status": "supported",
+      "passed": 6,
+      "failed": 0
+    },
+    {
+      "domain": "readonly_projection",
+      "status": "supported",
+      "passed": 2,
+      "failed": 0
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstack-ai-infra/digital-employee",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstack-ai-infra/digital-employee",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -1434,7 +1434,7 @@
     },
     "packages/core": {
       "name": "@fullstack-ai-infra/digital-employee-core",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstack-ai-infra/digital-employee",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "An Agent-native CLI and outer runtime for portable digital employees.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstack-ai-infra/digital-employee-core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Dependency-free package, Agent-host, and compatibility primitives for digital employees.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/136
- Consumed revision: R3
- R3 decision: issuecomment-5420350263 (decisionType release-preparation, decidedAt 2026-08-26T03:54:00Z, decidedBy 战略 CEO 胡总拍板、运营负责人派单转述, technicalOwner 技术 P9); requirement record R2 in the issue body
- Git baseline consumed: main 6089b21 (#202 合入后 HEAD，含 #200 bump-semantics 条目)
- Rebase note: head rebased onto main 6089b21 after PR #202 merge; the #200 bump-semantics CHANGELOG entry folded into the sealed `[0.5.0]` Added section (empty Unreleased retained), release-check + governance:check re-passed at 0fa12d9.
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | `package.json` + `packages/core/package.json` (0.4.0 → 0.5.0) + `package-lock.json` (three version entries) + `CHANGELOG.md` (Unreleased sealed as `[0.5.0] - 2026-08-26`, empty Unreleased retained; Changed section gains the #113 guard unsupported-Schema failure-point-moved-forward sentence per the dispatch) | R3 items 1/2/3: versions agree across root/core/lockfile in the same commit; `node scripts/release-check.js` passed; changelog format matches the 66d4d6c v0.4.0 precedent; AC-001 consumer gate runs on this prepared head |
| REQ-001 / AC-001 | `fixtures/qualification/snapshots/v0.5.0.json` (new) — earned by re-running the deterministic vector set against the reference stdio Host through the same code path as the release regression harness | R3 item 3: `validateAdapterQualificationSnapshot` accepts the file; `compareQualificationSnapshots(v0.4.0 baseline, current)` returns zero regressions (10 domains all supported; kit 1.3.0, 20-case corpus digest `11ed4b0f464fd49581e7b2c91e0254e34adb60d69ad1d7d2afc68c7d1dc4706d`; `readonly_projection` row carried forward, `output_schema` strengthened 1→6) |
| REQ-001 / AC-001 | zero release-channel side effects: no tag created, `release.yml` untouched | R3 items 4/5: this PR only prepares the merge commit; tagging is a separate post-merge step, so no registry write is triggered by merge |

## File domains

- `package.json` (+1/-1) — root version 0.4.0 → 0.5.0.
- `packages/core/package.json` (+1/-1) — core version 0.4.0 → 0.5.0.
- `package-lock.json` (+3/-3) — root, packages/core and its node_modules link versions.
- `CHANGELOG.md` (+6) — `## [0.5.0] - 2026-08-26` heading seals the Unreleased content (empty Unreleased retained per the v0.4.0 precedent); one sentence added to the #113 shared output-Schema guard entry recording the earlier failure point for unsupported Schemas relative to 0.4.0.
- `fixtures/qualification/snapshots/v0.5.0.json` (+new) — adapter-qualification-snapshot.v1 earned on the reference stdio Host: 10 domains all supported, kit 1.3.0, axes implemented/fixtureConformant true and liveQualified false.
- No code, schema, engine, contract or workflow file is modified.

## Scope and non-goals

Delivers the R3-frozen 0.5.0 release preparation: the version bump, the dated changelog seal, and the per-release qualification snapshot, in one commit whose three elements agree (docs/releasing.md discipline). Merging this PR does not publish anything.

**Not in scope** (explicitly separate):
- Tagging — `v0.5.0` is created only after merge confirmation (R3 item 4).
- The #136 REQ-002 generic downstream selection proof and docs/verification.md record — those belong to the post-tag release run and its evidence collection.
- Issue #136 / #113 closure — manual with merge-ledger comment per the no-auto-close discipline.
- The #200 releasing.md bump-semantics documentation — separate PR in the same batch.

## Validation

- Exact commands: `npm ci` ; `node scripts/release-check.js` ; `npm run build` ; `npx tsx --test --test-concurrency=1 tests/apps/stdio-agent-host.test.ts` ; `npm run typecheck` ; `npm run governance:check` ; `npm run security:check`
- Observed counts/results: PASS 5/5 stdio-agent-host.test.ts（含 release 回归 harness，v0.5.0 快照独立 deep-equal 校验后还原测试文件复跑确认零残留）；release-check passed；typecheck PASS；governance:check PASS（7 allowlisted PR fixtures）；security:check PASS；head 0fa12d9，macOS arm64，Node v24；full-suite adjudication delegated to CI Node 20/24（与 PR #198 同口径）。
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/pull/201/checks

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 / AC-001 | R3 items 1/2: root/core/lockfile versions agree at 0.5.0 | `node scripts/release-check.js` | macOS arm64, Node v24, head 0fa12d9 | release-check passed; all three report 0.5.0 | matched | PASS |
| V2 | REQ-001 / AC-001 | R3 item 2: changelog sealed with date; #113 failure-point sentence present | `head` of CHANGELOG.md + Changed entry read | 同上 | `## [0.5.0] - 2026-08-26` below empty Unreleased; sentence present | matched | PASS |
| V3 | REQ-001 / AC-001 | R3 item 3: v0.5.0 snapshot valid, zero regressions vs the committed v0.4.0 baseline | `npx tsx --test --test-concurrency=1 tests/apps/stdio-agent-host.test.ts` + snapshot deep-equal replay | 同上 | validator accepts; comparison returns [] | matched within PASS 5/5: 10 domains supported, kit 1.3.0 | PASS |
| V4 | REQ-001 / AC-001 | R3 item 5: full gate green on the release commit | `npm run typecheck` ; `npm run governance:check` ; `npm run security:check` | 同上 + CI Node 20/24 | typecheck/build/test/governance/security all pass | typecheck/governance/security/release-check/harness PASS locally (head 0fa12d9); CI Node 20/24 full suite as authoritative | PASS |

## Security and compatibility

Metadata-only release preparation: version strings, changelog text, and one additive JSON fixture. No executable code, contract schema, engine, workflow or dependency changes; the lockfile delta is three version strings only. The v0.5.0 snapshot strengthens evidence relative to the v0.4.0 baseline (no disappeared or weakened capability row), so the release regression gate stays fail-closed for the next release. No credential, network or spawn surface is introduced.

## Known limitations

- The v0.5.0 snapshot's axes record `liveQualified: false`: fixture conformance is proven, live Adapter entitlement stays with the per-host qualification records — unchanged from the v0.4.0 baseline.
- The baseline comparison test in `tests/apps/stdio-agent-host.test.ts` still pins the v0.4.0 file by name; pointing it at v0.5.0.json happens with the next release preparation, matching how the v0.4.0 baseline was introduced.
- Tagging, channel reconciliation and the #136 REQ-002 downstream-selection proof are post-merge steps and are not evidenced by this PR.

## Risk and rollback

Risk is minimal: three metadata files and one additive fixture, all verified by the full gate in the same commit. Rollback: revert the single release-preparation commit; the qualification gate then compares against the v0.4.0 baseline exactly as before. No state, migration or published artifact is touched before tagging.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: no release packet exists for this repository yet
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged

