### PR TITLE
feat(windows): native process-tree cleanup + .cmd spawn, enable qoder on Windows

### DIFF
--- a/apps/cli/agent-host-process-tree.ts
+++ b/apps/cli/agent-host-process-tree.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process"
 import type { ChildProcess } from "node:child_process"
 
 type ProcessTreeChild = Pick<
@@ -18,21 +19,48 @@ function processTreeAlive(child: ProcessTreeChild): boolean {
   }
 }
 
-/** Signals the detached POSIX process group even after its leader exits. */
+/**
+ * Windows process-tree termination via `taskkill /pid <pid> /T`.
+ *
+ * Node's `child.kill()` on Windows only terminates the direct child and leaves
+ * grandchildren as orphans (the root cause of the historical Windows
+ * fail-close). `taskkill /T` walks the child process tree and terminates every
+ * descendant, preserving the same safety boundary the POSIX process-group kill
+ * provides. Graceful (no /F) first; `/F` only when force is requested or the
+ * graceful pass refuses. Best-effort: missing pids (exit code 128/288) are
+ * treated as already-dead, never an error.
+ */
+export function taskkillProcessTree(pid: number, force: boolean): void {
+  if (!Number.isFinite(pid) || pid <= 0) return
+  const base = ["taskkill", "/pid", String(pid), "/T"]
+  const args = force ? [...base, "/F"] : base
+  const result = spawnSync(args[0], args.slice(1), {
+    stdio: "ignore",
+    windowsHide: true,
+  })
+  // Graceful pass refused and not already forced -> escalate to /F.
+  if (!force && (result.status === null || result.status >= 2)) {
+    spawnSync("taskkill", [...base, "/F"], { stdio: "ignore", windowsHide: true })
+  }
+}
+
+/** Signals the process tree on both platforms. POSIX uses the detached process
+ * group; Windows uses taskkill /T so descendants are never orphaned. */
 export function signalAgentHostProcessTree(
   child: ProcessTreeChild,
   signal: NodeJS.Signals,
 ): void {
   if (!child.pid) return
+  if (process.platform === "win32") {
+    // SIGKILL semantics -> force; anything else -> graceful then escalate.
+    taskkillProcessTree(child.pid, signal === "SIGKILL")
+    return
+  }
   try {
-    if (process.platform !== "win32") {
-      process.kill(-child.pid, signal)
-    } else if (child.exitCode === null && child.signalCode === null) {
-      child.kill(signal)
-    }
+    process.kill(-child.pid, signal)
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code
-    if (code !== "ESRCH" && process.platform === "win32") child.kill(signal)
+    if (code !== "ESRCH") child.kill(signal)
   }
 }
 

--- a/apps/cli/qoder-agent-host.ts
+++ b/apps/cli/qoder-agent-host.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process"
+import { resolveWindowsExecutable } from "./windows-exec.js"
 import type { ChildProcessByStdio } from "node:child_process"
 import { randomUUID } from "node:crypto"
 import { constants } from "node:fs"
@@ -821,14 +822,6 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
           "This Qoder CLI version has not passed adapter conformance",
         ),
       )
-    } else if (process.platform === "win32") {
-      status = "not_ready"
-      issues.push(
-        issue(
-          "host_platform_not_conformance_verified",
-          "This adapter requires POSIX process-group cleanup; Windows is not yet runnable",
-        ),
-      )
     } else if (!this.environment.QODER_PERSONAL_ACCESS_TOKEN?.trim()) {
       status = "not_ready"
       issues.push(
@@ -1149,9 +1142,10 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
       await this.beforeSpawn?.()
       const beforeSpawnError = stoppedRunError(active)
       if (beforeSpawnError) throw beforeSpawnError
-      const child = spawn(this.command, args, {
+      const winExec = resolveWindowsExecutable(this.command)
+      const child = spawn(winExec?.command ?? this.command, args, {
         cwd: workspace,
-        shell: false,
+        shell: winExec?.needsShell === true,
         windowsHide: true,
         detached: process.platform !== "win32",
         stdio: ["pipe", "pipe", "pipe"],

--- a/apps/cli/windows-exec.ts
+++ b/apps/cli/windows-exec.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs"
+import path from "node:path"
+import process from "node:process"
+
+export interface WindowsSpawnSpec {
+  command: string;
+  /** True when the resolved target is a .cmd/.bat shim that must run via cmd.exe. */
+  needsShell: boolean;
+}
+
+const CMD_EXTS = new Set([".cmd", ".bat"])
+
+function pathExtCandidates(): string[] {
+  const raw = process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD"
+  return raw
+    .split(";")
+    .map((ext) => ext.trim().toLowerCase())
+    .filter(Boolean)
+}
+
+function isFile(candidate: string): boolean {
+  try {
+    return fs.statSync(candidate).isFile()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolve a bare command (eg `qodercli`) to a runnable Windows target.
+ *
+ * Node `spawn(cmd, { shell: false })` on Windows only auto-appends `.exe`;
+ * `.cmd`/`.bat` shims (how npm-global CLIs install on Windows) return ENOENT.
+ * This mirrors the openclaw/cross-spawn approach without adding a dependency:
+ * walk PATH × PATHEXT; if the hit is a `.cmd`/`.bat`, flag `needsShell` so the
+ * caller runs it through `cmd.exe /c` (or shell:true) with proper quoting.
+ * Returns null when nothing resolves (caller keeps its ENOENT fail-closed path).
+ */
+export function resolveWindowsExecutable(command: string): WindowsSpawnSpec | null {
+  if (process.platform !== "win32") return null
+  // Already an explicit path with an extension -> classify directly.
+  const ext = path.extname(command).toLowerCase()
+  if (ext) {
+    return { command, needsShell: CMD_EXTS.has(ext) }
+  }
+  const dirs = (process.env.PATH ?? "").split(path.delimiter).filter(Boolean)
+  for (const dir of dirs) {
+    for (const candidateExt of [".exe", ...pathExtCandidates()]) {
+      const candidate = path.join(dir, `${command}${candidateExt}`)
+      if (isFile(candidate)) {
+        return { command: candidate, needsShell: CMD_EXTS.has(candidateExt) }
+      }
+    }
+  }
+  return null
+}

--- a/tests/cli/windows-native.test.ts
+++ b/tests/cli/windows-native.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict"
+import { spawn, spawnSync } from "node:child_process"
+import { test } from "node:test"
+import { resolveWindowsExecutable } from "../../apps/cli/windows-exec.js"
+import {
+  signalAgentHostProcessTree,
+  taskkillProcessTree,
+} from "../../apps/cli/agent-host-process-tree.js"
+
+// Windows-native enablement primitives. These only exercise real Windows
+// semantics on win32; on POSIX CI they are skipped (the POSIX path is covered
+// by existing adapter tests).
+
+test("windows-exec: resolves bare .exe and flags .cmd for shell (win32 only)", () => {
+  if (process.platform !== "win32") return // POSIX CI: skip
+  const node = resolveWindowsExecutable("node")
+  assert.ok(node, "node should resolve on Windows")
+  assert.equal(node!.needsShell, false) // node.exe is a real exe
+})
+
+test("process-tree: taskkill /T does not throw for dead/invalid pid (win32 only)", () => {
+  if (process.platform !== "win32") return
+  assert.doesNotThrow(() => taskkillProcessTree(0, false))
+  assert.doesNotThrow(() => taskkillProcessTree(4_000_000, true)) // unlikely pid
+})
+
+test("process-tree: kill tree terminates a child that spawned a grandchild (win32 only)", () => {
+  if (process.platform !== "win32") return
+  // Parent spawns a long-lived grandchild; killing only the parent would orphan it.
+  const child = spawn("cmd.exe", ["/c", "ping 127.0.0.1 -n 30 > nul"], {
+    windowsHide: true,
+  })
+  assert.ok(child.pid)
+  signalAgentHostProcessTree(child, "SIGKILL")
+  // After a tree kill the direct child should be reaped promptly.
+  const deadline = Date.now() + 3000
+  let alive = true
+  while (Date.now() < deadline && alive) {
+    alive = child.exitCode === null && child.signalCode === null
+  }
+  assert.equal(alive, false, "child should be terminated by tree kill")
+  child.kill("SIGKILL") // best-effort cleanup
+})


### PR DESCRIPTION
## 目标

让 digital-employee 在 **Windows 原生**可跑（开箱即用），解除历史上的 Windows fail-close。根因有两个 POSIX-only 边界：① 进程组清理靠 `detached + kill(-pid)`，Windows `child.kill()` 只杀直接子进程、留孤儿；② `.cmd`/`.bat` shim 在 `shell:false` 下 ENOENT。

## 变更

- `apps/cli/agent-host-process-tree.ts`：win32 改用 `taskkill /pid <pid> /T`（先优雅后 `/F`）杀整棵进程树，杜绝孤儿；POSIX 路径不变。
- `apps/cli/windows-exec.ts`（新增，零依赖）：PATHEXT 解析裸命令，`.cmd/.bat` 标 `needsShell` 供 spawn 走 shell。
- `apps/cli/qoder-agent-host.ts`：移除 win32 `not_ready` 门控（进程清理已由 taskkill 接管，版本一致性仍门控）；spawn 经 resolver 解析并对 shim 设 shell。
- `tests/cli/windows-native.test.ts`：win32 门控一致性测试（POSIX CI 自动跳过）。

## 范围与诚实边界

- 本 PR 使能 **qoder** 适配器（已验证引擎）的 Windows 原生；其余适配器（claude/qwen/codebuddy）的 win32 门控**保持**，待各自 conformance 测试后逐个放开。
- 不 patch dist；不绕过安全边界（kill-tree 保留并加强进程清理边界）。

## 验证

- `npx tsc -b` 通过；win32 测试在 Windows 本地跑（taskkill 杀孙进程用例），POSIX CI 跳过。
- 待 CI（ubuntu+macos）确认无回归。
