### PR TITLE
ci: enable free security baseline (#255)

### DIFF
--- a/.github/workflows/bytefolk-scorecard.yml
+++ b/.github/workflows/bytefolk-scorecard.yml
@@ -1,0 +1,49 @@
+name: ByteFolk Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "43 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scorecard:
+    name: OpenSSF Scorecard
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+      security-events: write
+      id-token: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Scorecard artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload Scorecard results
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/bytefolk-scorecard.yml
+++ b/.github/workflows/bytefolk-scorecard.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "43 3 * * 1"
+    - cron: '43 3 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/bytefolk-security.yml
+++ b/.github/workflows/bytefolk-security.yml
@@ -1,0 +1,64 @@
+name: ByteFolk Security Baseline
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          fail-on-scopes: runtime
+          comment-summary-in-pr: never
+
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.4
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/bytefolk-security.yml
+++ b/.github/workflows/bytefolk-security.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "17 3 * * 1"
+    - cron: '17 3 * * 1'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/bytefolk/digital-employee/issues/255
- Consumed revision: R1
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | `.github/workflows/bytefolk-security.yml` and `.github/workflows/bytefolk-scorecard.yml` | Static workflow policy PASS and remote CodeQL/Dependency Review jobs PASS |

## File domains

- `.github/workflows/bytefolk-security.yml`: CodeQL for JavaScript/TypeScript and Dependency Review.
- `.github/workflows/bytefolk-scorecard.yml`: scheduled OpenSSF Scorecard and SARIF upload.
- No application, dependency, release, credential, or runtime files are changed.

## Scope and non-goals

This workflow-only PR enables the free ByteFolk security baseline for the repository. It does not change application code, package manifests, release workflows, repository required checks, model access, deployment access, or local files. It does not add Strix or another AI/dynamic scanner to normal CI.

## Validation

- Exact commands: `python3` YAML parse plus immutable-Action policy check; `gh pr checks 256 --repo bytefolk/digital-employee`
- Observed counts/results: PASS 2/2 new security checks (CodeQL and Dependency Review); FAIL 3/3 existing Node test jobs because `npm audit --omit=dev --audit-level=high` reports `fast-uri` high severity.
- Check URLs: https://github.com/bytefolk/digital-employee/actions/runs/33970949357/job/101319238294

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 / AC-001 | Security workflows run without repository credentials | Open the PR checks and inspect CodeQL and Dependency Review jobs | GitHub-hosted runner | Both new security jobs pass | CodeQL and Dependency Review passed; existing dependency audit remains failed | FAIL |

## Security and compatibility

All Actions use full commit SHAs and least-privilege permissions. Fork pull requests do not receive CodeQL upload permissions. No `pull_request_target` trigger, secret reference, model credential, publishing credential, or deployment credential is introduced. Existing application and release workflows remain unchanged.

## Known limitations

The PR is intentionally held because the repository's existing Node test matrix reports a high-severity `fast-uri` vulnerability. That dependency remediation is a separate security issue and must not be hidden inside this workflow-only PR. Remote workflow results are the source of truth after each new head.

## Risk and rollback

The new jobs are non-required checks and do not receive application or release credentials. Rollback is a normal revert PR removing the two workflow files; repository security settings remain enabled independently.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @Bindy-lbb
- Milestone or release packet: N/A: workflow-only security adoption
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
- This PR remains Draft/HOLD until the existing dependency audit is remediated and all required CI is green.
