### PR TITLE
feat(contract): turn-envelope v1alpha2 optional conversationRef back-link (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `turn-envelope` bumps to `v1alpha2` with a strictly additive, optional
+  `conversationRef` back-link field (#205, DE-CONVREF-001): an opaque
+  workbench-generated conversation identifier that the spawn surface echoes
+  verbatim on every `engine.v1` event of the turn so consumers can group
+  turns by conversation. Legacy `turn-envelope.v1` envelopes remain accepted
+  with byte-exact behavior, a v1 envelope carrying the field fails closed,
+  and type violations (non-string, empty, oversized) reject through the
+  existing `engine.input_invalid` channel. The published
+  `configs/turn-envelope.schema.json` gains dual-version acceptance and an
+  `if/then` v1 guard under the builder byte-identity discipline.
+
 ## [0.5.0] - 2026-08-26
 
 ### Added

--- a/apps/cli/turn/envelope-schema.ts
+++ b/apps/cli/turn/envelope-schema.ts
@@ -1,13 +1,16 @@
 /**
- * Code-side builder for the turn-envelope.v1 JSON Schema (#173 REQ-002,
- * open decision 3: published under configs/ with the builder byte-identity
- * discipline). The published file configs/turn-envelope.schema.json must be
- * byte-identical to `JSON.stringify(buildTurnEnvelopeSchema(), null, 2) +
- * "\n"`; the schema-consistency test enforces this.
+ * Code-side builder for the turn-envelope.v1alpha2 JSON Schema (#173
+ * REQ-002, open decision 3: published under configs/ with the builder
+ * byte-identity discipline; #205 DE-CONVREF-001 adds the optional
+ * conversationRef back-link while still accepting legacy v1). The published
+ * file configs/turn-envelope.schema.json must be byte-identical to
+ * `JSON.stringify(buildTurnEnvelopeSchema(), null, 2) + "\n"`; the
+ * schema-consistency test enforces this.
  */
 
 import {
   TURN_ENVELOPE_SCHEMA_ID,
+  TURN_ENVELOPE_V1_VERSION,
   TURN_ENVELOPE_VERSION,
 } from "./envelope.js"
 
@@ -32,7 +35,7 @@ function budgetScopeSchema(): Record<string, unknown> {
 }
 
 /**
- * Build the turn-envelope.v1 JSON Schema (draft 2020-12). Mirrors
+ * Build the turn-envelope.v1alpha2 JSON Schema (draft 2020-12). Mirrors
  * `parseTurnEnvelope` field-by-field; validator/builder agreement is
  * asserted by the test suite on the fixture set.
  */
@@ -40,7 +43,7 @@ export function buildTurnEnvelopeSchema(): Record<string, unknown> {
   return {
     $schema: "https://json-schema.org/draft/2020-12/schema",
     $id: TURN_ENVELOPE_SCHEMA_ID,
-    title: "turn-envelope.v1 sealed turn request",
+    title: "turn-envelope.v1alpha2 sealed turn request",
     type: "object",
     additionalProperties: false,
     required: [
@@ -52,7 +55,9 @@ export function buildTurnEnvelopeSchema(): Record<string, unknown> {
       "envelopeDigest",
     ],
     properties: {
-      schemaVersion: { const: TURN_ENVELOPE_VERSION },
+      schemaVersion: {
+        enum: [TURN_ENVELOPE_VERSION, TURN_ENVELOPE_V1_VERSION],
+      },
       workspaceRef: boundedIdSchema(),
       positionId: boundedIdSchema(),
       turnId: boundedIdSchema(),
@@ -79,8 +84,14 @@ export function buildTurnEnvelopeSchema(): Record<string, unknown> {
       dayKey: boundedIdSchema(),
       deadline: { type: "string" },
       pendingApproval: { $ref: "#/$defs/pendingApproval" },
+      conversationRef: boundedIdSchema(),
       envelopeDigest: { type: "string", minLength: 1 },
     },
+    if: {
+      properties: { schemaVersion: { const: TURN_ENVELOPE_V1_VERSION } },
+      required: ["schemaVersion"],
+    },
+    then: { not: { required: ["conversationRef"] } },
     $defs: {
       budgetScope: budgetScopeSchema(),
       pendingApproval: {

--- a/apps/cli/turn/envelope.ts
+++ b/apps/cli/turn/envelope.ts
@@ -1,5 +1,5 @@
 /**
- * Sealed turn envelope (turn-envelope.v1) — the wire contract for the
+ * Sealed turn envelope (turn-envelope.v1alpha2) — the wire contract for the
  * `turn run` spawn surface (#173 REQ-002, OQ-1 adjudication).
  *
  * The envelope is digest-bound: `envelopeDigest` is the sha256 over the
@@ -7,6 +7,10 @@
  * itself), and the CLI re-verifies it before any consumption. A mismatched
  * or malformed envelope fails closed before any model consumption, per the
  * #90 package-binding discipline.
+ *
+ * v1alpha2 (#205, DE-CONVREF-001) strictly adds the optional
+ * `conversationRef` back-link; legacy `turn-envelope.v1` envelopes remain
+ * accepted with byte-exact behavior.
  */
 
 import { createHash } from "node:crypto"
@@ -21,7 +25,9 @@ import type {
   TurnPendingApprovalInput,
 } from "../../../packages/engine/src/contracts.js"
 
-export const TURN_ENVELOPE_VERSION = "turn-envelope.v1" as const
+export const TURN_ENVELOPE_VERSION = "turn-envelope.v1alpha2" as const
+/** Legacy version still accepted for byte-exact compatibility (#205). */
+export const TURN_ENVELOPE_V1_VERSION = "turn-envelope.v1" as const
 export const TURN_ENVELOPE_SCHEMA_ID =
   "https://fullstack-ai-infra.dev/schemas/turn-envelope.schema.json" as const
 
@@ -48,7 +54,7 @@ export const TURN_ENGINE_QODER_COMMAND_ENV =
   "DIGITAL_EMPLOYEE_QODER_COMMAND" as const
 
 export interface TurnEnvelope {
-  schemaVersion: typeof TURN_ENVELOPE_VERSION
+  schemaVersion: typeof TURN_ENVELOPE_VERSION | typeof TURN_ENVELOPE_V1_VERSION
   workspaceRef: string
   positionId: string
   turnId: string
@@ -64,6 +70,12 @@ export interface TurnEnvelope {
    * `TurnPendingApprovalInput` verbatim — no parallel vocabulary.
    */
   pendingApproval?: TurnPendingApprovalInput
+  /**
+   * Optional conversation back-link (#205, v1alpha2 only): an opaque
+   * workbench-generated conversation identifier, echoed verbatim on every
+   * event of the turn so consumers can group turns by conversation.
+   */
+  conversationRef?: string
   envelopeDigest: string
 }
 
@@ -139,12 +151,16 @@ export function parseTurnEnvelope(raw: unknown): TurnEnvelope {
       "envelope must be a JSON object",
     )
   }
-  if (raw.schemaVersion !== TURN_ENVELOPE_VERSION) {
+  if (
+    raw.schemaVersion !== TURN_ENVELOPE_VERSION &&
+    raw.schemaVersion !== TURN_ENVELOPE_V1_VERSION
+  ) {
     throw new TurnEnvelopeError(
       "engine.envelope_invalid",
-      `schemaVersion must be ${TURN_ENVELOPE_VERSION}`,
+      `schemaVersion must be ${TURN_ENVELOPE_VERSION} or ${TURN_ENVELOPE_V1_VERSION}`,
     )
   }
+  const schemaVersion = raw.schemaVersion as TurnEnvelope["schemaVersion"]
   const workspaceRef = assertBoundedId(raw.workspaceRef, "workspaceRef")
   const positionId = assertBoundedId(raw.positionId, "positionId")
   const turnId = assertBoundedId(raw.turnId, "turnId")
@@ -153,6 +169,20 @@ export function parseTurnEnvelope(raw: unknown): TurnEnvelope {
       "engine.input_invalid",
       "envelope input is required",
     )
+  }
+
+  // conversationRef belongs to v1alpha2 (#205): a v1 envelope carrying it is
+  // a version-mixing audit ambiguity and fails closed on the existing
+  // validation channel.
+  let conversationRef: string | undefined
+  if (raw.conversationRef !== undefined) {
+    if (schemaVersion !== TURN_ENVELOPE_VERSION) {
+      throw new TurnEnvelopeError(
+        "engine.input_invalid",
+        `conversationRef requires schemaVersion ${TURN_ENVELOPE_VERSION}`,
+      )
+    }
+    conversationRef = assertBoundedId(raw.conversationRef, "conversationRef")
   }
 
   let budget: TurnBudget | undefined
@@ -305,7 +335,7 @@ export function parseTurnEnvelope(raw: unknown): TurnEnvelope {
   }
 
   return {
-    schemaVersion: TURN_ENVELOPE_VERSION,
+    schemaVersion,
     workspaceRef,
     positionId,
     turnId,
@@ -316,6 +346,7 @@ export function parseTurnEnvelope(raw: unknown): TurnEnvelope {
       : {}),
     ...(raw.deadline !== undefined ? { deadline: raw.deadline as string } : {}),
     ...(pendingApproval !== undefined ? { pendingApproval } : {}),
+    ...(conversationRef !== undefined ? { conversationRef } : {}),
     envelopeDigest: raw.envelopeDigest,
   }
 }

--- a/apps/cli/turn/index.ts
+++ b/apps/cli/turn/index.ts
@@ -4,10 +4,10 @@
  *   turn run [workspace] --position <id> (--stdin | --input-file <path>)
  *
  * The spawn surface carries exactly one input source — the sealed
- * turn-envelope.v1 JSON — and one output discipline: NDJSON engine.v1
- * events on stdout, bounded diagnostics on stderr. `--json` is rejected
- * because the NDJSON stream IS the machine surface; a second formatting
- * mode would fork the contract.
+ * turn-envelope.v1/v1alpha2 JSON — and one output discipline: NDJSON
+ * engine.v1 events on stdout, bounded diagnostics on stderr. `--json` is
+ * rejected because the NDJSON stream IS the machine surface; a second
+ * formatting mode would fork the contract.
  */
 
 import { createReadStream } from "node:fs"
@@ -29,9 +29,10 @@ const TURN_INPUT_LIMIT_BYTES = 1024 * 1024
 function turnUsage(): string {
   return `digital-employee turn run [workspace] --position <id> (--stdin | --input-file <path>)
 
-Spawn surface for the built-in engine: consumes a sealed turn-envelope.v1
-request and streams NDJSON engine.v1 events. Exit 0 = exactly one trusted
-terminal; exit 1 = spawn-level failure (no terminal, indeterminate).
+Spawn surface for the built-in engine: consumes a sealed
+turn-envelope.v1/v1alpha2 request and streams NDJSON engine.v1 events.
+Exit 0 = exactly one trusted terminal; exit 1 = spawn-level failure (no
+terminal, indeterminate).
 `
 }
 

--- a/apps/cli/turn/turn-run.ts
+++ b/apps/cli/turn/turn-run.ts
@@ -2,9 +2,9 @@
  * `turn run` spawn surface (#173 REQ-001/REQ-003/REQ-004/REQ-005, OQ-1).
  *
  * Projects the merged engine core onto a stable CLI wire surface for
- * cross-product clients: sealed turn-envelope.v1 in, NDJSON engine.v1
- * events out, exactly one trusted terminal, unambiguous exit codes.
- * Engine-internal contracts are consumed, never changed.
+ * cross-product clients: sealed turn-envelope.v1/v1alpha2 in, NDJSON
+ * engine.v1 events out, exactly one trusted terminal, unambiguous exit
+ * codes. Engine-internal contracts are consumed, never changed.
  *
  * Exit-code semantics (#102 crash discipline):
  *   0 = exactly one trusted terminal reached (completed, or a modeled
@@ -294,7 +294,13 @@ export async function runTurn(options: TurnRunOptions): Promise<TurnRunResult> {
       ...(options.now !== undefined ? { now: options.now } : {}),
       ...(options.newId !== undefined ? { newId: options.newId } : {}),
     })) {
-      writeEvent(JSON.stringify(event))
+      writeEvent(
+        JSON.stringify(
+          envelope.conversationRef !== undefined
+            ? { ...event, conversationRef: envelope.conversationRef }
+            : event,
+        ),
+      )
       if (event.type === "run.completed" || event.type === "run.failed") {
         terminalEmitted = true
       }

--- a/configs/turn-envelope.schema.json
+++ b/configs/turn-envelope.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://fullstack-ai-infra.dev/schemas/turn-envelope.schema.json",
-  "title": "turn-envelope.v1 sealed turn request",
+  "title": "turn-envelope.v1alpha2 sealed turn request",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -14,7 +14,10 @@
   ],
   "properties": {
     "schemaVersion": {
-      "const": "turn-envelope.v1"
+      "enum": [
+        "turn-envelope.v1alpha2",
+        "turn-envelope.v1"
+      ]
     },
     "workspaceRef": {
       "type": "string",
@@ -81,9 +84,31 @@
     "pendingApproval": {
       "$ref": "#/$defs/pendingApproval"
     },
+    "conversationRef": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
     "envelopeDigest": {
       "type": "string",
       "minLength": 1
+    }
+  },
+  "if": {
+    "properties": {
+      "schemaVersion": {
+        "const": "turn-envelope.v1"
+      }
+    },
+    "required": [
+      "schemaVersion"
+    ]
+  },
+  "then": {
+    "not": {
+      "required": [
+        "conversationRef"
+      ]
     }
   },
   "$defs": {

--- a/tests/apps/turn-envelope-schema.test.ts
+++ b/tests/apps/turn-envelope-schema.test.ts
@@ -8,6 +8,7 @@ import { buildTurnEnvelopeSchema } from "../../apps/cli/turn/envelope-schema.js"
 import {
   computeEnvelopeDigest,
   parseTurnEnvelope,
+  TURN_ENVELOPE_V1_VERSION,
   TURN_ENVELOPE_VERSION,
 } from "../../apps/cli/turn/envelope.js"
 
@@ -146,4 +147,52 @@ test("#193 AC-005: malformed pendingApproval shapes reject before consumption", 
         (error as { code?: string }).code === "engine.input_invalid",
     )
   }
+})
+
+test("#205 AC-001: a legacy turn-envelope.v1 envelope parses byte-exactly", () => {
+  const raw = sealedEnvelope({ schemaVersion: TURN_ENVELOPE_V1_VERSION })
+  const envelope = parseTurnEnvelope(raw)
+  assert.equal(envelope.schemaVersion, TURN_ENVELOPE_V1_VERSION)
+  assert.equal(envelope.conversationRef, undefined)
+  assert.equal("conversationRef" in envelope, false)
+  // The parsed shape re-seals to the identical digest: no field added,
+  // dropped, or renamed on the legacy path.
+  const { envelopeDigest, ...body } = envelope
+  assert.equal(computeEnvelopeDigest(body), envelopeDigest)
+})
+
+test("#205 AC-001: v1alpha2 without conversationRef behaves like v1", () => {
+  const envelope = parseTurnEnvelope(sealedEnvelope())
+  assert.equal(envelope.schemaVersion, TURN_ENVELOPE_VERSION)
+  assert.equal("conversationRef" in envelope, false)
+})
+
+test("#205 AC-002: a v1alpha2 envelope carries a sealed conversationRef", () => {
+  const envelope = parseTurnEnvelope(
+    sealedEnvelope({ conversationRef: "conv-group-42" }),
+  )
+  assert.equal(envelope.conversationRef, "conv-group-42")
+})
+
+test("#205 AC-003: conversationRef type violations reject on the existing channel", () => {
+  const violations: unknown[] = [42, null, "", "   ", {}, [], "x".repeat(257)]
+  for (const conversationRef of violations) {
+    assert.throws(
+      () => parseTurnEnvelope(sealedEnvelope({ conversationRef })),
+      (error: unknown) =>
+        (error as { code?: string }).code === "engine.input_invalid",
+    )
+  }
+})
+
+test("#205: a v1 envelope carrying conversationRef fails closed", () => {
+  const envelope = sealedEnvelope({
+    schemaVersion: TURN_ENVELOPE_V1_VERSION,
+    conversationRef: "conv-group-42",
+  })
+  assert.throws(
+    () => parseTurnEnvelope(envelope),
+    (error: unknown) =>
+      (error as { code?: string }).code === "engine.input_invalid",
+  )
 })

--- a/tests/apps/turn-run.test.ts
+++ b/tests/apps/turn-run.test.ts
@@ -15,6 +15,7 @@ import { fileURLToPath, pathToFileURL } from "node:url"
 import { runTurn } from "../../apps/cli/turn/turn-run.js"
 import {
   computeEnvelopeDigest,
+  TURN_ENVELOPE_V1_VERSION,
   TURN_ENVELOPE_VERSION,
 } from "../../apps/cli/turn/envelope.js"
 import type { ModelPort } from "../../packages/engine/src/index.js"
@@ -698,5 +699,76 @@ test("#193 AC-004: an envelope without pendingApproval keeps current behavior", 
       String(event.type).startsWith("approval."),
     ),
     "no approval lifecycle events without a verdict field",
+  )
+})
+
+test("#205 AC-002: conversationRef back-links every event of the turn", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, {
+    conversationRef: "conv-group-42",
+  })
+  const { result, events } = await execute(
+    workspace,
+    JSON.stringify(envelope),
+    createDeterministicModelPort(["all issues summarized"]),
+  )
+  assert.equal(result.exitCode, 0)
+  assert.ok(events.length > 0)
+  for (const event of events) {
+    assert.equal(
+      event.conversationRef,
+      "conv-group-42",
+      `event ${String(event.type)} must echo the conversation back-link`,
+    )
+  }
+  assert.ok(events.some((event) => event.type === "run.completed"))
+})
+
+test("#205 AC-001: legacy v1 and ref-less v1alpha2 events stay byte-exact", async () => {
+  const workspace = await createWorkspace()
+  const model = createDeterministicModelPort(["all issues summarized"])
+  for (const schemaVersion of [
+    TURN_ENVELOPE_V1_VERSION,
+    TURN_ENVELOPE_VERSION,
+  ]) {
+    const envelope = sealedEnvelope(workspace, { schemaVersion })
+    const { result, events } = await execute(
+      workspace,
+      JSON.stringify(envelope),
+      model,
+    )
+    assert.equal(result.exitCode, 0)
+    assert.ok(events.length > 0)
+    for (const event of events) {
+      assert.equal(
+        "conversationRef" in event,
+        false,
+        `event ${String(event.type)} must not gain a key without the field`,
+      )
+    }
+  }
+})
+
+test("#205 AC-003: a non-string conversationRef fails spawn before any event", async () => {
+  const workspace = await createWorkspace()
+  const envelope = sealedEnvelope(workspace, { conversationRef: 42 })
+  let modelCalls = 0
+  const model: ModelPort = {
+    async complete() {
+      modelCalls += 1
+      return { text: "never" }
+    },
+  }
+  const { result, events, diagnostics } = await execute(
+    workspace,
+    JSON.stringify(envelope),
+    model,
+  )
+  assert.equal(result.exitCode, 1)
+  assert.equal(result.terminalEmitted, false)
+  assert.equal(events.length, 0)
+  assert.equal(modelCalls, 0)
+  assert.ok(
+    diagnostics.some((line) => line.includes("engine.input_invalid")),
   )
 })


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/205
- Consumed revision: R1
- R1 decision: the frozen DE-CONVREF-001 requirement record in the Issue #205 body (strictly additive v1alpha2 bump, optional conversationRef, three frozen ACs, no new envelope/channel/error category) as filed by the product line after CEO principle approval; technical draft anchor issuecomment-5426432661
- Git baseline consumed: main 8735e2a (post-#204 merge HEAD)
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | `apps/cli/turn/envelope.ts` dual-version acceptance, `apps/cli/turn/envelope-schema.ts` builder, `configs/turn-envelope.schema.json` regenerated | `tests/apps/turn-envelope-schema.test.ts` legacy v1 byte-exact parse and digest reseal; `tests/apps/turn-run.test.ts` v1 and ref-less v1alpha2 events carry no new key |
| REQ-001 / AC-002 | `apps/cli/turn/turn-run.ts` writeEvent seam passthrough | `tests/apps/turn-run.test.ts` spawn-to-event assertion: every emitted event echoes the same conversationRef |
| REQ-001 / AC-003 | `apps/cli/turn/envelope.ts` conversationRef validation via the existing bounded-id channel | `tests/apps/turn-envelope-schema.test.ts` rejection matrix (non-string, empty, whitespace, oversized); `tests/apps/turn-run.test.ts` spawn-level fail-closed with zero events and zero model consumption |

## File domains

- `apps/cli/turn/envelope.ts` — version constants, TurnEnvelope interface, parseTurnEnvelope dual-version and conversationRef validation
- `apps/cli/turn/envelope-schema.ts` + `configs/turn-envelope.schema.json` — builder bump and regenerated published schema under byte-identity discipline
- `apps/cli/turn/turn-run.ts` — event passthrough at the writeEvent seam; header comment only in `apps/cli/turn/index.ts`
- `tests/apps/turn-envelope-schema.test.ts`, `tests/apps/turn-run.test.ts` — contract and end-to-end coverage
- `CHANGELOG.md` — Unreleased entry

## Scope and non-goals

Strictly additive contract bump per the frozen issue record: `turn-envelope.v1alpha2` adds an optional `conversationRef` string; legacy `turn-envelope.v1` envelopes remain accepted with byte-exact parse and event output; a v1 envelope carrying the field fails closed as a version-mixing audit ambiguity. Engine contracts (`EngineTurnRequest`, `EngineEvent`) are consumed, never changed.

**Not in scope**: no new envelope, channel, or error category; no delegation trigger (peer_message) work; no workbench-side switchover (that is the org-workbench#34 transitional-debt settlement after this merges).

## Validation

- Exact commands: `npm run check` ; `npx tsx --test --test-concurrency=1 tests/apps/turn-envelope-schema.test.ts tests/apps/turn-run.test.ts` ; `npx tsx --test --test-concurrency=1 tests/apps/deploy-cli.test.ts` (isolated flake adjudication) ; `npm run governance:precheck -- --body-file /tmp/de-205-body.md --base-sha 8735e2a21163ce3563401f89d0798ade08931f92 --head-sha 5f8a057735e46c8e7063135172d0f72712bd4036 --pr-number 206` ; CI required checks on the PR
- Observed counts/results: PASS 5/5 local verification rows V1-V5; changed-file test files 39/39 pass; full `npm run check` typecheck/build/governance/security green and 1774/1779 tests pass; the five failing deploy-cli cases are load-induced timing flakes adjudicated in V5 under the docs/flaky-tests.md protocol (changed-file intersection empty, main CI green at the same baseline, registry-covered signatures); changed-file tests 39/39 pass
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/pull/206/checks

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 / AC-001 | legacy v1 envelope parses byte-exactly (digest reseals, no conversationRef key) | `npx tsx --test tests/apps/turn-envelope-schema.test.ts` | macOS arm64, Node 24 | test "legacy turn-envelope.v1 envelope parses byte-exactly" passes | passed | PASS |
| V2 | REQ-001 / AC-001 | v1 and ref-less v1alpha2 spawn emit events with no new key | `npx tsx --test tests/apps/turn-run.test.ts` | same as V1 | test "legacy v1 and ref-less v1alpha2 events stay byte-exact" passes | passed | PASS |
| V3 | REQ-001 / AC-002 | every event of a conversationRef-bearing turn echoes the same back-link | same command as V2 | same as V1 | test "conversationRef back-links every event of the turn" passes | passed | PASS |
| V4 | REQ-001 / AC-003 | non-string / empty / whitespace / oversized conversationRef reject on engine.input_invalid before any event or model call | both test files above | same as V1 | rejection matrix and spawn-level fail-closed tests pass | passed | PASS |
| V5 | flake adjudication | the five full-suite deploy-cli timing failures satisfy all three docs/flaky-tests.md adjudication conditions | `git diff origin/main...HEAD --name-only` intersection check; CI run 32952611437 at baseline 8735e2a; isolated rerun log /tmp/de-205-deploycli-isolated.log | same as V1 | empty changed-file intersection, green baseline CI, load-flake signatures | all three hold: intersection empty (deploy-cli.test.ts imports only node builtins and apps/cli/deploy/*); baseline CI 11/11 success; failures are waitFor condition_not_reached_before_timeout slips at load average 27-41, two cases registry-covered verbatim, same suite green 359/0 on 2026-08-26 morning at unrelated commit c98fdb2 | PASS |

## Security and compatibility

Additive contract change only: the new field is optional, bounded to 256 characters, digest-sealed like every other envelope field, and never influences model consumption, credentials, or spawn arguments. Legacy v1 consumers observe byte-identical behavior; consumers that hand-craft a v1 envelope with the field fail closed, which is the intended audit signal. No executable dependency, network surface, or privilege change.

## Known limitations

- The v1 + conversationRef combination rejects by design (version-mixing is an audit ambiguity); a consumer ready to send the field must stamp v1alpha2.
- The published schema uses an if/then guard for the v1 branch; consumers validating against older tooling that predates draft 2020-12 conditional keywords must pin the prior schema revision.

## Risk and rollback

Risk is low: single additive field with fail-closed validation and byte-exact legacy path. Rollback is a one-commit revert of 5f8a057; the wire surface returns to turn-envelope.v1 exactly, and any in-flight v1alpha2 envelopes fail closed at the schemaVersion gate, which is the correct fail-closed direction.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: no release packet exists for this repository yet
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
