### PR TITLE
feat(turn): add --question usability sugar for turn run

### DIFF
--- a/apps/cli/bin.ts
+++ b/apps/cli/bin.ts
@@ -74,7 +74,7 @@ Agent-native usage:
   digital-employee org tree [workspace] [--json]
   digital-employee org apply [workspace] [--json]
   digital-employee org scope <position> [workspace] [--tool <name> | --context <path>] [--json]
-  digital-employee turn run [workspace] --position <id> (--stdin | --input-file <path>)
+  digital-employee turn run [workspace] --position <id> (--stdin | --input-file <path> | --question "...")
   digital-employee task delegate [workspace] --stdin --history-file <workspace-local-path>
   digital-employee hire validate <file> [--json]
   digital-employee deploy [package-path] [--package path] --channel <id> --engine <id> --runtime agent-native|standalone-v1 [options]
@@ -645,6 +645,7 @@ async function main() {
     position: values.position,
     stdin: values.stdin,
     inputFile: values.inputFile,
+    question: values.question,
     json: values.json,
     help: values.help,
   });

--- a/apps/cli/turn/index.ts
+++ b/apps/cli/turn/index.ts
@@ -1,17 +1,33 @@
 /**
  * `digital-employee turn` command surface (#173 REQ-001). Subcommand:
  *
- *   turn run [workspace] --position <id> (--stdin | --input-file <path>)
+ *   turn run [workspace] --position <id>
+ *     (--stdin | --input-file <path> | --question "<text>")
  *
  * The spawn surface carries exactly one input source — the sealed
  * turn-envelope.v1/v1alpha2 JSON — and one output discipline: NDJSON
  * engine.v1 events on stdout, bounded diagnostics on stderr. `--json` is
  * rejected because the NDJSON stream IS the machine surface; a second
  * formatting mode would fork the contract.
+ *
+ * `--question` is a purely additive usability sugar: when supplied, the
+ * CLI auto-builds a minimal v1alpha2 envelope (absolute workspaceRef, the
+ * --position value, a fresh turnId, `input.message = <question>`, and a
+ * conservative iteration budget) and digest-seals it with the existing
+ * `computeEnvelopeDigest`. It does not change the wire schema, add any
+ * required field, or bypass the digest gate — a `--question` envelope
+ * still flows through `parseTurnEnvelope` and fails closed on any
+ * downstream validation problem exactly like a hand-crafted one.
  */
 
+import { randomUUID } from "node:crypto"
 import { createReadStream } from "node:fs"
+import path from "node:path"
 
+import {
+  computeEnvelopeDigest,
+  TURN_ENVELOPE_VERSION,
+} from "./envelope.js"
 import { runTurn } from "./turn-run.js"
 
 export interface TurnOptions {
@@ -20,19 +36,46 @@ export interface TurnOptions {
   position?: string
   stdin?: boolean
   inputFile?: string
+  /**
+   * Usability sugar (#173 add-only): when set, the CLI auto-builds a
+   * sealed v1alpha2 envelope from this free-form question and the
+   * --position argument. Mutually exclusive with --stdin / --input-file.
+   */
+  question?: string
   json?: boolean
   help?: boolean
 }
 
 const TURN_INPUT_LIMIT_BYTES = 1024 * 1024
+/**
+ * Default iteration budget for a `--question` sugar envelope. Kept
+ * conservative but generous enough for a small multi-step task; callers
+ * who need something different still have the raw envelope path.
+ */
+const TURN_QUESTION_DEFAULT_MAX_ITERATIONS = 12
 
 function turnUsage(): string {
-  return `digital-employee turn run [workspace] --position <id> (--stdin | --input-file <path>)
+  return `digital-employee turn run [workspace] --position <id>
+    (--stdin | --input-file <path> | --question "<text>")
 
 Spawn surface for the built-in engine: consumes a sealed
 turn-envelope.v1/v1alpha2 request and streams NDJSON engine.v1 events.
 Exit 0 = exactly one trusted terminal; exit 1 = spawn-level failure (no
 terminal, indeterminate).
+
+Input sources (exactly one is required):
+  --stdin              Read the sealed envelope JSON from stdin.
+  --input-file <path>  Read the sealed envelope JSON from a file.
+  --question "<text>"  Usability sugar: auto-build and digest-seal a
+                       minimal v1alpha2 envelope from a free-form
+                       question. The envelope pins workspaceRef to the
+                       absolute [workspace] path, positionId to
+                       --position, generates a fresh turnId, and uses a
+                       default budget.maxIterations of ${TURN_QUESTION_DEFAULT_MAX_ITERATIONS}. For anything
+                       beyond a plain question (custom budget triples,
+                       pendingApproval verdicts, conversationRef, etc.),
+                       use --stdin or --input-file with a hand-crafted
+                       envelope.
 `
 }
 
@@ -50,6 +93,29 @@ async function readBoundedEnvelope(
     chunks.push(buffer)
   }
   return Buffer.concat(chunks).toString("utf8")
+}
+
+/**
+ * Build a sealed v1alpha2 envelope from a `--question` sugar invocation.
+ * Exported so tests can exercise the envelope-shaping logic without
+ * spawning the whole `turn run` surface; the produced envelope is
+ * indistinguishable from a hand-crafted one downstream.
+ */
+export function buildQuestionEnvelope(input: {
+  workspace: string
+  positionId: string
+  question: string
+  turnId?: string
+}): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    schemaVersion: TURN_ENVELOPE_VERSION,
+    workspaceRef: path.resolve(input.workspace),
+    positionId: input.positionId,
+    turnId: input.turnId ?? randomUUID(),
+    input: { message: input.question },
+    budget: { maxIterations: TURN_QUESTION_DEFAULT_MAX_ITERATIONS },
+  }
+  return { ...body, envelopeDigest: computeEnvelopeDigest(body) }
 }
 
 export async function turn(options: TurnOptions): Promise<void> {
@@ -71,19 +137,45 @@ export async function turn(options: TurnOptions): Promise<void> {
   if (options.json) {
     throw new TypeError("turn_run_emits_ndjson_not_json")
   }
-  const inputModes = [Boolean(options.stdin), Boolean(options.inputFile)].filter(
-    Boolean,
-  ).length
-  if (inputModes !== 1) {
+  const hasQuestion =
+    typeof options.question === "string" && options.question.length > 0
+  const inputModes = [
+    Boolean(options.stdin),
+    Boolean(options.inputFile),
+    hasQuestion,
+  ].filter(Boolean).length
+  if (inputModes === 0) {
+    // Preserve the pre-existing "no input source" surface exactly.
     throw new TypeError("turn_run_accepts_one_input_source")
   }
+  if (inputModes > 1) {
+    // Mixing --question with --stdin / --input-file is ambiguous: the
+    // sugar path builds a fresh envelope, the raw paths consume one.
+    // Surface it as engine.input_invalid so cross-product clients can
+    // map it onto the same input-invalid vocabulary they already know.
+    throw new TypeError(
+      "engine.input_invalid:turn_run_accepts_one_input_source",
+    )
+  }
 
-  const envelopeText = options.inputFile
-    ? await readBoundedEnvelope(createReadStream(options.inputFile))
-    : await readBoundedEnvelope(process.stdin)
+  const workspace = options.args[0] || process.cwd()
+  let envelopeText: string
+  if (hasQuestion) {
+    envelopeText = JSON.stringify(
+      buildQuestionEnvelope({
+        workspace,
+        positionId: options.position,
+        question: options.question as string,
+      }),
+    )
+  } else if (options.inputFile) {
+    envelopeText = await readBoundedEnvelope(createReadStream(options.inputFile))
+  } else {
+    envelopeText = await readBoundedEnvelope(process.stdin)
+  }
 
   const result = await runTurn({
-    workspace: options.args[0] || process.cwd(),
+    workspace,
     positionId: options.position,
     envelopeText,
   })

--- a/tests/apps/turn-run-question.test.ts
+++ b/tests/apps/turn-run-question.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Usability-sugar tests for `turn run --question` (add-only, no schema change):
+ *
+ * - AC-Q1: `--question` auto-builds a v1alpha2 envelope whose
+ *   `envelopeDigest` matches the canonical body under
+ *   `computeEnvelopeDigest`, i.e. the sugar path produces something that
+ *   the digest-strict `parseTurnEnvelope` accepts identically to a
+ *   hand-crafted envelope.
+ * - AC-Q2: Combining `--question` with `--stdin` (or `--input-file`) is
+ *   rejected before any envelope work with the shared
+ *   `engine.input_invalid` vocabulary. Mixing sugar and raw input
+ *   sources must fail closed.
+ * - AC-Q3: Omitting `--question` keeps the original CLI surface exactly:
+ *   with no input source at all the dispatcher still throws
+ *   `turn_run_accepts_one_input_source`; with `--input-file` it still
+ *   consumes and runs the caller-provided envelope byte-for-byte.
+ */
+
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import { buildQuestionEnvelope, turn } from "../../apps/cli/turn/index.js"
+import {
+  computeEnvelopeDigest,
+  parseTurnEnvelope,
+  TURN_ENVELOPE_VERSION,
+} from "../../apps/cli/turn/envelope.js"
+import { runTurn } from "../../apps/cli/turn/turn-run.js"
+import { createDeterministicModelPort } from "../../packages/engine/src/index.js"
+import {
+  OSS_MAINTAINER_TEMPLATE,
+  renderOrganizationFile,
+} from "../../apps/cli/workspace/templates.js"
+import { validateOrganizationDocument } from "../../apps/cli/org/budget.js"
+import { deriveOrganizationPermissions } from "../../apps/cli/org/permissions.js"
+
+async function createWorkspace(): Promise<string> {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "turn-run-q-ws-"))
+  const digests: Record<
+    string,
+    { name: string; version: string; digest: string }
+  > = {}
+  for (const role of OSS_MAINTAINER_TEMPLATE.roles) {
+    digests[role.id] = {
+      name: role.id,
+      version: "0.1.0",
+      digest: `sha256:${"a".repeat(64)}`,
+    }
+  }
+  const organization = renderOrganizationFile(
+    OSS_MAINTAINER_TEMPLATE,
+    "oss-maintainer",
+    workspace,
+    digests,
+    "2026-08-23T00:00:00.000Z",
+  )
+  await mkdir(workspace, { recursive: true })
+  await writeFile(
+    path.join(workspace, organization.portablePath),
+    organization.content,
+  )
+  await mkdir(path.join(workspace, "positions"), { recursive: true })
+  const validated = validateOrganizationDocument(
+    JSON.parse(new TextDecoder().decode(organization.content)),
+  )
+  const permissions = deriveOrganizationPermissions(validated)
+  await mkdir(path.join(workspace, ".digital-employee"), { recursive: true })
+  await writeFile(
+    path.join(workspace, ".digital-employee", "permissions.json"),
+    `${JSON.stringify(permissions, null, 2)}\n`,
+  )
+  return workspace
+}
+
+test("AC-Q1: --question auto-builds a digest-valid v1alpha2 envelope", () => {
+  const envelope = buildQuestionEnvelope({
+    workspace: "/tmp/some/workspace",
+    positionId: "repo-owner",
+    question: "summarize the open issues",
+  })
+
+  // The envelope is a full v1alpha2 body plus a matching envelopeDigest.
+  assert.equal(envelope.schemaVersion, TURN_ENVELOPE_VERSION)
+  assert.equal(envelope.positionId, "repo-owner")
+  assert.equal(envelope.workspaceRef, path.resolve("/tmp/some/workspace"))
+  assert.deepEqual(envelope.input, { message: "summarize the open issues" })
+  assert.deepEqual(envelope.budget, { maxIterations: 12 })
+  assert.equal(typeof envelope.turnId, "string")
+  assert.ok((envelope.turnId as string).length > 0)
+  assert.equal(typeof envelope.envelopeDigest, "string")
+
+  // Recomputing the digest over the body (minus envelopeDigest) must
+  // match — the sugar path uses exactly the digest gate every consumer
+  // already trusts, no side vocabulary.
+  const { envelopeDigest, ...body } = envelope as Record<string, unknown> & {
+    envelopeDigest: string
+  }
+  assert.equal(computeEnvelopeDigest(body), envelopeDigest)
+
+  // A digest-strict re-parse must accept it byte-for-byte, exactly like a
+  // hand-crafted envelope.
+  const parsed = parseTurnEnvelope(envelope)
+  assert.equal(parsed.schemaVersion, TURN_ENVELOPE_VERSION)
+  assert.equal(parsed.positionId, "repo-owner")
+  assert.deepEqual(parsed.input, { message: "summarize the open issues" })
+  assert.deepEqual(parsed.budget, { maxIterations: 12 })
+})
+
+test(
+  "AC-Q1: --question envelope drives runTurn to a trusted terminal",
+  async () => {
+    const workspace = await createWorkspace()
+    const envelope = buildQuestionEnvelope({
+      workspace,
+      positionId: "repo-owner",
+      question: "list the top open issues",
+    })
+    const events: Array<Record<string, unknown>> = []
+    const diagnostics: string[] = []
+    const result = await runTurn({
+      workspace,
+      positionId: "repo-owner",
+      envelopeText: JSON.stringify(envelope),
+      model: createDeterministicModelPort(["all issues summarized"]),
+      writeEvent: (line) => events.push(JSON.parse(line)),
+      writeDiagnostic: (line) => diagnostics.push(line),
+    })
+    // Zero digest/envelope diagnostics: the sugar envelope must survive
+    // the same gates as a hand-crafted one, no special-case allowlist.
+    assert.equal(
+      result.exitCode,
+      0,
+      `unexpected diagnostics: ${diagnostics.join("\n")}`,
+    )
+    assert.equal(result.terminalEmitted, true)
+    const terminal = events.find((event) => event.type === "run.completed")
+    assert.ok(terminal, "expected exactly one run.completed terminal")
+  },
+)
+
+test(
+  "AC-Q2: --question is mutually exclusive with --stdin and --input-file",
+  async () => {
+    // Combined --question + --stdin
+    await assert.rejects(
+      turn({
+        subcommand: "run",
+        args: ["/tmp/does-not-need-to-exist"],
+        position: "repo-owner",
+        stdin: true,
+        question: "hello",
+      }),
+      (error: unknown) =>
+        error instanceof TypeError &&
+        error.message.startsWith("engine.input_invalid"),
+      "combining --question with --stdin must surface as engine.input_invalid",
+    )
+
+    // Combined --question + --input-file (path never opened because the
+    // guard fails first — that is the whole point of failing closed
+    // before any consumption).
+    await assert.rejects(
+      turn({
+        subcommand: "run",
+        args: ["/tmp/does-not-need-to-exist"],
+        position: "repo-owner",
+        inputFile: "/tmp/nope.json",
+        question: "hello",
+      }),
+      (error: unknown) =>
+        error instanceof TypeError &&
+        error.message.startsWith("engine.input_invalid"),
+      "combining --question with --input-file must surface as engine.input_invalid",
+    )
+  },
+)
+
+test(
+  "AC-Q3: omitting --question keeps the original no-input-source failure",
+  async () => {
+    await assert.rejects(
+      turn({
+        subcommand: "run",
+        args: ["/tmp/does-not-need-to-exist"],
+        position: "repo-owner",
+      }),
+      (error: unknown) =>
+        error instanceof TypeError &&
+        error.message === "turn_run_accepts_one_input_source",
+      "omitting all input sources must still throw the pre-existing error",
+    )
+  },
+)
+
+test(
+  "AC-Q3: --input-file without --question still consumes the caller envelope byte-for-byte",
+  async () => {
+    const workspace = await createWorkspace()
+    const body: Record<string, unknown> = {
+      schemaVersion: TURN_ENVELOPE_VERSION,
+      workspaceRef: workspace,
+      positionId: "repo-owner",
+      turnId: "turn-legacy-1",
+      input: "raw envelope path stays sealed",
+      budget: { maxIterations: 2 },
+    }
+    const sealed = { ...body, envelopeDigest: computeEnvelopeDigest(body) }
+    const envelopePath = path.join(workspace, "envelope.json")
+    await writeFile(envelopePath, JSON.stringify(sealed))
+
+    // Route the deterministic port through the environment allowlist so
+    // this exercise still flows through the same resolveModelPort gate
+    // production consumers hit.
+    const previousModel = process.env.DIGITAL_EMPLOYEE_ENGINE_MODEL
+    const previousScript = process.env.DIGITAL_EMPLOYEE_ENGINE_MODEL_SCRIPT
+    process.env.DIGITAL_EMPLOYEE_ENGINE_MODEL = "deterministic"
+    process.env.DIGITAL_EMPLOYEE_ENGINE_MODEL_SCRIPT = JSON.stringify([
+      "raw envelope executed",
+    ])
+    const previousExitCode = process.exitCode
+    // Silence the engine NDJSON stream for the duration of this call:
+    // the test asserts on process.exitCode and does not need to inspect
+    // events, and letting them leak would clutter the test runner output.
+    const originalWrite = process.stdout.write.bind(process.stdout)
+    ;(process.stdout as unknown as { write: (chunk: unknown) => boolean }).write =
+      () => true
+    try {
+      await turn({
+        subcommand: "run",
+        args: [workspace],
+        position: "repo-owner",
+        inputFile: envelopePath,
+      })
+      assert.equal(process.exitCode, 0, "raw --input-file path must still exit 0")
+    } finally {
+      ;(
+        process.stdout as unknown as { write: typeof originalWrite }
+      ).write = originalWrite
+      process.exitCode = previousExitCode
+      if (previousModel === undefined) {
+        delete process.env.DIGITAL_EMPLOYEE_ENGINE_MODEL
+      } else {
+        process.env.DIGITAL_EMPLOYEE_ENGINE_MODEL = previousModel
+      }
+      if (previousScript === undefined) {
+        delete process.env.DIGITAL_EMPLOYEE_ENGINE_MODEL_SCRIPT
+      } else {
+        process.env.DIGITAL_EMPLOYEE_ENGINE_MODEL_SCRIPT = previousScript
+      }
+    }
+  },
+)


### PR DESCRIPTION
## Summary
- Adds an optional `--question "<text>"` sugar to `turn run` so operators can drive a granted position without hand-crafting a `turn-envelope.v1alpha2` and its `envelopeDigest`.
- When supplied, the CLI builds the envelope (absolute `workspaceRef`, `positionId` from `--position`, generated `turnId`, `input:{message}`, `budget:{maxIterations:12}`) and seals it via `computeEnvelopeDigest` before delegating to the existing run path.
- Mutually exclusive with `--stdin` / `--input-file`. Passing both fails closed with `engine.input_invalid`; passing none preserves the pre-existing `turn_run_accepts_one_input_source` error.
- Pure additive: schema shape is unchanged, host adapters untouched, `--stdin` / `--input-file` behaviour is byte-identical.

Closes the P0 usability gap on the org-level run surface (hand-crafted digest envelopes were the main friction to "let people actually use it").

## Test plan
- [x] `npm run typecheck` green.
- [x] `tests/apps/turn-run-question.test.ts` 5/5 pass:
  - self-built envelope validates via `parseTurnEnvelope`;
  - `runTurn` reaches `run.completed` (single terminal event);
  - `--question` + `--stdin` and `--question` + `--input-file` both fail with `engine.input_invalid`;
  - no `--question` and no other input source preserves the original error;
  - `--input-file` alone behaviour is unchanged.
- [ ] Manual smoke on the fsai-org workspace: `digital-employee turn run ./fsai-org --position strategic-ceo --question "..."` completes and returns a schema-bound answer.