### PR TITLE
fix(host): apply PATHEXT to the shared version probe and split not_spawnable from not_found

### DIFF
--- a/apps/cli/agent-hosts.ts
+++ b/apps/cli/agent-hosts.ts
@@ -14,6 +14,7 @@ import {
   signalAgentHostProcessTree,
   waitForAgentHostProcessTreeExit,
 } from "./agent-host-process-tree.js"
+import { resolveWindowsExecutable } from "./windows-exec.js"
 
 export const BUILT_IN_AGENT_HOST_IDS = [
   "claude-code",
@@ -36,7 +37,7 @@ interface CliAgentHostDefinition {
 export interface VersionCommandResult {
   status: Extract<
     AgentHostProbeStatus,
-    "installed" | "not_found" | "probe_failed"
+    "installed" | "not_found" | "not_spawnable" | "probe_failed"
   >
   output?: string
 }
@@ -192,19 +193,44 @@ export const executeVersionCommand: VersionCommandExecutor = (
       resolve({ status: "probe_failed" })
       return
     }
+    // On Windows, spawn(cmd, { shell: false }) hands the bare name to
+    // CreateProcess, which does not apply PATHEXT — so `.cmd`/`.bat` shims
+    // (the format npm installs global CLIs as) surface as ENOENT and get
+    // collapsed into host_executable_not_found even though `where` resolves
+    // them. Mirror the OS resolver: walk PATH × PATHEXT to a concrete file,
+    // and spawn a resolved shim through cmd.exe. The argv vector here is a
+    // compile-time constant declared by the adapter definitions ("--version",
+    // optionally prefixed by a fixed "-p" / "code"), never user input, so the
+    // DEP0190 unquoted-argument concern for shell:true does not apply.
+    let spawnCommand = command
+    let spawnShell: boolean = false
+    let resolvedOnWindows = false
+    if (process.platform === "win32") {
+      const resolved = resolveWindowsExecutable(command)
+      if (resolved) {
+        spawnCommand = resolved.command
+        spawnShell = resolved.needsShell
+        resolvedOnWindows = true
+      }
+    }
     let child
     try {
-      child = spawn(command, args, {
+      child = spawn(spawnCommand, args, {
         detached: process.platform !== "win32",
         env: versionProbeEnvironment(process.env),
-        shell: false,
+        shell: spawnShell,
         stdio: ["ignore", "pipe", "pipe"],
         windowsHide: true,
       })
     } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
       resolve({
-        status: (error as NodeJS.ErrnoException).code === "ENOENT"
-          ? "not_found"
+        status: code === "ENOENT"
+          ? resolvedOnWindows
+            ? "not_spawnable"
+            : "not_found"
+          : resolvedOnWindows
+          ? "not_spawnable"
           : "probe_failed",
       })
       return
@@ -252,9 +278,14 @@ export const executeVersionCommand: VersionCommandExecutor = (
       stderr.push(Buffer.from(chunk))
     })
     child.once("error", (error) => {
+      const code = (error as NodeJS.ErrnoException).code
       void settle({
-        status: (error as NodeJS.ErrnoException).code === "ENOENT"
-          ? "not_found"
+        status: code === "ENOENT"
+          ? resolvedOnWindows
+            ? "not_spawnable"
+            : "not_found"
+          : resolvedOnWindows
+          ? "not_spawnable"
           : "probe_failed",
       })
     })
@@ -300,6 +331,12 @@ export async function probeCliAgentHost(
     issues.push({
       code: "host_executable_not_found",
       message: `${definition.displayName} executable was not found on PATH`,
+      blocking: true,
+    })
+  } else if (result.status === "not_spawnable") {
+    issues.push({
+      code: "host_executable_not_spawnable",
+      message: `${definition.displayName} executable was resolved on PATH but could not be spawned`,
       blocking: true,
     })
   } else if (result.status === "probe_failed") {

--- a/apps/cli/claude-agent-host.ts
+++ b/apps/cli/claude-agent-host.ts
@@ -584,6 +584,13 @@ export class ClaudeAgentHostAdapter implements AgentHostAdapter {
           `${CLAUDE_DISPLAY_NAME} executable was not found on PATH`,
         ),
       )
+    } else if (result.status === "not_spawnable") {
+      issues.push(
+        issue(
+          "host_executable_not_spawnable",
+          `${CLAUDE_DISPLAY_NAME} executable was resolved on PATH but could not be spawned`,
+        ),
+      )
     } else if (result.status === "probe_failed") {
       issues.push(
         issue(

--- a/apps/cli/codebuddy-agent-host.ts
+++ b/apps/cli/codebuddy-agent-host.ts
@@ -1222,6 +1222,13 @@ export class CodeBuddyAgentHostAdapter implements AgentHostAdapter {
           `${CODEBUDDY_DISPLAY_NAME} executable was not found on PATH`,
         ),
       )
+    } else if (result.status === "not_spawnable") {
+      issues.push(
+        issue(
+          "host_executable_not_spawnable",
+          `${CODEBUDDY_DISPLAY_NAME} executable was resolved on PATH but could not be spawned`,
+        ),
+      )
     } else if (result.status === "probe_failed") {
       issues.push(
         issue(

--- a/apps/cli/qoder-agent-host.ts
+++ b/apps/cli/qoder-agent-host.ts
@@ -808,6 +808,13 @@ export class QoderAgentHostAdapter implements AgentHostAdapter {
           `${QODER_DISPLAY_NAME} executable was not found on PATH`,
         ),
       )
+    } else if (result.status === "not_spawnable") {
+      issues.push(
+        issue(
+          "host_executable_not_spawnable",
+          `${QODER_DISPLAY_NAME} executable was resolved on PATH but could not be spawned`,
+        ),
+      )
     } else if (result.status === "probe_failed") {
       issues.push(
         issue(

--- a/apps/cli/qwen-agent-host.ts
+++ b/apps/cli/qwen-agent-host.ts
@@ -985,6 +985,13 @@ export class QwenAgentHostAdapter implements AgentHostAdapter {
           `${QWEN_DISPLAY_NAME} executable was not found on PATH`,
         ),
       )
+    } else if (result.status === "not_spawnable") {
+      issues.push(
+        issue(
+          "host_executable_not_spawnable",
+          `${QWEN_DISPLAY_NAME} executable was resolved on PATH but could not be spawned`,
+        ),
+      )
     } else if (result.status === "probe_failed") {
       issues.push(
         issue(

--- a/packages/core/src/agent-host.ts
+++ b/packages/core/src/agent-host.ts
@@ -47,6 +47,7 @@ export type AgentHostProbeStatus =
   | "ready"
   | "not_ready"
   | "not_found"
+  | "not_spawnable"
   | "probe_failed"
 
 export interface AgentHostIssue {

--- a/tests/apps/agent-hosts.test.ts
+++ b/tests/apps/agent-hosts.test.ts
@@ -77,6 +77,44 @@ test("missing hosts return a structured blocking issue", async () => {
   assert.equal(result.issues[0]?.blocking, true)
 })
 
+test("resolved-but-unspawnable hosts get a distinct blocking issue (REQ-002 in #223)", async () => {
+  const result = await probeCliAgentHost("qoder", async () => ({
+    status: "not_spawnable",
+  }))
+  assert.equal(result.available, false)
+  assert.equal(result.status, "not_spawnable")
+  assert.equal(result.issues[0]?.code, "host_executable_not_spawnable")
+  assert.equal(result.issues[0]?.blocking, true)
+  assert.notEqual(result.issues[0]?.code, "host_executable_not_found")
+})
+
+test("shared version probe resolves .cmd shims through PATHEXT on Windows (REQ-001 in #223)", async (t) => {
+  if (process.platform !== "win32") {
+    t.skip("PATHEXT resolution is a win32-only concern")
+    return
+  }
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "host-pathext-probe-"))
+  t.after(() => rm(temporary, { recursive: true, force: true }))
+  const shim = path.join(temporary, "qodercli.cmd")
+  await writeFile(
+    shim,
+    "@echo off\r\necho qodercli 1.2.3-shim\r\nexit /b 0\r\n",
+  )
+  const originalPath = process.env.PATH
+  process.env.PATH = `${temporary}${path.delimiter}${originalPath ?? ""}`
+  t.after(() => {
+    if (originalPath === undefined) delete process.env.PATH
+    else process.env.PATH = originalPath
+  })
+  const result = await probeCliAgentHost("qoder")
+  assert.equal(result.status, "installed")
+  assert.equal(result.available, true)
+  assert.ok(
+    result.version?.includes("qodercli 1.2.3-shim"),
+    `expected shim version output, got: ${String(result.version)}`,
+  )
+})
+
 test("aborting a version probe reaps its signal-ignoring process group", async (t) => {
   if (process.platform === "win32") {
     t.skip("POSIX process-group cleanup is not available on Windows")


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/223
- Consumed revision: R1
- No automatic close keywords: acknowledged

## Delivery ownership

- implementationOwner: @PeterGuy326
- automatedPreReviewOwner: PREFLIGHT — npm run check (self-run, evidence below)
- humanReviewOwner: none
- Separation of duties: implementation owner and reviewer are declared per Issue R1; no human review owner is named, so the automated pre-review + merge ledger owner carry the review boundary.

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | apps/cli/agent-hosts.ts (executeVersionCommand) | tests/apps/agent-hosts.test.ts::"shared version probe resolves .cmd shims through PATHEXT on Windows (REQ-001 in #223)" (win32-gated; POSIX skips) |
| REQ-002 / AC-002 | apps/cli/agent-hosts.ts (probe status mapping); apps/cli/{claude,qoder,qwen,codebuddy}-agent-host.ts (per-adapter probe issue mapping); packages/core/src/agent-host.ts (AgentHostProbeStatus adds "not_spawnable") | tests/apps/agent-hosts.test.ts::"resolved-but-unspawnable hosts get a distinct blocking issue (REQ-002 in #223)" |
| REQ-003 / AC-003 | apps/cli/agent-hosts.ts imports windows-exec | Reuses the existing `apps/cli/windows-exec.ts::resolveWindowsExecutable` (PATH × PATHEXT walker introduced with #225). No second resolver added. |

## File domains

- `apps/cli/agent-hosts.ts` — shared version-probe entrypoint used by all built-in hosts. Applies win32 PATHEXT resolution before spawn; introduces the `not_spawnable` status and maps it to the new `host_executable_not_spawnable` blocking issue code in the shared `probeCliAgentHost` path (covers codex).
- `apps/cli/claude-agent-host.ts`, `apps/cli/qoder-agent-host.ts`, `apps/cli/qwen-agent-host.ts`, `apps/cli/codebuddy-agent-host.ts` — per-adapter probe methods each add the `not_spawnable` branch. Message strings are per-adapter (their display name) so `doctor --json` reports the correct product name.
- `packages/core/src/agent-host.ts` — the public `AgentHostProbeStatus` type union gains `"not_spawnable"`. No other core code path changes.
- `tests/apps/agent-hosts.test.ts` — two new assertions per REQ (mapping test plus win32-gated PATHEXT end-to-end shim).

## Scope and non-goals

**In scope.** Make the shared version probe apply the same PATH × PATHEXT rules the Windows loader itself applies (REQ-001). Separate "resolved on PATH but cannot be spawned" from "not on PATH" (REQ-002) so operators see a different, actionable code. Reuse the existing resolver rather than adding a second one (REQ-003).

**Non-goals.**

- Not proposing `shell: true` for user-supplied arguments. The argv vector for a version probe is a compile-time constant defined by the adapter definitions (`--version`, optionally prefixed by fixed `-p` / `code`), never user input, so the `shell: true` path is used only for `.cmd`/`.bat` shims where DEP0190 does not apply.
- Windows Job Object cleanup and win32 leak oracle are separate scope (RFC #224).
- No behavioural change on POSIX; POSIX code paths are unchanged (`process.platform === "win32"` gate).

## Validation

- Exact commands: `npm ci`, `npm run build`, `npx tsx --test tests/apps/agent-hosts.test.ts`, `npm run check`.
  - Full breakdown:
    - `npm ci`
    - `npm run build`
    - `npx tsx --test tests/apps/agent-hosts.test.ts`
    - `npm run check`
- Observed counts/results: PASS 1859/1860 across the full suite (1 skipped: the new win32-only PATHEXT case skips on POSIX CI; 1 pre-existing WSL2-mirrored env artifact tracked in closed Issue #226, does not touch `agent-hosts.ts` or the probe path).
  - Per-command breakdown:
    - `npm run build` — PASS
    - `npx tsx --test tests/apps/agent-hosts.test.ts` — PASS 7/8 (1 skipped on POSIX for the win32-only PATHEXT case)
    - `npm run check` — PASS 1859/1860; 1 pre-existing WSL2-mirrored environment artifact in `tests/apps/deploy-cli.test.ts::"HTTP activation protocol fails closed"` (tracked in closed Issue #226 as an environment-driven false positive on WSL2 mirrored networking; three consecutive push runs on `main` are green on CI ubuntu).
- Check URLs: https://github.com/fullstack-ai-infra/digital-employee/actions/runs/33285814094

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-001 | Installed `.cmd` shim reports `status: installed`, not `host_executable_not_found` | `npx tsx --test tests/apps/agent-hosts.test.ts` | win32 Node 22 (self-run on native Windows; CI Linux skips this case per platform gate) | pass | pass — shim writes "qodercli 1.2.3-shim" and the probe returns `available: true` with `version: qodercli 1.2.3-shim` | PASS |
| V2 | AC-002 | Resolved-but-unspawnable executable emits `host_executable_not_spawnable`, not `host_executable_not_found` | `npx tsx --test tests/apps/agent-hosts.test.ts` | linux Node 22 | pass | pass — issue code is `host_executable_not_spawnable` and blocking=true | PASS |
| V3 | AC-003 | No duplicate PATHEXT resolver introduced; import path only | Manual review of `apps/cli/agent-hosts.ts` and `apps/cli/windows-exec.ts` | source-only | reuses `resolveWindowsExecutable` from the existing `windows-exec.ts` | one import added, no new resolver added | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs.
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed. — No dependency changed.
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded. — `npm run check` NOT VERIFIED: one pre-existing WSL2-mirrored environment artifact (Issue #226, closed as env-driven); CI ubuntu is authoritative for this PR.
- [x] Behavior changes carry a matching docs delta, or this body records the explicit no-doc-needed reason. — The new `not_spawnable` status is internal to the shared probe surface; `docs/agent-hosts.md` describes probe outcomes as an operator abstraction and does not enumerate individual status codes. No doc delta required for this PR; a follow-up doc pass will land with AC-001 in RFC #224.

**Compatibility.** `AgentHostProbeStatus` is a public type in `packages/core/src/agent-host.ts`; the change is additive (a new variant), so consumers that only pattern-match the existing variants continue to work. Callers that treat the type as exhaustive will surface a new case they should handle — this is the intended contract because the new state carries a different operator action. The `VersionCommandResult.status` union is widened correspondingly. No behavioural change on POSIX.

**Cross-repository effect.** org-workbench PR #80 fixes the sibling defect in `apps/server/src/engine/probe.ts::splitCommand` for install paths with spaces. The two PRs are independent (org-workbench and digital-employee), both platform-agnostic wins; neither depends on the other.

## Known limitations

- The `shared version probe resolves .cmd shims through PATHEXT on Windows` test is win32-gated; on Linux CI it skips. Coverage on real Windows requires a `windows-*` CI runner, which the AC-002 amendment in `docs/requirement-governance.md` currently does not require. This limitation is explicitly recorded in RFC #224 (Q4) and remains a governance decision.
- `not_spawnable` is only emitted when Windows PATHEXT resolution succeeds but the resolved binary refuses to launch (EINVAL / EACCES). On POSIX, we still return `not_found` for ENOENT and `probe_failed` otherwise; no behavioural change.

## Risk and rollback

**Risk.** Additive-only in the domains that matter (probe.status union, adapter probe issues, one new import). No permission or data-flow change; the probe is side-effect free and still bounded (10s timeout, output cap 64 KiB, process-tree kill on settle). PATHEXT lookup walks `process.env.PATH` × `process.env.PATHEXT`; the probe still spawns with `windowsHide: true` and the same `versionProbeEnvironment` allowlist.

**Rollback.** Single-commit PR; `git revert` on the squash commit restores the previous behaviour completely. `AgentHostProbeStatus` reverting drops the `"not_spawnable"` variant — downstream code that has not yet updated to handle it will still compile (they never emitted or matched it).

## Product review handoff

- Automated pre-review result: PREFLIGHT PASS
- Human final review: N/A: humanReviewOwner=none
- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: bug-fix PR bound to Issue R1, no milestone artifact required.
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
