### PR TITLE
fix(deps): update fast-uri to patched release (#257)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1059,9 +1059,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/bytefolk/digital-employee/issues/257
- Consumed revision: R1
- No automatic close keywords: acknowledged

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 | `package-lock.json` dependency resolution | Scrubbed `npm audit` reports zero vulnerabilities; `fast-uri` resolves to 3.1.6 |

## File domains

- `package-lock.json`: one transitive npm package resolution and integrity entry.
- No application source, runtime configuration, environment files, release files, or credentials are changed.

## Scope and non-goals

This PR updates the lockfile from vulnerable `fast-uri` 3.1.5 to patched 3.1.6. It preserves the direct `ajv` dependency contract and does not lower audit thresholds, disable security checks, or change application behavior intentionally. It does not include the separate workflow-only security baseline PR.

## Validation

- Exact commands: `ruby -rjson -e '...'`; `npm ls fast-uri --all --package-lock-only --omit=dev --userconfig=/dev/null --registry=https://registry.npmjs.org/`; `npm audit --package-lock-only --omit=dev --audit-level=high --userconfig=/dev/null --registry=https://registry.npmjs.org/`
- Observed counts/results: PASS 3/3 local lockfile, dependency-tree, and audit checks; PASS 12/12 remote CI checks including Node 20/22/24, coverage, packaging, and governance.
- Check URLs: https://github.com/bytefolk/digital-employee/actions/runs/33972629604/job/101323726926

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 / AC-001 | The lockfile resolves a patched fast-uri release and high-severity audit passes | Run the three commands listed above from the repository root | macOS host and GitHub-hosted Node 20/22/24 jobs, npm registry forced to registry.npmjs.org, no user config, scripts not executed locally | fast-uri is 3.1.6 and audit exits 0 | fast-uri is 3.1.6; local audit found 0 vulnerabilities; all remote CI checks passed | PASS |

## Security and compatibility

The update covers the published `fast-uri` 3.1.6 fixes for the reported URI normalization and SSRF advisories. The direct `ajv@8.20.0` range already accepts this patch release. No credentials or network-accessing application code is introduced; package metadata was queried with an empty npm user config and the project scripts were not executed locally.

## Known limitations

The fix addresses the resolved lockfile package; a future dependency update may require repeating the audit. No blocking CI or audit failure remains on this head.

## Risk and rollback

The change is limited to a lockfile resolution and package integrity value. Rollback is a normal revert PR restoring the previous lockfile entry, but that would restore the known vulnerability and is not recommended.

## Product review handoff

- Merge ledger owner: @PeterGuy326
- Product reviewer: @Bindy-lbb
- Milestone or release packet: N/A: dependency security fix
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
- This PR is ready for administrator merge after the recorded CI pass.
