### PR TITLE
chore(brand): align public coordinates with ByteFolk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Replace former GitHub owner coordinates in shipped templates and examples
+  with ByteFolk, and align visible employee authorship while retaining frozen
+  JSON Schema identities and the existing npm compatibility namespace.
 - Prepare GitHub repository and GHCR coordinates for the ByteFolk organization
   handle cutover while retaining published JSON Schema identities and the
   existing npm compatibility namespace.

--- a/apps/cli/org/budget.ts
+++ b/apps/cli/org/budget.ts
@@ -29,6 +29,10 @@ export const WORKSPACE_ORG_SCHEMA_VERSION = "workspace-org.v1" as const
 export const WORKSPACE_ORG_SCHEMA_ID =
   "https://raw.githubusercontent.com/fullstack-ai-infra/digital-employee/main/configs/workspace-org.schema.json" as const
 
+/** Current public locator written into generated organization documents. */
+export const WORKSPACE_ORG_SCHEMA_URL =
+  "https://raw.githubusercontent.com/bytefolk/digital-employee/main/configs/workspace-org.schema.json" as const
+
 /** Upper bound for every budget cap (guards against overflow and typos). */
 export const BUDGET_LIMIT_MAX = 1_000_000_000 as const
 

--- a/apps/cli/org/model.ts
+++ b/apps/cli/org/model.ts
@@ -34,6 +34,7 @@ import path from "node:path"
 
 import {
   WORKSPACE_ORG_SCHEMA_ID,
+  WORKSPACE_ORG_SCHEMA_URL,
   organizationNameSchema,
   positionBudgetDefs,
   positionModeSchema,
@@ -448,7 +449,7 @@ export function buildAppliedOrganization(
     },
   )
   return {
-    $schema: WORKSPACE_ORG_SCHEMA_ID,
+    $schema: WORKSPACE_ORG_SCHEMA_URL,
     schemaVersion: current.schemaVersion,
     business: current.business,
     description: current.description,

--- a/apps/cli/workspace/templates.ts
+++ b/apps/cli/workspace/templates.ts
@@ -16,7 +16,7 @@ import path from "node:path"
 
 import type { EmployeePackageManifest } from "../../../packages/core/src/employee-package.js"
 import {
-  WORKSPACE_ORG_SCHEMA_ID,
+  WORKSPACE_ORG_SCHEMA_URL,
   WORKSPACE_ORG_SCHEMA_VERSION,
 } from "../org/budget.js"
 import type { PositionBudget } from "../org/budget.js"
@@ -198,7 +198,7 @@ function jsonFile(value: unknown): Uint8Array {
 function manifestForRole(role: WorkspaceTemplateRole): EmployeePackageManifest {
   return {
     $schema:
-      "https://raw.githubusercontent.com/fullstack-ai-infra/digital-employee/main/configs/employee-package.schema.json",
+      "https://raw.githubusercontent.com/bytefolk/digital-employee/main/configs/employee-package.schema.json",
     schemaVersion: "employee-package.v1alpha1",
     name: role.id,
     version: WORKSPACE_POSITION_PACKAGE_VERSION,
@@ -440,7 +440,7 @@ export function renderOrganizationFile(
   updatedAt: string,
 ): WorkspaceFile {
   const organization: RenderedOrganization = {
-    $schema: WORKSPACE_ORG_SCHEMA_ID,
+    $schema: WORKSPACE_ORG_SCHEMA_URL,
     schemaVersion: WORKSPACE_ORG_SCHEMA_VERSION,
     business,
     description: template.description,
@@ -501,7 +501,7 @@ export function renderWorkspaceManifest(
 ): WorkspaceFile {
   const manifest: RenderedWorkspaceManifest = {
     $schema:
-      "https://raw.githubusercontent.com/fullstack-ai-infra/digital-employee/main/configs/workspace.schema.json",
+      "https://raw.githubusercontent.com/bytefolk/digital-employee/main/configs/workspace.schema.json",
     schemaVersion: WORKSPACE_MANIFEST_SCHEMA_VERSION,
     name: business,
     description: template.description,

--- a/examples/recipes/minimal-answer.v1/minimal-answer/employee.json
+++ b/examples/recipes/minimal-answer.v1/minimal-answer/employee.json
@@ -1,12 +1,12 @@
 {
-  "$schema": "https://raw.githubusercontent.com/fullstack-ai-infra/digital-employee/main/configs/employee-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/bytefolk/digital-employee/main/configs/employee-package.schema.json",
   "schemaVersion": "employee-package.v1alpha1",
   "name": "minimal-answer",
   "version": "0.1.0",
   "description": "A portable read-only employee that answers from approved knowledge.",
   "license": "Apache-2.0",
   "authors": [
-    "fullstack-ai-infra"
+    "ByteFolk"
   ],
   "host": {
     "protocol": "agent-host.v1",

--- a/examples/recipes/structured-action.v1/structured-action/employee.json
+++ b/examples/recipes/structured-action.v1/structured-action/employee.json
@@ -1,12 +1,12 @@
 {
-  "$schema": "https://raw.githubusercontent.com/fullstack-ai-infra/digital-employee/main/configs/employee-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/bytefolk/digital-employee/main/configs/employee-package.schema.json",
   "schemaVersion": "employee-package.v1alpha1",
   "name": "structured-action",
   "version": "0.1.0",
   "description": "A read-only employee that returns a structured action proposal without executing it.",
   "license": "Apache-2.0",
   "authors": [
-    "fullstack-ai-infra"
+    "ByteFolk"
   ],
   "host": {
     "protocol": "agent-host.v1",

--- a/profiles/answer-agent/profile.json
+++ b/profiles/answer-agent/profile.json
@@ -6,7 +6,7 @@
   "description": "A read-only support employee that answers only from approved evidence and escalates uncertainty.",
   "license": "Apache-2.0",
   "authors": [
-    "fullstack-ai-infra"
+    "ByteFolk"
   ],
   "provenance": {
     "repository": "https://github.com/bytefolk/digital-employee"

--- a/recipes/real-local-context/employee/employee.json
+++ b/recipes/real-local-context/employee/employee.json
@@ -1,12 +1,12 @@
 {
-  "$schema": "https://raw.githubusercontent.com/fullstack-ai-infra/digital-employee/main/configs/employee-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/bytefolk/digital-employee/main/configs/employee-package.schema.json",
   "schemaVersion": "employee-package.v1alpha1",
   "name": "employee",
   "version": "0.1.0",
   "description": "A portable read-only employee that resumes context from actual pinned local mem and doc services.",
   "license": "Apache-2.0",
   "authors": [
-    "fullstack-ai-infra"
+    "ByteFolk"
   ],
   "host": {
     "protocol": "agent-host.v1",

--- a/recipes/synthetic-mcp-context/employee/employee.json
+++ b/recipes/synthetic-mcp-context/employee/employee.json
@@ -1,12 +1,12 @@
 {
-  "$schema": "https://raw.githubusercontent.com/fullstack-ai-infra/digital-employee/main/configs/employee-package.schema.json",
+  "$schema": "https://raw.githubusercontent.com/bytefolk/digital-employee/main/configs/employee-package.schema.json",
   "schemaVersion": "employee-package.v1alpha1",
   "name": "employee",
   "version": "0.1.0",
   "description": "A portable read-only employee that answers from approved knowledge.",
   "license": "Apache-2.0",
   "authors": [
-    "fullstack-ai-infra"
+    "ByteFolk"
   ],
   "host": {
     "protocol": "agent-host.v1",

--- a/tests/apps/org-budget.test.ts
+++ b/tests/apps/org-budget.test.ts
@@ -23,6 +23,7 @@ import { fileURLToPath } from "node:url"
 import {
   BUDGET_LIMIT_MAX,
   buildWorkspaceOrgSchema,
+  WORKSPACE_ORG_SCHEMA_URL,
   validateOrganizationBudgets,
   validateOrganizationDocument,
   validatePositionBudget,
@@ -215,6 +216,7 @@ function renderedOrganization(): Record<string, unknown> {
 
 test("renderOrganizationFile emits a budget for every role", () => {
   const organization = renderedOrganization()
+  assert.equal(organization.$schema, WORKSPACE_ORG_SCHEMA_URL)
   const roles = organization.roles as Array<Record<string, unknown>>
   assert.equal(roles.length, 4)
   for (const role of roles) {

--- a/tests/apps/workspace-cli.test.ts
+++ b/tests/apps/workspace-cli.test.ts
@@ -86,6 +86,10 @@ test("AC-001: workspace init materializes the oss-maintainer skeleton on a clean
 
   // Top-level skeleton layout.
   const organization = await readJson(path.join(target, "organization.v1alpha1.json"))
+  assert.equal(
+    organization.$schema,
+    "https://raw.githubusercontent.com/bytefolk/digital-employee/main/configs/workspace-org.schema.json",
+  )
   assert.equal(organization.schemaVersion, "workspace-org.v1")
   assert.equal(organization.business, "oss")
   assert.equal(organization.owner, "repo-owner")
@@ -148,6 +152,10 @@ test("AC-001: workspace init materializes the oss-maintainer skeleton on a clean
   }
 
   const manifest = await readJson(path.join(target, "workspace.json"))
+  assert.equal(
+    manifest.$schema,
+    "https://raw.githubusercontent.com/bytefolk/digital-employee/main/configs/workspace.schema.json",
+  )
   assert.equal(manifest.schemaVersion, "workspace.v1alpha1")
   assert.equal(manifest.template, "oss-maintainer")
   assert.equal(manifest.organization, "./organization.v1alpha1.json")
@@ -164,6 +172,10 @@ test("AC-001: workspace init materializes the oss-maintainer skeleton on a clean
       ...EXPECTED_LOCATION_SEGMENTS[position],
     )
     const manifest = await readJson(path.join(positionDirectory, "employee.json"))
+    assert.equal(
+      manifest.$schema,
+      "https://raw.githubusercontent.com/bytefolk/digital-employee/main/configs/employee-package.schema.json",
+    )
     assert.equal(manifest.schemaVersion, "employee-package.v1alpha1")
     assert.equal(manifest.name, position)
     const skill = await readFile(path.join(positionDirectory, "SKILL.md"), "utf8")

--- a/tests/fixtures/runtime/minimal-reader.profile.json
+++ b/tests/fixtures/runtime/minimal-reader.profile.json
@@ -5,7 +5,7 @@
   "description": "A minimal test-only read profile used to prove local registry extension.",
   "license": "Apache-2.0",
   "authors": [
-    "fullstack-ai-infra"
+    "ByteFolk"
   ],
   "provenance": {
     "repository": "https://github.com/bytefolk/digital-employee"


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/bytefolk/digital-employee/issues/244
- Consumed revision: R5
- Consumed decision comment: https://github.com/bytefolk/digital-employee/issues/244#issuecomment-5490459111
- Tracks: https://github.com/bytefolk/digital-employee/issues/244
- No automatic close keywords: acknowledged

## Delivery ownership

- implementationOwner: @PeterGuy326
- automatedPreReviewOwner: Codex independent pre-review
- humanReviewOwner: @Bindy-lbb
- Separation of duties: confirmed; @PeterGuy326 implements and @Bindy-lbb is the independent final human reviewer

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | generated workspace/organization locators and four shipped employee manifests | scoped `rg` scan; HTTP matrix; workspace CLI 26/26 PASS |
| REQ-002 / AC-002 | five visible employee authors plus one runtime fixture author | scoped author scan 0 old / 6 ByteFolk; manifest/profile tests PASS |
| REQ-003 / AC-003 | separate generated-document locator from frozen schema builder identity | workspace/org/hire schema byte-identity tests PASS; `configs/`, npm/package/lockfile, and legal diff empty |

## File domains

- Runtime source: generated-document `$schema` locators only in `apps/cli/org` and `apps/cli/workspace`.
- Public examples and metadata: four employee manifests, one shipped profile, one test-only runtime fixture, and `[Unreleased]` changelog.
- Regression evidence: exact generated locator assertions in the existing org/workspace test domains.
- Frozen public contracts and compatibility surfaces: unchanged.

## Scope and non-goals

Replace the six audited former-owner operational `$schema` locator literals and six visible author values with ByteFolk. Keep the three code-side schema builder IDs paired with their nine frozen published `configs/` identities. Do not migrate `@fullstack-ai-infra/*`, npm registry or lockfile coordinates, protocol/schema identities, LICENSE/NOTICE, or any runtime behavior beyond the generated locator value.

## Validation

- Environment: macOS arm64; Node.js 24.14.1; npm 11.9.0; repository base `f220a5588d4eabd5014d2e6d4ec723233b421fbe`.
- Exact commands:
  - `npm run build`
  - `npx tsx --test --test-concurrency=1 tests/apps/org-budget.test.ts tests/apps/hire-request-schema.test.ts tests/core/profile-manifest.test.ts tests/apps/registry.test.ts tests/apps/employee-package.test.ts tests/apps/employee-eval.test.ts tests/apps/synthetic-mcp.test.ts tests/apps/real-local-host.test.ts`
  - `npx tsx --test --test-concurrency=1 tests/apps/workspace-cli.test.ts tests/apps/org-budget.test.ts tests/apps/hire-request-schema.test.ts`
  - `node ./dist/apps/cli/bin.js validate <each of four changed employee-package directories> --json` and `eval` with the same matrix
  - `npm run governance:check`; `npm run security:check`; `npm audit --omit=dev --audit-level=high`; `git diff --check`
- Observed counts/results: build PASS; focused suite PASS 85/85; generated-locator suite PASS 26/26; package matrix PASS 8/8 commands (`validate=valid`, `eval=passed`, `failed=0`); governance PASS 7/7 fixtures; security PASS; audit PASS 0 vulnerabilities; diff check PASS.
- Compatibility counts: former raw-owner tracked lines 14 -> 8 (six operational literals removed); target author values 6 -> 0; `ByteFolk` target authors 0 -> 6; frozen config identities 9 -> 9; npm scope lines 76 -> 76; protected config/package/lock/legal diff 0 files.
- Check URLs: https://github.com/bytefolk/digital-employee/actions/runs/33482887337

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 / AC-001 | Audited generated locators use ByteFolk; paired builder IDs remain frozen | scoped `rg` plus `curl` matrix | Node 24 / public GitHub raw endpoints | zero old operational literals; two existing schema targets HTTP 200; missing workspace schema has old/new parity | 0 old operational literals; employee-package and workspace-org 200; workspace schema 404 before and after | PASS with named pre-existing limit |
| V2 | REQ-002 / AC-002 | Changed manifests and fixture expose ByteFolk authorship and remain consumable | four `validate` + four `eval`; profile/registry tests | built local CLI; no credentials | 8/8 commands pass; profile/fixture tests pass | 8/8 PASS; focused suite 85/85 PASS | PASS |
| V3 | REQ-003 / AC-003 | Frozen schema/npm/legal identities do not drift | `git diff` protected paths; builder byte-identity tests | exact main baseline | protected diff empty; identity tests pass | 0 protected files; 9 config IDs retained; schema tests PASS | PASS |
| V4 | REQ-001..003 / AC-001..003 | Repository required checks accept the exact head | GitHub Actions required checks | clean Node 20/22/24 runners | all required checks green | PASS 12/12 at run `33482887337` on exact head `024994a07736a79e99fc74b8ba7736583eef43cf` | PASS |

## Security and compatibility

- [x] No credentials, personal identifiers, private messages, internal URLs, or generated indexes are included.
- [x] Source/tool access and public evidence are explicitly bounded.
- [x] Logs redact content, identities, and credential-bearing URLs.
- [x] Compatibility, migration, and cross-repository effects are stated below.
- [x] New dependencies and licenses were reviewed, or no dependency changed.
- [x] `npm run check` and `npm audit --omit=dev --audit-level=high` pass, or an exact NOT VERIFIED boundary is recorded.
- [x] Behavior changes carry a matching docs delta, or this body records the explicit no-doc-needed reason (CONTRIBUTING.md, "Documentation consistency").

No dependency, credential, permission, network behavior, npm coordinate, legal attribution, or persisted format changes. `npm run security:check` passed, `npm audit --omit=dev --audit-level=high` found 0 vulnerabilities, the public diff contains no internal email or common credential shapes, and commit author/committer use the verified GitHub noreply address. The generated organization locator is deliberately separated from the frozen builder `$id` so compatibility and current discovery do not conflict.

Documentation consistency: the user-visible metadata/locator change is recorded in `CHANGELOG.md` under `[Unreleased]`; no command, protocol, schema, support matrix, deploy policy, or release policy changed, so no additional product documentation delta is needed.

## Known limitations

- `configs/workspace.schema.json` is absent from protected main. Both the former-owner and ByteFolk raw URL return HTTP 404. This PR preserves the exact path and records the pre-existing missing-artifact limit; it does not invent a new public schema or substitute an incompatible existing schema.
- The local full `npm run check` reached unrelated deploy/DingTalk real-time E2E tests under a heavily loaded macOS host and reported multiple timing/lock failures before the run was stopped. All changed-domain tests, build, governance, security, and package journeys pass. Clean GitHub required CI on the exact head is the authoritative full-suite gate and remains pending at initial push.

## Risk and rollback

Risk is limited to consumers that compare generated `$schema` strings rather than resolving their target. Frozen `$id` values remain unchanged. If a downstream regression appears, revert commit `024994a07736a79e99fc74b8ba7736583eef43cf`; no data migration, dependency rollback, registry change, or cleanup step is required.

## Product review handoff

- Automated pre-review result: PREFLIGHT PASS at exact head `024994a07736a79e99fc74b8ba7736583eef43cf` (independent read-only review; no P0/P1/P2 findings; not a GitHub approval)
- Human final review: PENDING
- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: maintenance-only metadata and locator update has no milestone or release packet
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
