### PR TITLE
docs(host): align Windows wording with the AC-002 governance amendment

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,10 @@ write tools and approval callbacks. Their model control plane remains reachable,
 while employee tool/MCP data-plane network access is denied. Conformance
 fixtures have been run, but live model entitlement has not been tested.
 The runnable preview is currently POSIX-only so descendant process groups can
-be terminated and verified before a terminal event is published.
+be terminated and verified before a terminal event is published. Windows is
+**NOT VERIFIED** in this milestone and remains a named limit — see
+[Windows status](docs/architecture.md#windows-status) for the anchored
+governance record and the outstanding evidence gap.
 
 ## Release status
 

--- a/apps/cli/claude-agent-host.ts
+++ b/apps/cli/claude-agent-host.ts
@@ -604,7 +604,7 @@ export class ClaudeAgentHostAdapter implements AgentHostAdapter {
       issues.push(
         issue(
           "host_platform_not_conformance_verified",
-          "This adapter requires POSIX process-group cleanup; Windows is not yet runnable",
+          "Windows is NOT VERIFIED in this milestone (named limit): the runnable Adapter still requires POSIX process-group cleanup; see docs/architecture.md#windows-status",
         ),
       )
     } else if (!this.environment.ANTHROPIC_API_KEY?.trim()) {

--- a/apps/cli/codebuddy-agent-host.ts
+++ b/apps/cli/codebuddy-agent-host.ts
@@ -1242,7 +1242,7 @@ export class CodeBuddyAgentHostAdapter implements AgentHostAdapter {
       issues.push(
         issue(
           "host_platform_not_conformance_verified",
-          "This adapter requires POSIX process-group cleanup; Windows is not yet runnable",
+          "Windows is NOT VERIFIED in this milestone (named limit): the runnable Adapter still requires POSIX process-group cleanup; see docs/architecture.md#windows-status",
         ),
       )
     }

--- a/apps/cli/qwen-agent-host.ts
+++ b/apps/cli/qwen-agent-host.ts
@@ -1005,7 +1005,7 @@ export class QwenAgentHostAdapter implements AgentHostAdapter {
       issues.push(
         issue(
           "host_platform_not_conformance_verified",
-          "This adapter requires POSIX process-group cleanup; Windows is not yet runnable",
+          "Windows is NOT VERIFIED in this milestone (named limit): the runnable Adapter still requires POSIX process-group cleanup; see docs/architecture.md#windows-status",
         ),
       )
     } else if (!this.environment.OPENAI_API_KEY?.trim()) {

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -8,7 +8,7 @@
 
 `digital-employee` 不实现另一套通用 Agent loop。模型推理、上下文窗口、原生工具循环和宿主会话由 Agent Host 负责；本项目负责员工包、Host Adapter、能力协商、策略、标准事件，以及后续的通道、队列、审计和人工接力。
 
-当前源码中有四条版本锁定的 **runnable** 路径：Qoder CLI 1.1.x、Claude Code `>=2.1.214 <2.2.0`、Qwen Code `0.17.1` 和 CodeBuddy Code `2.106.4`。它们都是 one-shot、无状态、POSIX 本机/单租户技术预览；Qoder 只获得最小只读文件投影，另外三个是不暴露原生工具的 context-only Adapter。四条路径都不支持 MCP、附件、会话恢复、写工具或审批回调，也都没有使用真实模型权益验收。Windows 因尚无经过验证的 Job Object 进程树清理而 fail closed。Codex 仍是 **probe-only**：Codex CLI 0.148.0 无法可靠移除所有模型可见的内建工具，其中包括 `apply_patch`，详见 [0.148.0 复审](research/codex-cli-0.148.0-default-deny-audit.md)。
+当前源码中有四条版本锁定的 **runnable** 路径：Qoder CLI 1.1.x、Claude Code `>=2.1.214 <2.2.0`、Qwen Code `0.17.1` 和 CodeBuddy Code `2.106.4`。它们都是 one-shot、无状态、POSIX 本机/单租户技术预览；Qoder 只获得最小只读文件投影，另外三个是不暴露原生工具的 context-only Adapter。四条路径都不支持 MCP、附件、会话恢复、写工具或审批回调，也都没有使用真实模型权益验收。Windows 在本里程碑 **NOT VERIFIED**，作为治理记录中的**已命名限制（named limit）**暂缓，等 Job Object 进程树清理 + win32 leak-oracle fixture 落地后解锁，详见 [Windows status](architecture.md#windows-status)。Codex 仍是 **probe-only**：Codex CLI 0.148.0 无法可靠移除所有模型可见的内建工具，其中包括 `apply_patch`，详见 [0.148.0 复审](research/codex-cli-0.148.0-default-deny-audit.md)。
 
 官方产品文档只能证明某个宿主值得适配，不能把 `documented` 提升为本仓库的 `supported`。只有版本锁定、Adapter 实现和仓库内 Adapter 专用确定性 fixture 全部通过后，一项能力才能参与运行前兼容性判断。
 
@@ -220,7 +220,7 @@ Workbench Bridge 不得：
 | --- | --- |
 | 启用方式 | `DIGITAL_EMPLOYEE_ENGINE_MODEL=qoder`；二进制默认取 PATH 上的 `qodercli`，可用 `DIGITAL_EMPLOYEE_QODER_COMMAND` 指定 |
 | 凭据 | 唯一入口是环境 allowlist 中的 `QODER_PERSONAL_ACCESS_TOKEN`。令牌不进 argv、envelope、事件流或诊断；沿用 Adapter 的 auth-payload 文件纪律（0600、run 局部、运行结束即删除） |
-| 版本族 | 与隔离 Adapter 相同：`1.1.x` conformance 族。族外版本、二进制缺失或未验证平台（Windows）在 port 解析阶段 fail closed（退出码 1，环境故障），不会被建模成"员工失败"的治理结论（退出码 0） |
+| 版本族 | 与隔离 Adapter 相同：`1.1.x` conformance 族。族外版本、二进制缺失或本里程碑 **NOT VERIFIED / named limit** 的平台（Windows，详见 [Windows status](architecture.md#windows-status)）在 port 解析阶段 fail closed（退出码 1，环境故障），不会被建模成"员工失败"的治理结论（退出码 0） |
 | 工具面 | 零工具：`tools.default=deny` 且 allow 为空、无文件系统授权、网络 deny、approval never、无 MCP、`maxTurns=1`。Adapter 的 init 断言会在运行期复核公告的工具集 |
 | 用量 | **如实缺失**：Adapter 的 usage 事件不是稳定契约（`usage_events: unknown`），该 port 只返回文本、不返回 token 数。per-task/per-day 的 token 记账对该 port 记 0，iteration 预算仍生效；不得据此 port 做 token 级预算拦截 |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -194,9 +194,36 @@ All four use a new stateless session, filtered environment, stdin/native stream
 transport and an explicit deployment service API key rather than a personal
 CLI login. They reject MCP, attachments, resume, writes and approval callbacks.
 The runnable preview is POSIX-only: a terminal event is withheld until the
-detached process group has exited. Windows remains not-ready until equivalent
-Job Object process-tree cleanup is implemented and covered by deterministic
-Adapter fixtures.
+detached process group has exited.
+
+### Windows status
+
+Windows is **NOT VERIFIED** in this milestone and remains a **named limit**,
+per the AC-002 amendment recorded in `docs/requirement-governance.md`. This is
+an evidence-gap decision, not a permanent unsupported statement. The
+outstanding work is two pieces, both required before the named limit can be
+lifted:
+
+1. **Job Object process-tree cleanup** — the win32 branch of
+   `signalAgentHostProcessTree` currently uses `taskkill /pid <pid> /T` (fixed
+   in #225), which reaches descendants correctly for the shared version probe
+   but is not the equivalent-strength primitive of the POSIX detached
+   process-group model. The stronger Windows primitive is
+   `CreateJobObject` + `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` +
+   `AssignProcessToJobObject`, which the kernel enforces even if the parent
+   crashes.
+2. **win32 leak-oracle fixture** — `inspectProcessIdentities` in
+   `packages/core/src/adapter-qualification.ts` currently short-circuits on
+   win32 because the oracle shells out to `/bin/ps`. Without a win32 oracle
+   there is no fixture-side way to prove absence of leaks, and the acceptance
+   bar in this section requires exactly that.
+
+Until both pieces land, Windows fails closed at doctor and at adapter probe
+with a **named-limit** code (`platform_named_limit` at the runner surface,
+`host_platform_not_conformance_verified` at the adapter surface). The gate
+itself is intended, correct, and traceable; this section is the single anchor
+for its wording so `README`, `docs/agent-hosts.md`, `runner doctor`, and every
+adapter probe track the same governance record.
 
 Across all built-in Adapters, `structured_output` has one meaning:
 **Adapter-enforced terminal validity**. When `outputSchema` is present, the

--- a/packages/core/src/runner-lifecycle.ts
+++ b/packages/core/src/runner-lifecycle.ts
@@ -263,7 +263,14 @@ export async function runnerDoctor(
     checks.push({
       name: "platform_support",
       result: "fail",
-      message: "Windows is not supported; POSIX platforms only",
+      // AC-001 (docs/requirement-governance.md): the governance record says
+      // "AC-002 requires Linux and macOS evidence; Windows is NOT VERIFIED and
+      // remains a named limit." Track that language here so no surface (this
+      // doctor line, README, docs/agent-hosts.md, adapter probes) implies a
+      // permanence the record does not. See docs/architecture.md#windows-status
+      // for the anchored evidence gap and the two-piece prerequisite.
+      message:
+        "Windows is NOT VERIFIED in this milestone (named limit); see docs/architecture.md#windows-status",
     })
   } else {
     checks.push({


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/fullstack-ai-infra/digital-employee/issues/224
- Consumed revision: R1
- No automatic close keywords: acknowledged

## Delivery ownership

- implementationOwner: @PeterGuy326
- automatedPreReviewOwner: PREFLIGHT — npm run check (self-run, evidence below)
- humanReviewOwner: none
- Separation of duties: implementation owner and reviewer are declared per Issue R1; no human review owner is named, so the automated pre-review + merge ledger owner carry the review boundary.

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | packages/core/src/runner-lifecycle.ts (doctor platform_support message); apps/cli/claude-agent-host.ts, apps/cli/qwen-agent-host.ts, apps/cli/codebuddy-agent-host.ts (adapter probe host_platform_not_conformance_verified message); docs/architecture.md (new anchored `### Windows status` section); README.md (link to anchor); docs/agent-hosts.md (two references) | Wording is grep-verifiable across surfaces; no test asserts the exact old strings, and tests/core/runner-lifecycle.test.ts:559-565 asserts result, not message text. |

## File domains

- **doctor surface** — `packages/core/src/runner-lifecycle.ts`: the `platform_support` check on `win32` now emits "Windows is NOT VERIFIED in this milestone (named limit); see docs/architecture.md#windows-status" instead of "Windows is not supported; POSIX platforms only". Check result unchanged (`result: "fail"`).
- **adapter probe surfaces** — `apps/cli/claude-agent-host.ts`, `apps/cli/qwen-agent-host.ts`, `apps/cli/codebuddy-agent-host.ts`: the `host_platform_not_conformance_verified` issue message now carries the same governance language and links back to the same anchor. Issue code and `status: "not_ready"` unchanged.
- **anchor document** — `docs/architecture.md`: adds a new `### Windows status` section that names the two outstanding pieces of work (Job Object cleanup + win32 leak-oracle fixture) and reiterates that the gate is intentional and traceable. Every other surface links here so the record has one authoritative wording.
- **README + agent-hosts.md** — replace absolute statements with governance-record language and a link to `docs/architecture.md#windows-status`.

## Scope and non-goals

**In scope.** AC-001 wording alignment across all five Windows-status surfaces (README, docs/architecture.md, docs/agent-hosts.md, `runner doctor`, adapter probes). No behavioural change; no test-asserted string touched.

**Non-goals.**

- AC-002 (Job Object cleanup + win32 leak-oracle fixture + fixture porting) — separate future work, discussed in #224.
- AC-003 (append a formal `<!-- requirement-decision:v1 -->` entry to `docs/requirement-governance.md`) — that requires a PO signature and is deliberately not attempted here; the governance record already carries the AC-002 amendment this PR references (docs/requirement-governance.md line 163).
- AC-004 (name the macOS evidence source or add a `macos-*` CI runner) — governance-level decision, out of scope for a wording PR.
- No change to `AgentHostProbeStatus`, no change to any issue code, no change to any status transition.

## Validation

- Exact commands: `npm ci`, `npm run build`, `npx tsx --test tests/apps/agent-hosts.test.ts tests/core/runner-lifecycle.test.ts tests/apps/qoder-agent-host.test.ts tests/apps/qwen-agent-host.test.ts tests/apps/claude-agent-host.test.ts tests/apps/codebuddy-agent-host.test.ts`, `npm run check`.
  - Full breakdown:
    - `npm ci`
    - `npm run build`
    - `npx tsx --test tests/apps/agent-hosts.test.ts tests/core/runner-lifecycle.test.ts tests/apps/qoder-agent-host.test.ts tests/apps/qwen-agent-host.test.ts tests/apps/claude-agent-host.test.ts tests/apps/codebuddy-agent-host.test.ts`
    - `npm run check`
- Observed counts/results: PASS 1858/1860 across the full suite (1 skipped: the win32-only PATHEXT case introduced in #223; 1 pre-existing WSL2-mirrored env artifact tracked in closed Issue #226, does not touch any file in this PR's domain).
  - Per-command breakdown:
    - `npm run build` — PASS
    - Focused subset (204 subtests) — PASS 204/204
    - `npm run check` — PASS 1858/1860; 1 skipped (win32-gated PATHEXT case introduced in #223, POSIX skips); 1 pre-existing WSL2-mirrored environment artifact in `tests/apps/deploy-cli.test.ts::"HTTP activation protocol fails closed"` (tracked/closed as #226; three consecutive push runs on `main` are green on CI ubuntu).
- Check URLs: NOT VERIFIED: PR run pending at push time; the CI URL will attach on push.

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | AC-001 | `runner doctor` on win32 no longer says "Windows is not supported" | `grep -n "is not supported" packages/core/src/runner-lifecycle.ts` | source-only | no match | no match | PASS |
| V2 | AC-001 | Adapter probe messages on win32 no longer say "Windows is not yet runnable" | `grep -rn "not yet runnable" apps/cli` | source-only | no match | no match | PASS |
| V3 | AC-001 | Every surface links to the same anchor | `grep -rn "docs/architecture.md#windows-status\|architecture.md#windows-status" README.md docs apps/cli packages/core` | source-only | 5+ hits (README, agent-hosts.md, runner-lifecycle.ts, claude/qwen/codebuddy adapter probes) | 5+ hits | PASS |
| V4 | AC-001 | No behavioural test regressions | `npx tsx --test tests/apps/agent-hosts.test.ts tests/core/runner-lifecycle.test.ts tests/apps/{qoder,qwen,claude,codebuddy}-agent-host.test.ts` | linux Node 22 | 204/204 pass | 204/204 pass | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs.
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed. — No dependency changed.
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded. — NOT VERIFIED: 1 pre-existing WSL2-mirrored environment flake (Issue #226, closed as env-driven); ubuntu CI is authoritative and green.
- [x] Behavior changes carry a matching docs delta, or this body records the explicit no-doc-needed reason. — This PR **is** the docs delta; the surface strings and the anchor section land together.

**Compatibility.** Doctor and adapter probes still emit the same issue code and same result/status on win32; only the human-readable message text changes. Downstream tooling that pattern-matches issue codes is unaffected. Any consumer that grep-matches the previous absolute string ("Windows is not supported; POSIX platforms only" / "Windows is not yet runnable") will need to update its matcher — grep on the internet suggests only this repo's own docs reference those strings.

**Cross-repository effect.** None. Sibling repos are not touched.

## Known limitations

- This PR carries AC-001 only. AC-002 (Job Object cleanup + win32 leak-oracle fixture), AC-003 (formal governance decision append), and AC-004 (macOS evidence source) remain open pending @PeterGuy326's direction on Q1/Q2/Q4 in #224.
- The win32-only PATHEXT test introduced in #223 (`tests/apps/agent-hosts.test.ts::"shared version probe resolves .cmd shims through PATHEXT on Windows"`) still skips on Linux CI. Not a regression of this PR; it is the same environment gap this RFC frames.

## Risk and rollback

**Risk.** Zero behavioural risk — only text changes on already-failing branches; no permission, data-flow, or public API change. Anchor is a new heading in an existing document.

**Rollback.** Single-commit PR; `git revert` restores every surface's previous string in one operation.

## Product review handoff

- Automated pre-review result: PREFLIGHT PASS
- Human final review: N/A: humanReviewOwner=none
- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: docs-only PR bound to Issue R1, no milestone artifact required.
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
