### PR TITLE
docs(release): codify version-bump semantics in releasing.md (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `docs/releasing.md` codifies the version-bump semantics (#200): within 0.x,
+  additive capability releases bump MINOR, defect-only releases bump PATCH,
+  breaking changes to a shipped surface bump MINOR with a `Breaking` changelog
+  heading, and MAJOR is reserved for the 1.0 stability commitment. The
+  convention takes effect starting with the 0.5.0 release.
 - Local PR governance precheck (#197 REQ-001): `npm run governance:precheck
   -- --body-file <path>` validates a draft pull request body against the
   exact CI implementation-trace gate before pushing. The precheck builds a

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -8,6 +8,12 @@ verified archives; they do not rebuild them.
 
 ## Normal release
 
+Version numbers follow semver vocabulary: within 0.x, additive capability
+releases bump MINOR, defect-only releases bump PATCH, and any breaking change
+to a shipped surface (commands, schemas, envelopes, package layout) bumps
+MINOR and is called out in the changelog under a `Breaking` heading; MAJOR is
+reserved for the 1.0 stability commitment.
+
 1. Merge a commit whose root/core package versions and changelog agree.
 2. Create the matching stable tag on that commit.
 3. Let `.github/workflows/release.yml` reconcile npm, GitHub Releases, and


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/200
- Consumed revision: R1
- R1 decision: issuecomment-5420379170 (decisionType scope-freeze, decidedAt 2026-08-26T04:05:00Z, decidedBy 技术 P9, technicalOwner 技术 P9); issue 正文 Proposal/Done/Don't 为范围依据
- Git baseline consumed: main b3d54bf (#198 合入后 HEAD); head 6eb4cb1
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | `docs/releasing.md` — "Normal release" section gains the semver-vocabulary bump convention paragraph (MINOR additive / PATCH defect-only / MINOR+`Breaking` heading for breaking changes / MAJOR reserved for 1.0), the wording frozen by R1 | review evidence: paragraph matches the R1-frozen Proposal wording; governance:check + security:check green at head 6eb4cb1 |
| REQ-001 / AC-002 | `CHANGELOG.md` — Unreleased Added entry records the convention and its effective start version 0.5.0 | review evidence: entry present under Unreleased Added naming 0.5.0 as the start version |
| REQ-001 / AC-003 | zero tooling and zero history rewrite: `git diff b3d54bf 6eb4cb1 --stat` shows exactly the two markdown files | review evidence: no script, workflow or dependency delta; no historical version heading rewritten |

## File domains

- `docs/releasing.md` (+6) — bump-semantics convention paragraph in the "Normal release" section.
- `CHANGELOG.md` (+5) — Unreleased Added entry recording the convention and the 0.5.0 effective start.
- No code, schema, workflow or dependency change.

## Scope and non-goals

Delivers the R1-frozen documentation convention: one paragraph of version-bump semantics in docs/releasing.md plus the changelog record, batched with the 0.5.0 release preparation per the 2026-08-26 operations dispatch (separate PR by design).

**Not in scope** (explicitly separate):
- No automatic bump tooling or release-please-style mechanism (AC-003); the tag stays a manual gate.
- No retroactive renumbering or rewriting of historical versions (AC-003).
- The 0.5.0 release-preparation commit itself — separate PR in the same batch.
- Issue closure — manual with merge-ledger comment per the no-auto-close discipline.

## Validation

- Exact commands: `npm ci` ; `npm run governance:check` ; `npm run security:check` ; `npm run governance:precheck -- --body-file /tmp/de200-body.md`
- Observed counts/results: PASS 2/2 local gates (governance:check, security:check) at head 6eb4cb1, macOS arm64, Node v24; docs-only delta carries no test-suite surface, CI full suite is the authoritative regression check
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/pull/202/checks

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 / AC-001 | releasing.md contains the frozen convention paragraph | read `docs/releasing.md` "Normal release" section at head 6eb4cb1 | macOS arm64 | paragraph present, wording matches the R1 freeze | matched | PASS |
| V2 | REQ-001 / AC-002 | CHANGELOG Unreleased records the convention and start version | read `CHANGELOG.md` Unreleased Added at head 6eb4cb1 | 同上 | entry present, names 0.5.0 as start version | matched | PASS |
| V3 | REQ-001 / AC-003 | no tooling added, no historical versions rewritten | `git diff b3d54bf 6eb4cb1 --stat` | 同上 | exactly two files: docs/releasing.md + CHANGELOG.md | matched | PASS |

## Security and compatibility

Documentation-only change: two markdown files, no executable surface, no dependency, no credential or network impact. Existing release mechanics are untouched; the paragraph only codifies the practiced convention.

## Known limitations

- The convention is prospective discipline, not script-enforced (deliberate per AC-003); enforcement remains the manual tag gate.
- Effective-start wording names 0.5.0; if the release-preparation PR rebases over this one, its sealed changelog carries this entry unchanged.

## Risk and rollback

Risk is negligible: additive markdown. Rollback: revert the single commit 6eb4cb1; no state or artifact impact.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: no release packet exists for this repository yet
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
