### PR TITLE
feat(engine): wire memory_recall slot to strict MemoryPort seam (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,19 @@ All notable changes to this project will be documented in this file.
   permissions; an absent mode defaults to read_only and a malformed mode fails
   `org apply` closed. A new `permission_denied` terminal reason lands with the
   semantic-mapping doc.
+- Engine wires the `memory_recall` context slot to the strict `MemoryPort`
+  seam (#180 wiring, consumed through #209): an opt-in `EngineMemoryOptions`
+  (disabled by default) calls a pinned, scope-bound adapter before any model
+  consumption; `optional` mode converts only a typed `MEMORY_UNAVAILABLE`
+  outage into an empty recall plus one warning, `required` mode settles the
+  turn retryable with `engine.memory_unavailable` before the model call, and
+  denial, scope mismatch, revoked/expired grants, archived/forgotten items,
+  tampered records, bad configuration (including a missing or malformed
+  adapter identity), or an unexpected wire schema version fail closed as
+  `engine.memory_denied` in both modes. `turn-evidence.v1` gains a
+  digest-only `memory` field (adapter identity, item digests, locators, state
+  versions, provenance digests, byte counts) that never carries recall text
+  or raw provenance.
 
 ## [0.5.0] - 2026-08-26
 

--- a/docs/engine-codex-semantic-mapping.md
+++ b/docs/engine-codex-semantic-mapping.md
@@ -51,9 +51,13 @@ contracts.ts 已声明 TerminalReason 是本仓自有枚举、不是外部枚举
 | deadline_exceeded | TurnAborted（超时路径） |
 | cancelled | TurnAborted / Op::SuspendTurnAndShutdown |
 | permission_denied | 无直接对应（#159 权限强制：越权请求在模型消耗前失败关闭） |
+| memory_unavailable | 无直接对应（codex 无持久记忆平面；required 模式持久记忆不可用的可重试结算） |
+| memory_denied | 无直接对应（召回被拒/作用域不匹配/记录畸形/配置无效的双模式 fail-closed 结算） |
 | engine_internal_error | StreamError / Error |
 
 结算语义注记（权限强制，#159）：权限强制在引擎执行链两层执行（模型消耗前预检 + 派发时检查），消费 `org apply` 重算的单一强制件 `permissions.json`（org-permissions.v1）。越权上下文读以 `workspace_org_context_denied` 结算、越权工具调用以 `workspace_org_authority_denied` 结算、未知岗位以 `workspace_org_position_unknown` 在生命周期事件发出前结算；拒绝一律携带 `redirectTo=owner`。拒绝尝试入回合证据（positionId、请求的路径或工具名、稳定码、指向），绝不携带被拒资源的内容；重复拒绝不升级、不自动重试。权限拒绝族（`workspace_org_*`）与审批结算族（`engine.approval_*`）正交并存。工件缺失/畸形以 `engine.permissions_invalid` 在模型消耗前失败关闭。
+
+结算语义注记（memory 接缝，#180）：记忆召回接缝在任何 model 消耗之前执行，默认停用、显式启用才召回，作用域由钉住的 MemoryPort 绑定透传、不接受回合输入供给或放宽。optional 模式仅把类型化 `MEMORY_UNAVAILABLE` 故障转为空召回 + 一条警告、回合照常进行；required 模式故障以 `engine.memory_unavailable`（retryable=true）结算；拒绝/作用域不匹配/记录畸形/配置无效/线协议版本异常在两种模式下统一 `engine.memory_denied`（retryable=false）fail-closed。证据仅记召回条目摘要/定位符/状态版本/字节计数，绝不记原文。
 
 ## 4. approval 语义对位（已实施词表，单一来源 contracts.ts）
 

--- a/packages/engine/src/contracts.ts
+++ b/packages/engine/src/contracts.ts
@@ -32,6 +32,8 @@ export type TerminalReason =
   | "deadline_exceeded"
   | "cancelled"
   | "permission_denied"
+  | "memory_unavailable"
+  | "memory_denied"
   | "engine_internal_error"
 
 /** Lowercase ASCII machine code: `[a-z0-9][a-z0-9._-]{0,127}`. */

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -62,7 +62,7 @@ export {
 export type { PreparedTerminalSchema } from "./output-schema-guard.js"
 
 export { executeTurn } from "./turn-executor.js"
-export type { TurnExecutorOptions } from "./turn-executor.js"
+export type { EngineMemoryOptions, TurnExecutorOptions } from "./turn-executor.js"
 
 export {
   MAX_BUDGET_CAP,
@@ -116,6 +116,9 @@ export type {
   TurnEvidenceApprovalRef,
   TurnEvidenceBudget,
   TurnEvidencePermissions,
+  TurnEvidenceMemory,
+  TurnEvidenceMemoryItem,
+  TurnEvidenceMemoryWarning,
   TurnEvidenceRecord,
   TurnEvidenceTerminal,
 } from "./turn-evidence.js"

--- a/packages/engine/src/turn-evidence.ts
+++ b/packages/engine/src/turn-evidence.ts
@@ -60,6 +60,45 @@ export interface TurnEvidencePermissions {
   denials: PermissionDenialAttempt[]
 }
 
+/**
+ * Digest-only evidence for one recalled memory item (#180 memory-recall
+ * seam, consumed through #209). Raw recall text never enters evidence:
+ * items are untrusted data with authority "none"; only digests, locators,
+ * and bounded counters are recorded. Provenance enters as a digest over the
+ * canonical provenance block — never as raw provenance fields (#209
+ * REQ-001).
+ */
+export interface TurnEvidenceMemoryItem {
+  digest: string
+  locator: string
+  kind: string
+  stateVersion: number
+  byteLength: number
+  /** sha256 over the canonical provenance block of the recalled item. */
+  provenanceDigest: string
+}
+
+export interface TurnEvidenceMemoryWarning {
+  code: string
+}
+
+/**
+ * Digest-only memory-consumption evidence (#209 REQ-001): effective mode,
+ * retrievedAt, adapter identity, and per-item locators/state versions/
+ * content digests/provenance digests. Never raw recall content, never
+ * credentials.
+ */
+export interface TurnEvidenceMemory {
+  mode: "optional" | "required"
+  /** Bounded machine identity of the pinned adapter, e.g. "mem-http.v1". */
+  adapterIdentity: string
+  retrievedAt: string
+  itemCount: number
+  totalBytes: number
+  items: TurnEvidenceMemoryItem[]
+  warnings: TurnEvidenceMemoryWarning[]
+}
+
 export interface TurnEvidenceRecord {
   schemaVersion: typeof TURN_EVIDENCE_VERSION
   evidenceId: string
@@ -78,6 +117,8 @@ export interface TurnEvidenceRecord {
   approvalRef?: TurnEvidenceApprovalRef
   /** Permission decision summary + zero-content denial attempts (#159). */
   permissions?: TurnEvidencePermissions
+  /** Digest-only memory-recall consumption evidence (#180 seam). */
+  memory?: TurnEvidenceMemory
   /** Assembly manifest digest from context-assembly.v1. */
   assemblyManifestDigest: string
   timeBounds: {

--- a/packages/engine/src/turn-executor.ts
+++ b/packages/engine/src/turn-executor.ts
@@ -1,6 +1,14 @@
-import { randomUUID } from "node:crypto"
+import { createHash, randomUUID } from "node:crypto"
 
 import type { SafeValue } from "../../core/src/contracts.js"
+import {
+  derivePositionPrincipal,
+  MemoryPortError,
+  MEMORY_RECALL_SCHEMA_VERSION,
+  type MemoryPort,
+  type MemoryRecall,
+  type MemoryRecallProvenance,
+} from "../../core/src/memory-port.js"
 
 import {
   checkPositionBudget,
@@ -53,8 +61,43 @@ import {
   TURN_EVIDENCE_VERSION,
   type EvidenceSinkPort,
   type TurnEvidenceApprovalRef,
+  type TurnEvidenceMemory,
   type TurnEvidenceRecord,
 } from "./turn-evidence.js"
+
+/**
+ * Memory-recall seam configuration (#180 wiring, consumed through #209).
+ * Disabled by default: recall happens only when `enabled` is exactly true.
+ * The port instance is pinned to one workspace instance + position +
+ * memoryScope binding (#181); the engine passes the pinned scope through
+ * unchanged and never accepts scope supplied or widened by turn input.
+ * `adapterIdentity` is the bounded machine identity of the pinned adapter
+ * (e.g. "mem-http.v1"); it is validated before any port call and recorded
+ * in turn evidence (#209 REQ-001). The port contract itself stays frozen.
+ */
+export interface EngineMemoryOptions {
+  port: MemoryPort
+  enabled: boolean
+  workspaceInstanceId: string
+  sessionId: string
+  memoryScope: string
+  mode: "optional" | "required"
+  adapterIdentity: string
+  limit?: number
+}
+
+/** Bounded machine identity: leading alnum, then `[A-Za-z0-9._:@-]`, ≤128. */
+const ADAPTER_IDENTITY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/
+
+/**
+ * Canonical digest over a recall item's provenance block (#209 REQ-001).
+ * Provenance enters evidence only through this digest — never as raw
+ * fields — keeping the evidence record digest-only and identity-free.
+ */
+function digestProvenance(provenance: MemoryRecallProvenance): string {
+  const canonical = JSON.stringify(provenance, Object.keys(provenance).sort())
+  return createHash("sha256").update(canonical ?? "{}", "utf8").digest("hex")
+}
 
 export interface TurnExecutorOptions {
   model: ModelPort
@@ -64,6 +107,7 @@ export interface TurnExecutorOptions {
   evidenceSink?: EvidenceSinkPort
   orgLookup?: OrgReportingLookup
   doomLoop?: Partial<DoomLoopConfig>
+  memory?: EngineMemoryOptions
   newId?: () => string
 }
 
@@ -81,12 +125,15 @@ const REASON_TO_CODE: Readonly<Record<TerminalReason, string>> = {
   deadline_exceeded: "engine.deadline_exceeded",
   cancelled: "engine.cancelled",
   permission_denied: "engine.permission_denied",
+  memory_unavailable: "engine.memory_unavailable",
+  memory_denied: "engine.memory_denied",
   engine_internal_error: "engine.internal_error",
 }
 
 const RETRYABLE_REASONS: ReadonlySet<TerminalReason> = new Set([
   "invalid_output_exhausted",
   "deadline_exceeded",
+  "memory_unavailable",
   "engine_internal_error",
 ])
 
@@ -284,6 +331,112 @@ export async function* executeTurn(
     return
   }
 
+  // Memory-recall seam (#180): runs before any model consumption. Disabled
+  // by default; when enabled the pinned port is called with the pinned scope
+  // (never supplied or widened by turn input). Recalled text is untrusted
+  // data for the memory_recall slot; evidence keeps digests only.
+  let recallLines: string[] = []
+  let memoryEvidence: TurnEvidenceMemory | undefined
+  if (options.memory && options.memory.enabled === true) {
+    const memoryOptions = options.memory
+    // Bad configuration fails closed before any port call (#209 REQ-004):
+    // the adapter identity must be a bounded machine identifier.
+    if (!ADAPTER_IDENTITY_PATTERN.test(memoryOptions.adapterIdentity ?? "")) {
+      yield fail(
+        REASON_TO_CODE.memory_denied,
+        "memory adapter identity is missing or malformed",
+        "memory_denied",
+        false,
+      )
+      return
+    }
+    let recall: MemoryRecall | undefined
+    try {
+      recall = await memoryOptions.port.recall({
+        workspaceInstanceId: memoryOptions.workspaceInstanceId,
+        sessionId: memoryOptions.sessionId,
+        positionId: request.positionId,
+        principal: derivePositionPrincipal(request.positionId),
+        memoryScope: memoryOptions.memoryScope,
+        mode: memoryOptions.mode,
+        ...(memoryOptions.limit !== undefined
+          ? { limit: memoryOptions.limit }
+          : {}),
+      })
+    } catch (error) {
+      const portCode =
+        error instanceof MemoryPortError ? error.code : undefined
+      if (
+        memoryOptions.mode === "optional" &&
+        portCode === "MEMORY_UNAVAILABLE"
+      ) {
+        // Typed outage in optional mode: empty recall plus one warning; the
+        // turn proceeds without memory.
+        memoryEvidence = {
+          mode: "optional",
+          adapterIdentity: memoryOptions.adapterIdentity,
+          retrievedAt: timestamp(now),
+          itemCount: 0,
+          totalBytes: 0,
+          items: [],
+          warnings: [{ code: "MEMORY_UNAVAILABLE" }],
+        }
+      } else if (portCode === "MEMORY_UNAVAILABLE") {
+        // Required-mode outage: stable retryable failure before model call.
+        yield fail(
+          REASON_TO_CODE.memory_unavailable,
+          "durable memory is unavailable in required mode",
+          "memory_unavailable",
+          true,
+        )
+        return
+      } else {
+        // Denial, scope mismatch, malformed record, bad configuration, or
+        // unsupported contract: fail closed in both modes.
+        yield fail(
+          REASON_TO_CODE.memory_denied,
+          portCode !== undefined
+            ? `memory recall failed closed: ${portCode}`
+            : "memory recall failed closed",
+          "memory_denied",
+          false,
+        )
+        return
+      }
+    }
+    if (recall !== undefined) {
+      if (recall.schemaVersion !== MEMORY_RECALL_SCHEMA_VERSION) {
+        yield fail(
+          REASON_TO_CODE.memory_denied,
+          "memory recall returned an unexpected wire schema version",
+          "memory_denied",
+          false,
+        )
+        return
+      }
+      recallLines = recall.items.map((item) => item.text)
+      memoryEvidence = {
+        mode: memoryOptions.mode,
+        adapterIdentity: memoryOptions.adapterIdentity,
+        retrievedAt: recall.retrievedAt,
+        itemCount: recall.items.length,
+        totalBytes: recall.items.reduce(
+          (sum, item) => sum + Buffer.byteLength(item.text, "utf8"),
+          0,
+        ),
+        items: recall.items.map((item) => ({
+          digest: item.digest,
+          locator: item.locator,
+          kind: item.kind,
+          stateVersion: item.stateVersion,
+          byteLength: Buffer.byteLength(item.text, "utf8"),
+          provenanceDigest: digestProvenance(item.provenance),
+        })),
+        warnings: recall.warnings.map((warning) => ({ code: warning.code })),
+      }
+    }
+  }
+
   const assembled = assembleContext({
     positionId: request.positionId,
     turnId: request.turnId,
@@ -293,6 +446,7 @@ export async function* executeTurn(
       typeof request.input === "string"
         ? request.input
         : JSON.stringify(request.input),
+    memoryRecall: recallLines,
   })
 
   const detector = new DoomLoopDetector(options.doomLoop)
@@ -379,6 +533,7 @@ export async function* executeTurn(
             },
           }
         : {}),
+      ...(memoryEvidence !== undefined ? { memory: memoryEvidence } : {}),
       assemblyManifestDigest: assembled.manifest.digest,
       timeBounds: { startedAt, completedAt: timestamp(now) },
     }

--- a/tests/engine/turn-memory-recall.test.ts
+++ b/tests/engine/turn-memory-recall.test.ts
@@ -1,0 +1,379 @@
+import assert from "node:assert/strict"
+import { createHash } from "node:crypto"
+import test from "node:test"
+
+import {
+  MemoryPortError,
+  MEMORY_RECALL_SCHEMA_VERSION,
+  type MemoryPort,
+  type MemoryRecall,
+  type MemoryRecallItem,
+  type MemoryRecallRequest,
+} from "../../packages/core/src/memory-port.js"
+import {
+  createDeterministicModelPort,
+  createInMemoryEvidenceSink,
+  evidenceRecordContainsForbiddenMaterial,
+  executeTurn,
+} from "../../packages/engine/src/index.js"
+import type {
+  EngineEvent,
+  EngineMemoryOptions,
+  EngineTurnRequest,
+  TurnExecutorOptions,
+} from "../../packages/engine/src/index.js"
+
+const FIXED_NOW = () => new Date("2026-08-27T00:00:00.000Z")
+const WS_INSTANCE = "00000000-0000-4000-8000-000000000002"
+const SESSION = "00000000-0000-4000-8000-000000000003"
+const SCOPE = "/workspaces/00000000-0000-4000-8000-000000000002/positions/repo-owner"
+
+function baseRequest(overrides: Partial<EngineTurnRequest> = {}): EngineTurnRequest {
+  return {
+    workspaceRef: "ws-1",
+    positionId: "repo-owner",
+    turnId: "turn-1",
+    runId: "run-1",
+    input: "Summarize the open issues.",
+    budget: { maxIterations: 3 },
+    position: {
+      instructions: "You are the repo owner.",
+      spec: "mode=read_only",
+    },
+    ...overrides,
+  }
+}
+
+function recallItem(index: number, text: string): MemoryRecallItem {
+  const id = `00000000-0000-4000-8000-0000000000a${index}`
+  return {
+    memoryId: id,
+    kind: "task-state",
+    text,
+    digest: `sha256:${"ab".repeat(31)}${String(index).padStart(2, "0")}`,
+    citation: `mem://memories/${id}`,
+    locator: `mem://memories/${id}@1`,
+    stateVersion: 1,
+    recordedAt: "2026-08-26T00:00:00.000Z",
+    provenance: { sourceType: "test" },
+    trust: "untrusted",
+    authority: "none",
+  }
+}
+
+function makeRecall(
+  request: MemoryRecallRequest,
+  items: MemoryRecallItem[],
+  schemaVersion: string = MEMORY_RECALL_SCHEMA_VERSION,
+): MemoryRecall {
+  return {
+    schemaVersion: schemaVersion as typeof MEMORY_RECALL_SCHEMA_VERSION,
+    workspaceInstanceId: request.workspaceInstanceId,
+    sessionId: request.sessionId,
+    positionId: request.positionId,
+    principal: request.principal,
+    retrievedAt: "2026-08-27T00:00:00.000Z",
+    items,
+    warnings: [],
+  }
+}
+
+interface MockMemoryPort {
+  port: MemoryPort
+  requests: MemoryRecallRequest[]
+}
+
+function mockPort(
+  behavior: (request: MemoryRecallRequest) => MemoryRecall,
+): MockMemoryPort {
+  const requests: MemoryRecallRequest[] = []
+  return {
+    requests,
+    port: {
+      async writeTaskState() {
+        throw new MemoryPortError("MEMORY_DENIED", "writes are not under test")
+      },
+      async recall(request) {
+        requests.push(request)
+        return behavior(request)
+      },
+    },
+  }
+}
+
+function memoryOptions(
+  port: MemoryPort,
+  overrides: Partial<EngineMemoryOptions> = {},
+): EngineMemoryOptions {
+  return {
+    port,
+    enabled: true,
+    workspaceInstanceId: WS_INSTANCE,
+    sessionId: SESSION,
+    memoryScope: SCOPE,
+    mode: "optional",
+    adapterIdentity: "mem-http.v1",
+    ...overrides,
+  }
+}
+
+function expectedProvenanceDigest(provenance: Record<string, unknown>): string {
+  const canonical = JSON.stringify(provenance, Object.keys(provenance).sort())
+  return createHash("sha256").update(canonical ?? "{}", "utf8").digest("hex")
+}
+
+async function run(
+  request: EngineTurnRequest,
+  options: Omit<TurnExecutorOptions, "model" | "now"> &
+    Partial<Pick<TurnExecutorOptions, "model" | "now">>,
+): Promise<{ events: EngineEvent[]; evidence: ReturnType<typeof createInMemoryEvidenceSink> }> {
+  const evidenceSink = createInMemoryEvidenceSink()
+  const model =
+    options.model ?? createDeterministicModelPort(["plain answer"])
+  const events: EngineEvent[] = []
+  for await (const event of executeTurn(request, {
+    now: FIXED_NOW,
+    evidenceSink,
+    ...options,
+    model,
+  })) {
+    events.push(event)
+  }
+  return { events, evidence: evidenceSink }
+}
+
+test("memory recall disabled by default: no port call, no memory evidence", async () => {
+  const mock = mockPort((request) =>
+    makeRecall(request, [recallItem(1, "forgotten decision")]),
+  )
+  const { events, evidence } = await run(baseRequest(), {})
+  const terminals = events.filter(isTerminalEvent)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.completed")
+  assert.equal(mock.requests.length, 0)
+  assert.equal(evidence.records.length, 1)
+  assert.equal(evidence.records[0]!.memory, undefined)
+})
+
+test("enabled:false behaves as disabled", async () => {
+  const mock = mockPort((request) => makeRecall(request, []))
+  const { events } = await run(baseRequest(), {
+    memory: memoryOptions(mock.port, { enabled: false }),
+  })
+  assert.equal(events.filter(isTerminalEvent).length, 1)
+  assert.equal(mock.requests.length, 0)
+})
+
+test("optional happy path: recall feeds context, evidence is digest-only", async () => {
+  const secretText = "decision: ship v0.5.0 on Friday"
+  const mock = mockPort((request) =>
+    makeRecall(request, [recallItem(1, secretText), recallItem(2, "second note")]),
+  )
+  const withMemory = await run(baseRequest(), {
+    memory: memoryOptions(mock.port),
+  })
+  const baseline = await run(baseRequest(), {})
+
+  const terminals = withMemory.events.filter(isTerminalEvent)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.completed")
+
+  // The pinned port was called exactly once with the pinned binding.
+  assert.equal(mock.requests.length, 1)
+  const seen = mock.requests[0]!
+  assert.equal(seen.workspaceInstanceId, WS_INSTANCE)
+  assert.equal(seen.sessionId, SESSION)
+  assert.equal(seen.memoryScope, SCOPE)
+  assert.equal(seen.positionId, "repo-owner")
+  assert.equal(seen.principal, "position.repo-owner")
+  assert.equal(seen.mode, "optional")
+
+  // Recalled text changed the assembled context (input digest differs).
+  assert.equal(withMemory.evidence.records.length, 1)
+  const record = withMemory.evidence.records[0]!
+  assert.notEqual(
+    record.inputDigest,
+    baseline.evidence.records[0]!.inputDigest,
+  )
+
+  // Evidence carries digests/locators/versions only — never raw recall text.
+  assert.ok(record.memory)
+  assert.equal(record.memory!.mode, "optional")
+  assert.equal(record.memory!.adapterIdentity, "mem-http.v1")
+  assert.equal(record.memory!.itemCount, 2)
+  assert.equal(record.memory!.items.length, 2)
+  assert.equal(record.memory!.items[0]!.stateVersion, 1)
+  assert.equal(record.memory!.items[0]!.locator.endsWith("@1"), true)
+  // Provenance enters evidence only as the canonical digest (#209 REQ-001).
+  assert.equal(
+    record.memory!.items[0]!.provenanceDigest,
+    expectedProvenanceDigest({ sourceType: "test" }),
+  )
+  assert.deepEqual(record.memory!.warnings, [])
+  assert.equal(
+    evidenceRecordContainsForbiddenMaterial(record, [
+      secretText,
+      "second note",
+      '{"sourceType"',
+    ]),
+    false,
+  )
+})
+
+test("optional outage: empty recall with warning, turn proceeds", async () => {
+  const mock = mockPort(() => {
+    throw new MemoryPortError("MEMORY_UNAVAILABLE", "mem is down", {
+      retryable: true,
+    })
+  })
+  const model = createDeterministicModelPort(["plain answer"])
+  const { events, evidence } = await run(baseRequest(), {
+    model,
+    memory: memoryOptions(mock.port),
+  })
+  const terminals = events.filter(isTerminalEvent)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.completed")
+  const record = evidence.records[0]!
+  assert.ok(record.memory)
+  assert.equal(record.memory!.itemCount, 0)
+  assert.deepEqual(record.memory!.warnings, [{ code: "MEMORY_UNAVAILABLE" }])
+})
+
+test("required outage: retryable failure before any model consumption", async () => {
+  const mock = mockPort(() => {
+    throw new MemoryPortError("MEMORY_UNAVAILABLE", "mem is down", {
+      retryable: true,
+    })
+  })
+  const model = createDeterministicModelPort(["never reached"])
+  const { events, evidence } = await run(baseRequest(), {
+    model,
+    memory: memoryOptions(mock.port, { mode: "required" }),
+  })
+  const terminals = events.filter(isTerminalEvent)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.failed")
+  if (terminals[0]!.type === "run.failed") {
+    assert.equal(terminals[0]!.error.code, "engine.memory_unavailable")
+    assert.equal(terminals[0]!.error.terminalReason, "memory_unavailable")
+    assert.equal(terminals[0]!.error.retryable, true)
+  }
+  // No evidence record: the failure precedes the evidence sequence, matching
+  // the established early-fail paths. Model must not have been consumed.
+  assert.equal(evidence.records.length, 0)
+  assert.equal(events.some((event) => event.type === "model.delta"), false)
+})
+
+test("scope mismatch fails closed in optional mode with zero model calls", async () => {
+  const mock = mockPort(() => {
+    throw new MemoryPortError("MEMORY_SCOPE_MISMATCH", "wrong scope")
+  })
+  const model = createDeterministicModelPort(["never reached"])
+  const { events } = await run(baseRequest(), {
+    model,
+    memory: memoryOptions(mock.port, { mode: "optional" }),
+  })
+  const terminals = events.filter(isTerminalEvent)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.failed")
+  if (terminals[0]!.type === "run.failed") {
+    assert.equal(terminals[0]!.error.code, "engine.memory_denied")
+    assert.equal(terminals[0]!.error.terminalReason, "memory_denied")
+    assert.equal(terminals[0]!.error.retryable, false)
+  }
+  assert.equal(events.some((event) => event.type === "model.delta"), false)
+})
+
+test("malformed recall record fails closed in required mode", async () => {
+  const mock = mockPort(() => {
+    throw new MemoryPortError("MEMORY_RECORD_INVALID", "bad record")
+  })
+  const { events } = await run(baseRequest(), {
+    memory: memoryOptions(mock.port, { mode: "required" }),
+  })
+  const terminals = events.filter(isTerminalEvent)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.failed")
+  if (terminals[0]!.type === "run.failed") {
+    assert.equal(terminals[0]!.error.code, "engine.memory_denied")
+    assert.equal(terminals[0]!.error.retryable, false)
+  }
+})
+
+test("unexpected wire schema version fails closed", async () => {
+  const mock = mockPort((request) =>
+    makeRecall(request, [recallItem(1, "x")], "memory-recall.v9"),
+  )
+  const { events } = await run(baseRequest(), {
+    memory: memoryOptions(mock.port),
+  })
+  const terminals = events.filter(isTerminalEvent)
+  assert.equal(terminals.length, 1)
+  assert.equal(terminals[0]!.type, "run.failed")
+  if (terminals[0]!.type === "run.failed") {
+    assert.equal(terminals[0]!.error.code, "engine.memory_denied")
+    assert.equal(terminals[0]!.error.retryable, false)
+  }
+})
+
+// #209 AC-002 negative classes: revoked/expired grants, archived/forgotten
+// items, and tampered digests surface through typed port codes and all fail
+// closed before any model consumption with the stable engine.memory_denied
+// code (code generation for these classes is proven at the adapter level in
+// #181 AC-003; the seam must fail closed on every one of them).
+const AC002_NEGATIVE_CODES = [
+  "MEMORY_DENIED",
+  "MEMORY_NOT_FOUND",
+  "MEMORY_RECORD_INVALID",
+  "MEMORY_SCOPE_INVALID",
+] as const
+
+for (const code of AC002_NEGATIVE_CODES) {
+  test(`AC-002: ${code} fails closed before any model consumption`, async () => {
+    const mock = mockPort(() => {
+      throw new MemoryPortError(code, "negative fixture")
+    })
+    const model = createDeterministicModelPort(["never reached"])
+    const { events, evidence } = await run(baseRequest(), {
+      model,
+      memory: memoryOptions(mock.port),
+    })
+    const terminals = events.filter(isTerminalEvent)
+    assert.equal(terminals.length, 1)
+    assert.equal(terminals[0]!.type, "run.failed")
+    if (terminals[0]!.type === "run.failed") {
+      assert.equal(terminals[0]!.error.code, "engine.memory_denied")
+      assert.equal(terminals[0]!.error.terminalReason, "memory_denied")
+      assert.equal(terminals[0]!.error.retryable, false)
+    }
+    assert.equal(mock.requests.length, 1)
+    assert.equal(events.some((event) => event.type === "model.delta"), false)
+    assert.equal(evidence.records.length, 0)
+  })
+}
+
+test("AC-002: missing or malformed adapter identity fails closed before any port call", async () => {
+  for (const bad of ["", " leading-space", "has space", "x".repeat(129)]) {
+    const mock = mockPort((request) => makeRecall(request, []))
+    const model = createDeterministicModelPort(["never reached"])
+    const { events } = await run(baseRequest(), {
+      model,
+      memory: memoryOptions(mock.port, { adapterIdentity: bad }),
+    })
+    const terminals = events.filter(isTerminalEvent)
+    assert.equal(terminals.length, 1, `identity ${JSON.stringify(bad)}`)
+    assert.equal(terminals[0]!.type, "run.failed")
+    if (terminals[0]!.type === "run.failed") {
+      assert.equal(terminals[0]!.error.code, "engine.memory_denied")
+      assert.equal(terminals[0]!.error.terminalReason, "memory_denied")
+      assert.equal(terminals[0]!.error.retryable, false)
+    }
+    assert.equal(mock.requests.length, 0)
+    assert.equal(events.some((event) => event.type === "model.delta"), false)
+  }
+})
+
+function isTerminalEvent(event: EngineEvent): boolean {
+  return event.type === "run.completed" || event.type === "run.failed"
+}


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/209
- Consumed revision: R1
- Consumed decision: DEC-DE-209-001 (carve-out of the #180 AC-004 wiring slice; #180 accepted via DEC-DE-180-002)
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 + AC-004 (turn-evidence memory consumption fields, digest-only) | packages/engine/src/turn-evidence.ts (TurnEvidenceMemory: mode, adapterIdentity, retrievedAt, itemCount, totalBytes, items, warnings; TurnEvidenceMemoryItem: digest, locator, kind, stateVersion, byteLength, provenanceDigest), packages/engine/src/turn-executor.ts (evidence construction), packages/engine/src/index.ts (type exports) | turn-memory-recall.test.ts optional happy path asserts adapterIdentity, per-item digest/locator/stateVersion, provenanceDigest stability, warnings; AC-004 evidence shape validates against the declared form with digests only; forbidden-material probes prove no raw recall text or raw provenance enter the record |
| REQ-002 + AC-001 (context-assembly memory_recall seam, granted happy path) | packages/engine/src/turn-executor.ts (recall lines projected into assembleContext memoryRecall), packages/engine/src/context-assembler.ts (pre-existing memory_recall slot in deterministic slot order from the #181 seam) | turn-memory-recall.test.ts optional happy path: granted run recalls exactly the authorized pack through the pinned binding (workspace instance, session, position, principal, scope asserted on the port request), input digest differs from the no-memory baseline proving recall entered assembly, assembly order deterministic via the assembler's fixed slot order recorded in the assembly manifest digest |
| REQ-003 + AC-003 (optional/required dual mode, no automatic retry) | packages/engine/src/turn-executor.ts (optional outage degrades to empty recall plus one typed warning; required outage settles engine.memory_unavailable retryable before any model call; RETRYABLE_REASONS marks memory_unavailable only) | turn-memory-recall.test.ts mode fixtures: optional outage fixture completes run.completed with a MEMORY_UNAVAILABLE warning; the same outage under required mode yields run.failed engine.memory_unavailable retryable=true with zero model.delta and no evidence record; no automatic retry in either path |
| REQ-004 + AC-002 (cross-scope fail-closed, stable codes, no model) | packages/engine/src/turn-executor.ts (any typed MemoryPortError except optional-mode MEMORY_UNAVAILABLE fails closed as engine.memory_denied retryable=false before model consumption; malformed or missing adapter identity fails closed before any port call; unexpected wire schema version fails closed; pinned scope passed through unchanged, never supplied or widened by turn input) | turn-memory-recall.test.ts negative fixtures: MEMORY_SCOPE_MISMATCH, MEMORY_DENIED (revoked/expired grant class), MEMORY_NOT_FOUND (archived/forgotten class), MEMORY_RECORD_INVALID (tampered-record class), MEMORY_SCOPE_INVALID, malformed adapter identity, and unexpected schema version all invoke no model and settle engine.memory_denied; adapter-level generation of these codes is proven by #181 AC-003 |
| REQ-005 + AC-005 (credential boundary unchanged, secret-safe) | packages/engine/src/turn-executor.ts (seam consumes the pinned MemoryPort only; no token, argv, or request-JSON surface), packages/core/src/mem-http-memory-adapter.ts (env-only MEM_*_TOKEN consumption stays server-side per #181) | turn-memory-recall.test.ts evidenceRecordContainsForbiddenMaterial probes for recall text and raw provenance JSON are negative; locators are mem:// URIs with no absolute local path; no token surface exists in the wiring (static review of the seam) |

## File domains

- packages/engine/src/turn-executor.ts — memory-recall seam before any model consumption: EngineMemoryOptions (disabled by default; pinned workspace instance + session + scope binding; adapter identity validation), optional/required settlement, digest-only evidence construction; owned by REQ-002/REQ-003/REQ-004.
- packages/engine/src/turn-evidence.ts — TurnEvidenceMemory / TurnEvidenceMemoryItem / TurnEvidenceMemoryWarning (digest-only consumption evidence incl. adapter identity and per-item provenance digests); owned by REQ-001.
- packages/engine/src/contracts.ts — memory_unavailable / memory_denied terminal reasons; owned by REQ-003/REQ-004.
- packages/engine/src/index.ts — EngineMemoryOptions + memory evidence type exports; owned by REQ-001.
- packages/core/src/memory-port.ts — consumed only; port contract frozen by #180 R1, unchanged here.
- tests/engine/turn-memory-recall.test.ts — deterministic engine-axis fixtures for AC-001..AC-005.
- docs/engine-codex-semantic-mapping.md — memory_unavailable / memory_denied coverage rows + settlement note (vocabulary change lands with the mapping doc in the same PR).
- CHANGELOG.md — entry under [Unreleased].

## Scope and non-goals

User-visible change: with memory explicitly enabled on the executor, a turn recalls the position's reviewed durable memory through the pinned MemoryPort before any model consumption, projects it into the memory_recall context slot as quoted untrusted data, and records digest-only consumption evidence; outages degrade or fail per mode; every denial class fails closed with stable codes.

Non-goals (per #209): no new MemoryPort capability (port contract frozen by #180 R1); no recall-quality or ranking claims; no conversation-history copy; no Host resume; no live Qoder/Claude qualification; memory stays disabled by default.

Design notes for the needs-design record (REQ-001 interpretations fixed here for product review): provenance enters evidence only as a sha256 digest over the canonical provenance block, because raw provenance fields can carry producer identifiers the evidence standard keeps out of records; adapter identity is a bounded machine identifier (pattern `[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}`, e.g. "mem-http.v1") supplied through EngineMemoryOptions since the MemoryPort contract is frozen, validated before any port call with a missing or malformed identity failing closed as engine.memory_denied.

## Validation

- Exact commands: `npm run typecheck`; `npx tsx --test --test-concurrency=1 tests/engine/turn-memory-recall.test.ts`; `npm run check`; `npm run governance:check`; `npm run security:check`
- Observed counts/results: targeted memory-recall fixture PASS 13/13; full suite PASS 1809/1811 with the single failure being the pre-existing WSL-environmental `deploy-cli` HTTP-activation IPC-lease test (fails on clean main; Linux CI authoritative); governance:check PASS (7 allowlisted PR fixtures); security:check PASS.
- Check URLs: NOT VERIFIED: CI triggers on PR creation; the green run URL will be posted as a follow-up comment.

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-001 | granted turn injects exactly the authorized recall pack; evidence digest-only; assembly order deterministic | `npx tsx --test tests/engine/turn-memory-recall.test.ts` | WSL Ubuntu-22.04, Node v22.14.0 | pinned binding asserted on the port request; input digest differs from baseline; digest-only evidence | optional happy path fixture green | PASS |
| V2 | AC-002 | cross-scope, revoked, expired, archived, forgotten, tampered-digest recall invoke no model and produce stable codes | `npx tsx --test tests/engine/turn-memory-recall.test.ts` | WSL Ubuntu-22.04, Node v22.14.0 | engine.memory_denied, retryable=false, zero model.delta per class | scope-mismatch + 4 negative-code + identity + schema-version fixtures green | PASS |
| V3 | AC-003 | optional outage completes with typed warning; required outage fails before model; no automatic retry | `npx tsx --test tests/engine/turn-memory-recall.test.ts` | WSL Ubuntu-22.04, Node v22.14.0 | run.completed + warning / run.failed engine.memory_unavailable retryable | both mode fixtures green | PASS |
| V4 | AC-004 | memory evidence validates with digests only, no raw recall text or raw provenance | `npx tsx --test tests/engine/turn-memory-recall.test.ts` | WSL Ubuntu-22.04, Node v22.14.0 | shape assertions green, forbidden-material probes negative | green | PASS |
| V5 | AC-005 | no token, transcript body, or absolute local path in evidence | `npx tsx --test tests/engine/turn-memory-recall.test.ts` | WSL Ubuntu-22.04, Node v22.14.0 | probes negative, mem:// locators only | green | PASS |
| V6 | AC-001 (live axis) | same criterion against actual local mem/PostgreSQL | separate live lane per the issue evidence plan | local mem + PostgreSQL | happy path E3 | not executed in this PR | NOT VERIFIED |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs. (evidence carries digests, locators, and bounded counters only; recall text and raw provenance never enter records)
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed. (no dependency change)
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded. (full suite 1809/1811 with the single pre-existing WSL-environmental deploy-cli failure; governance:check and security:check pass)
- [x] Behavior changes carry a matching docs delta, or this body records the explicit no-doc-needed reason. (CHANGELOG.md entry and docs/engine-codex-semantic-mapping.md settlement note land in the same PR)

Compatibility: strictly additive engine surface. Memory stays disabled by default; an executor without `memory` options behaves byte-identically. The MemoryPort contract (#180 R1) is untouched. turn-evidence.v1 gains an optional `memory` field — existing records stay valid. No cross-repository effect: org-workbench consumes the seam later through its own harness wiring (org-workbench#12 owns the initiation decision).

## Known limitations

- The AC-001 live local-mem E3 axis is not executed in this PR (three-axis discipline: deterministic fixture axis delivered here; live axis runs as a separate lane per the issue evidence plan).
- The session-rotation trigger binding with org-workbench#12 (who initiates recall on session create/rotate) is the recorded open decision in #209 and is untouched here: the engine consumes the pinned port supplied by the harness; initiation is a harness-side concern.
- Recall is projected verbatim into the memory_recall slot in adapter order; no ranking or compaction (frozen contract, explicit non-goal).

## Risk and rollback

Additive opt-in seam on the engine execution chain; rollback reverts the commit. No irreversible effect, no migration, no credential surface change.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: W1 — Workspace closed loop; release packet lands with the v0.6.0 cut
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
