### PR TITLE
ci: report required Scorecard analysis on pull requests

### DIFF
--- a/.github/workflows/scorecard-pr.yml
+++ b/.github/workflows/scorecard-pr.yml
@@ -1,0 +1,38 @@
+name: Scorecard PR
+
+on:
+  pull_request:
+    branches:
+      - main
+
+# Experimental PR support analyzes the local merge checkout. Repository-wide
+# reporting and publication remain in bytefolk-scorecard.yml on main.
+# Never add pull_request_target, publication credentials, or PR script steps.
+permissions:
+  contents: read
+
+jobs:
+  scorecard:
+    name: OpenSSF Scorecard
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out PR merge commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Analyze PR checkout
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: false
+
+      - name: Upload PR Scorecard report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-pr-results
+          path: results.sarif
+          if-no-files-found: error
+          retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Run the required OpenSSF Scorecard analysis on pull requests targeting main
+  with read-only permissions and a local report artifact, preserving the
+  separate default-branch reporting workflow (#262).
+
 ### Changed
 
 - Replace former GitHub owner coordinates in shipped templates and examples

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -110,6 +110,32 @@ Adapter-specific deterministic fixtures do not establish live model
 entitlement, provider terms or multi-tenant isolation; no live model request
 was used for the current verification claim.
 
+## Pull request Scorecard boundary
+
+The required `OpenSSF Scorecard` PR check analyzes the checked-out PR merge
+commit and uploads `scorecard-pr-results` as a workflow artifact. It uses only
+`contents: read`, does not persist checkout credentials, and does not execute
+repository scripts. Publication is disabled: no PAT, secret input, OIDC or
+SARIF-upload permission is granted. A missing report fails the artifact step.
+This check confirms analysis completed, not that every Scorecard finding is
+resolved or that a human approved the candidate.
+
+The pinned [Scorecard action v2.4.4 implementation](https://github.com/ossf/scorecard-action/blob/2d1146689b8cda280b9bc96326124645441f03bc/options/options.go)
+selects local-checkout analysis for `pull_request`. Repository metadata comes
+from the event's top-level repository, so a fork-to-canonical PR is distinct
+from running the action inside the fork repository. Upstream calls PR support
+experimental; source inspection is not a substitute for exact-head hosted
+artifact evidence. Local analysis has limited repository-governance coverage
+and does not replace the unchanged main/scheduled `bytefolk-scorecard.yml`
+repository-wide reporting, badge or code-scanning publication.
+
+All workflow action references are commit-pinned and require review when
+updated. The upstream action itself uses a version-tagged container image;
+record the actual image digest from the hosted run, not an end-to-end immutable
+image claim. Run the focused security-contract tests with
+`npx tsx --test tests/scripts/scorecard-workflow.test.ts`; they also run in the
+unchanged `npm run check` CI matrix.
+
 ## Supported versions
 
 Until the first stable release, only the latest tagged `0.x` release receives

--- a/tests/scripts/scorecard-workflow.test.ts
+++ b/tests/scripts/scorecard-workflow.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import YAML from "yaml";
+
+const readWorkflow = (name: string) =>
+  readFileSync(new URL(`../../.github/workflows/${name}`, import.meta.url), "utf8");
+
+// Exact allowlist: a new job, step, input, env, condition or permission needs
+// explicit security review. Parse YAML rather than matching comments as policy.
+const expected = {
+  name: "Scorecard PR",
+  on: { pull_request: { branches: ["main"] } },
+  permissions: { contents: "read" },
+  jobs: {
+    scorecard: {
+      name: "OpenSSF Scorecard",
+      "runs-on": "ubuntu-24.04",
+      "timeout-minutes": 15,
+      steps: [
+        {
+          name: "Check out PR merge commit",
+          uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+          with: { "persist-credentials": false }
+        },
+        {
+          name: "Analyze PR checkout",
+          uses: "ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc",
+          with: {
+            results_file: "results.sarif",
+            results_format: "sarif",
+            publish_results: false
+          }
+        },
+        {
+          name: "Upload PR Scorecard report",
+          uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+          with: {
+            name: "scorecard-pr-results",
+            path: "results.sarif",
+            "if-no-files-found": "error",
+            "retention-days": 14
+          }
+        }
+      ]
+    }
+  }
+};
+
+function validatePrWorkflow(source: string) {
+  const doc = YAML.parseDocument(source, { uniqueKeys: true });
+  assert.deepEqual(doc.errors, [], "workflow must be unambiguous YAML");
+  assert.deepEqual(doc.toJS({ maxAliasCount: 0 }), expected,
+    "PR workflow must match the reviewed least-privilege analysis contract");
+}
+
+test("PR workflow emits the required real analysis and artifact with read-only authority", () => {
+  validatePrWorkflow(readWorkflow("scorecard-pr.yml"));
+});
+
+test("security contract accepts YAML formatting and comments, not textual lookalikes", () => {
+  validatePrWorkflow(`# publication stays disabled\n${YAML.stringify(expected)}`);
+  assert.throws(() => validatePrWorkflow(`# ${YAML.stringify(expected).replaceAll("\n", "\n# ")}`));
+});
+
+type Mutation = { name: string; path: (string | number)[]; value?: unknown; remove?: boolean };
+const mutations: Mutation[] = [
+  { name: "missing PR trigger", path: ["on", "pull_request"], remove: true },
+  { name: "unsafe privileged trigger", path: ["on", "pull_request_target"], value: {} },
+  { name: "non-main target", path: ["on", "pull_request", "branches"], value: ["release"] },
+  { name: "path-filtered required check", path: ["on", "pull_request", "paths"], value: ["src/**"] },
+  { name: "missing synchronize events", path: ["on", "pull_request", "types"], value: ["opened"] },
+  { name: "missing required name", path: ["jobs", "scorecard", "name"], remove: true },
+  { name: "wrong required name", path: ["jobs", "scorecard", "name"], value: "Scorecard" },
+  { name: "write-all shorthand", path: ["permissions"], value: "write-all" },
+  { name: "contents write", path: ["permissions", "contents"], value: "write" },
+  { name: "OIDC write", path: ["permissions", "id-token"], value: "write" },
+  { name: "SARIF write", path: ["permissions", "security-events"], value: "write" },
+  { name: "extra token read scope", path: ["permissions", "actions"], value: "read" },
+  { name: "job permission override", path: ["jobs", "scorecard", "permissions"], value: { contents: "write" } },
+  { name: "job skip", path: ["jobs", "scorecard", "if"], value: false },
+  { name: "job failure waiver", path: ["jobs", "scorecard", "continue-on-error"], value: true },
+  { name: "persisted checkout credentials", path: ["jobs", "scorecard", "steps", 0, "with", "persist-credentials"], value: true },
+  { name: "default persisted credentials", path: ["jobs", "scorecard", "steps", 0, "with", "persist-credentials"], remove: true },
+  { name: "base instead of candidate checkout", path: ["jobs", "scorecard", "steps", 0, "with", "ref"], value: "main" },
+  { name: "other checkout repository", path: ["jobs", "scorecard", "steps", 0, "with", "repository"], value: "example/other" },
+  { name: "missing analysis", path: ["jobs", "scorecard", "steps", 1], remove: true },
+  { name: "skipped analysis", path: ["jobs", "scorecard", "steps", 1, "if"], value: false },
+  { name: "analysis failure waiver", path: ["jobs", "scorecard", "steps", 1, "continue-on-error"], value: true },
+  { name: "publication enabled", path: ["jobs", "scorecard", "steps", 1, "with", "publish_results"], value: true },
+  { name: "implicit publication default", path: ["jobs", "scorecard", "steps", 1, "with", "publish_results"], remove: true },
+  { name: "custom PAT", path: ["jobs", "scorecard", "steps", 1, "with", "repo_token"], value: "${{ secrets.SCORECARD_PAT }}" },
+  { name: "event spoofing", path: ["jobs", "scorecard", "steps", 1, "env"], value: { GITHUB_EVENT_NAME: "push" } },
+  { name: "arbitrary PR command", path: ["jobs", "scorecard", "steps", 3], value: { run: "npm run untrusted" } },
+  { name: "extra publication action", path: ["jobs", "scorecard", "steps", 3], value: { uses: "github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938" } },
+  { name: "missing report allowed", path: ["jobs", "scorecard", "steps", 2, "with", "if-no-files-found"], value: "warn" },
+  { name: "wrong report uploaded", path: ["jobs", "scorecard", "steps", 2, "with", "path"], value: "README.md" },
+  { name: "workflow secret environment", path: ["env"], value: { CUSTOM_TOKEN: "${{ secrets.CUSTOM_TOKEN }}" } },
+  ...[0, 1, 2].map((index) => ({
+    name: `unpinned action ${index}`,
+    path: ["jobs", "scorecard", "steps", index, "uses"],
+    value: expected.jobs.scorecard.steps[index]!.uses.replace(/@[a-f0-9]{40}$/, "@main")
+  }))
+];
+
+for (const mutation of mutations) {
+  test(`PR security negative control rejects ${mutation.name}`, () => {
+    const doc = new YAML.Document(structuredClone(expected));
+    if (mutation.remove) doc.deleteIn(mutation.path);
+    else doc.setIn(mutation.path, mutation.value);
+    assert.throws(() => validatePrWorkflow(doc.toString()), /least-privilege analysis contract/);
+  });
+}
+
+test("duplicate YAML policy keys fail closed", () => {
+  assert.throws(() => validatePrWorkflow(`${YAML.stringify(expected)}permissions: write-all\n`),
+    /unambiguous YAML/);
+});
+
+test("default-branch repository reporting remains separate from PR analysis", () => {
+  const main = YAML.parse(readWorkflow("bytefolk-scorecard.yml"));
+  assert.deepEqual(main.on, {
+    push: { branches: ["main"] },
+    schedule: [{ cron: "43 3 * * 1" }],
+    workflow_dispatch: null
+  });
+  const steps = main.jobs.scorecard.steps;
+  assert.equal(steps.find((step: { uses: string }) => step.uses.startsWith("ossf/scorecard-action@")).with.publish_results, true);
+  assert.equal(main.jobs.scorecard.permissions["security-events"], "write");
+  assert.equal(main.jobs.scorecard.permissions["id-token"], "write");
+  assert.ok(steps.some((step: { uses: string }) => step.uses.startsWith("github/codeql-action/upload-sarif@")));
+});


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/bytefolk/digital-employee/issues/262
- Consumed revision: R1
- No automatic close keywords: acknowledged

## Delivery ownership

- implementationOwner: @PeterGuy326
- automatedPreReviewOwner: independent Codex preflight (Mendel; final-head bounded preflight recorded)
- humanReviewOwner: @Bindy-lbb
- Separation of duties: implementation and automated testing do not grant human approval. The implementation owner is not the final human reviewer.

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
|---|---|---|
| REQ-001 / AC-001 / AC-002 | `.github/workflows/scorecard-pr.yml` | Required exact-name PR analysis; hosted report evidence pending below |
| REQ-002 / AC-001 | PR workflow and `SECURITY.md` | Full YAML allowlist; 34 unsafe-configuration mutation controls; pinned upstream implementation inspection |
| REQ-003 / AC-001 / AC-002 / AC-003 | `tests/scripts/scorecard-workflow.test.ts`, `CHANGELOG.md` | 38 focused tests; unchanged full matrix; separate independent and human gates |

## File domains

- Maintenance implementation owner owns only the new PR workflow, its focused regression test, the security boundary documentation, and the Unreleased changelog entry.
- Existing main/scheduled Scorecard reporting, all other workflows, runtime, packages, dependency lockfiles and other PR heads are unchanged.

## Scope and non-goals

Main requires `OpenSSF Scorecard`, but the existing reporting workflow runs only on main push, schedule and manual dispatch. This separate repair adds a real PR-triggered local analysis for every ordinary PR update targeting main, with no path or fork filters. Checkout uses GitHub's PR merge ref, not main or an arbitrary repository. The report is uploaded as a workflow artifact; it is not a synthetic status or a waiver of findings.

Only `contents: read` is granted, checkout credentials are not persisted, publication is explicitly false, and all three actions are pinned to verified release commits. There is no privileged PR event, PAT/secret input, OIDC/SARIF write permission, repository script execution, skip condition, or failure waiver. The existing reporting workflow blob remains `bca8aa4951f1c48c65bd4be272e53c61927bc3eb`.

No runtime change, release, branch-protection/ruleset edit, permission expansion, human approval, merge, or modification of PR #254/#252 is included. Existing PRs will need fresh incorporation and checks after an ordinary reviewed merge; no prior review is transferred to a changed head.

## Validation

- Base: `9b27cd480519173d5d8df67d04e61943f84def90` (clean canonical main).
- Head: `6432db6a2d4684944b6e52b72df5c48828c74fe5`.
- Environment: isolated macOS arm64 worktree; Node.js 26.7.0, npm 11.19.0; `npm ci --ignore-scripts --no-audit --no-fund` installed 47 packages. Hosted Node 20/22/24 lanes remain authoritative for those versions.
- Exact commands: `npx tsx --test tests/scripts/scorecard-workflow.test.ts`, `npm run check`, `npm audit --omit=dev --audit-level=high`, `git diff --check origin/main...HEAD`. All commands run from repository root. Tests mutate YAML in memory, do not invoke live agents or SMTP, and need no service credentials. No generated files are committed; disposable fixture cleanup is owned by the existing tests.
- Observed counts/results: 38/38 focused tests pass (34 configuration mutations, duplicate-key rejection, comment-only rejection, real-workflow acceptance, and preservation of separate main reporting). Before adding the workflow, the same suite failed with ENOENT for the missing PR workflow: 37 pass, 1 fail.
- Check URLs: https://github.com/bytefolk/digital-employee/actions/runs/34444903590

Current-head hosted checks: all 16 are SUCCESS, including all 8 required contexts. [Full CI 34444903590](https://github.com/bytefolk/digital-employee/actions/runs/34444903590) covers Node 20/22/24 and coverage; [Scorecard job 102767486144](https://github.com/bytefolk/digital-employee/actions/runs/34444903638/job/102767486144) produced the real SARIF. Final-head [automated preflight](https://github.com/bytefolk/digital-employee/pull/263#issuecomment-5614189487) and [non-author technical review](https://github.com/bytefolk/digital-employee/pull/263#issuecomment-5614597231) independently parsed that report. The local failed/incomplete run below remains recorded; no full macOS pass is claimed. This PR is ready but still requires a formal non-author GitHub approval.

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
|---|---|---|---|---|---|---|---|
| V1 | REQ-001 / REQ-002 / AC-001 | Real required check exists and unsafe workflow mutations are rejected | `npx tsx --test tests/scripts/scorecard-workflow.test.ts` | Local Node 26 | Positive contract accepted; each negative rejected | 38/38 pass; original missing-workflow negative fails | PASS |
| V2 | REQ-003 / AC-001 | Type, build, tests, governance and source security remain valid | `npm run check` | Local Node 26 | Exit 0 | Type/build passed; full suite stopped after lock failure: 700 reported tests, 586 pass, 2 fail (subtest + parent), 111 cancelled, 1 skipped. This is not a completed aggregate run | FAIL / INCOMPLETE (local) |
| V3 | REQ-002 / AC-001 | No high runtime dependency advisory or accidental whitespace | `npm audit --omit=dev --audit-level=high` and `git diff --check origin/main...HEAD` | Local | Exit 0 | Zero vulnerabilities; clean diffcheck | PASS |
| V4 | REQ-002 / AC-001 | Full existing matrix and main report remain unchanged | `git diff --exit-code 9b27cd480519173d5d8df67d04e61943f84def90 HEAD -- .github/workflows/bytefolk-scorecard.yml .github/workflows/bytefolk-security.yml .github/workflows/ci.yml package.json package-lock.json` | Local Git | Empty diff, exit 0 | Exact match | PASS |
| V5 | REQ-001 / AC-002 | Candidate actually runs local analysis and uploads a nonempty SARIF report | Inspect exact-head PR job logs and download `scorecard-pr-results` | GitHub-hosted Ubuntu 24.04 | Concrete required check; local PR mode, publication false; parseable nonempty SARIF | Exact-head hosted artifact independently parsed in the linked preflight and non-author technical review: SARIF 2.1.0, 81,493 bytes, 38 findings | PASS (hosted; not findings-free) |
| V6 | REQ-001 / AC-002 | Fork-to-canonical PR behavior is distinct from running in a fork | Inspect pinned source and RoleWeave fork PR/run linked below | Source + existing hosted cross-repository evidence | Local checkout selected, publication false, real artifact | Verified source and RoleWeave #213 run metadata/logs | PASS (qualified) |

### Pinned source and fork evidence

Verified checkout v7.0.1 -> `3d3c42e5aac5ba805825da76410c181273ba90b1`, upload-artifact v7.0.1 -> `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`, and Scorecard's signed annotated v2.4.4 tag -> `2d1146689b8cda280b9bc96326124645441f03bc` using GitHub's official ref/tag APIs. The actions are the same reviewed versions already used by the main reporting workflow.

- [Options at the exact pin](https://github.com/ossf/scorecard-action/blob/2d1146689b8cda280b9bc96326124645441f03bc/options/options.go): PR events select `Local="."`, not repository-wide remote mode.
- [Event parser](https://github.com/ossf/scorecard-action/blob/2d1146689b8cda280b9bc96326124645441f03bc/github/github.go): reads the top-level event repository rather than the fork head repository.
- [Action entrypoint](https://github.com/ossf/scorecard-action/blob/2d1146689b8cda280b9bc96326124645441f03bc/main.go): rejects `pull_request_target`; publication is not entered for ordinary PR events or this explicit false input.
- [Local repository selection](https://github.com/ossf/scorecard-action/blob/2d1146689b8cda280b9bc96326124645441f03bc/internal/scorecard/scorecard.go) and [SARIF formatting](https://github.com/ossf/scorecard-action/blob/2d1146689b8cda280b9bc96326124645441f03bc/internal/scorecard/format.go) perform analysis and write the result.
- Existing cross-repository evidence: [RoleWeave #213](https://github.com/bytefolk/roleweave/pull/213), `sun-970/org-workbench` -> canonical main, head `f6fb58a09a2e72654a611a99eef0a08b894c5ecd`; [run 34197974575](https://github.com/bytefolk/roleweave/actions/runs/34197974575/job/101969894971) is SUCCESS, with `Local: .`, `Event name: pull_request`, `Publication enabled: false`. Artifact ID `10044640353`, `scorecard-pr-results`, is 10,743 archive bytes. This existing fork run supports the pattern; it does not replace this DE candidate's hosted evidence.

## Security and compatibility

The source security scan passes; no credentials, internal paths/URLs, private data or generated artifacts are committed. No npm dependency or runtime API changes. `SECURITY.md` documents the contributor-visible boundary, and the changelog records the repair. All actions are upstream official references, using the same versions as the existing baseline; no third-party implementation code is copied into the runtime.

## Known limitations

The local full suite failed `deployment lock deadline and supervised-helper matrix uses the real platform primitive` / `direct real utility contention, watchdog close, timeout, and successor` at `tests/apps/deploy-cli.test.ts:5113`: actual `['SIGTERM', 'SIGTERM']`, expected `['SIGTERM']`. It was then stopped on request to avoid concurrent heavy suites; cancellation fallout is not reported as additional independent source failures. No full rerun was performed.

One focused comparison used `npx tsx --test --test-name-pattern='deployment lock deadline and supervised-helper matrix uses the real platform primitive' tests/apps/deploy-cli.test.ts` after clean install/build at each tree. Clean main `9b27cd480519173d5d8df67d04e61943f84def90` reproduced the same double-SIGTERM assertion (12 pass, 2 fail including the parent). Candidate replay passed that subcase but failed `owner and record-fence changes fail after one real utility attempt` at line 4964 / caller 6227: actual phase `error`, expected `acquired` (12 pass, 2 fail including the parent). The file blob is identically `7cc94feef3344ebd587bac7cd02b927fe256af04` in both trees; no runtime file differs. `docs/flaky-tests.md` records this matrix under Issue #193 / PR #195, but that history and the current baseline evidence do not waive the local failure or required hosted checks. Linux final-head CI remains the full-suite gate; no lock implementation, timeout or assertion is modified.

Upstream describes PR support as experimental. Local-checkout results have limited repository-governance coverage; this workflow is not a replacement for main's repository-wide badge/reporting or proof that all findings are resolved. The pinned action metadata uses a version-tagged Docker image, so the actual hosted image digest must be recorded; commit-pinned action refs are not an end-to-end immutable-image guarantee. Fork behavior is source-verified and corroborated by the existing RoleWeave hosted fork run, not yet a fresh DE fork run. Local tests are not hosted-action evidence. Independent automated review, human approval, and current required CI are separate gates.

## Risk and rollback

The change adds one read-only analysis job and retained report artifact. Risks are action/service availability and contributor friction from experimental PR support. Revert this maintenance change through an ordinary reviewed PR if necessary; do not remove the required context or grant extra permissions to make it pass. No data migration or runtime rollback is involved.

## Product review handoff

- Automated pre-review result: final-head bounded PREFLIGHT PASS, recorded in [5614189487](https://github.com/bytefolk/digital-employee/pull/263#issuecomment-5614189487); subsequently completed hosted CI is linked above. The local full-suite failure and its baseline comparisons remain limitations, not waived passes.
- Human final review: PENDING; the non-author technical comment is not an APPROVED review. No GitHub approval is claimed.
- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: bounded maintenance only.
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged

## Admin-visible required-check verification (2026-09-10)

Read-only `gh api repos/bytefolk/digital-employee/branches/main/protection` succeeded under the authenticated ADMIN viewer. It reports exactly eight required contexts:

- `test (20)`
- `test (22)`
- `test (24)`
- `container`
- `coverage`
- `CodeQL (javascript-typescript)`
- `Dependency review`
- `OpenSSF Scorecard`

The supplemental `gh api repos/bytefolk/digital-employee/rules/branches/main` returned an empty rule list. Classic protection still applies: one approving review, CODEOWNER approval, last-push approval, stale-review dismissal, conversation resolution, linear history, and enforcement for admins. Its current `strict` value is false; this follow-up did not change it or any other protection/permission. All eight named contexts are successful on the unchanged candidate head `6432db6a2d4684944b6e52b72df5c48828c74fe5`. The reviewer's 404 was a visibility limitation; it is not proof that protection is absent. Formal human approval remains pending.


