### PR TITLE
ci: drop the hand-dispatch path from the default-branch Scorecard workflow

### DIFF
--- a/.github/workflows/bytefolk-scorecard.yml
+++ b/.github/workflows/bytefolk-scorecard.yml
@@ -6,7 +6,6 @@ on:
       - main
   schedule:
     - cron: '43 3 * * 1'
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/tests/scripts/scorecard-workflow.test.ts
+++ b/tests/scripts/scorecard-workflow.test.ts
@@ -122,7 +122,6 @@ test("default-branch repository reporting remains separate from PR analysis", ()
   assert.deepEqual(main.on, {
     push: { branches: ["main"] },
     schedule: [{ cron: "43 3 * * 1" }],
-    workflow_dispatch: null
   });
   const steps = main.jobs.scorecard.steps;
   assert.equal(steps.find((step: { uses: string }) => step.uses.startsWith("ossf/scorecard-action@")).with.publish_results, true);


### PR DESCRIPTION
## Canonical requirement

- Canonical Issue URL: https://github.com/bytefolk/digital-employee/issues/274
- Consumed revision: R1
- No automatic close keywords: acknowledged

Refs #274. This branch deliberately carries no auto-close keyword, so merging it
leaves the triage decision to a human.

## Delivery ownership

- implementationOwner: @waterbro-8
- automatedPreReviewOwner: none; the author ran the focused suite and three mutation controls locally, recorded below
- humanReviewOwner: @PeterGuy326
- Separation of duties: the author of this pull request is the implementation owner and therefore withholds any self-approval. The only approval that can satisfy this change has to come from a CODEOWNERS eligible reviewer who is not me.

## Requirement trace

| REQ/AC IDs | Changed files / domain | Tests or review evidence |
| --- | --- | --- |
| REQ-001 / AC-001 | `.github/workflows/bytefolk-scorecard.yml` trigger block | V1 and V2 below: parsed `on:` after the edit lists only push and schedule, and the focused workflow test passes with the assertion updated |
| REQ-002 / AC-002 | `.github/workflows/bytefolk-scorecard.yml` job body, `tests/scripts/scorecard-workflow.test.ts` | V3 and V4 below: the whole-repository diff is two deleted lines, and the pinned job name, `publish_results`, artifact name, action pins and `permissions` all still assert green |
| REQ-003 / AC-003 | `tests/scripts/scorecard-workflow.test.ts` `default-branch repository reporting remains separate from PR analysis` | V5 below: mutation control putting the trigger back on the workflow alone turns exactly that one test red, so the shape is guarded and not merely documented |

## File domains

Two files, both already inside the domain the requirement names:

- `.github/workflows/bytefolk-scorecard.yml`: one deleted line, the `workflow_dispatch:` entry of the `on:` block.
- `tests/scripts/scorecard-workflow.test.ts`: one deleted line, the `workflow_dispatch: null` member of the `deepEqual` in the test that pins the default-branch reporting shape.

`scorecard-pr.yml` is not touched. No source file, no document, no other workflow
and no release artifact is touched.

## Scope and non-goals

The problem is a hand dispatch against a topic branch. `bytefolk-scorecard.yml`
offers `workflow_dispatch`, and a person using it for a routine repository
inspection picks a branch; the action itself refuses anything that is not the
default branch, so no analysis happens, yet the run still publishes the check
context `OpenSSF Scorecard`, which is a required context on pull requests. The
red lands on that branch's open pull request, and the author has no way to make
it green, because a `pull_request` event runs workflow files from the merge ref
and this workflow does not trigger on `pull_request` at all. Real instance:
run 34550602717, job 103112513228, `event=workflow_dispatch`,
`branch=fix/253-qoder-command-override`, `2026-09-11T01:25:29Z`, conclusion
failure, log line `Only the default branch main is supported.`

Deleting the trigger closes that door at its only hinge: the action's own
admission rule (`ossf/scorecard-action` v2.4.4, `options.go:122-128`) means a
non-`pull_request`, non-default-branch run can never produce a report, so the
trigger has no reachable useful outcome on a topic branch.

Explicitly out of scope, as recorded in the issue:

- Not renaming either job, and not giving the two same-named contexts distinct
  names. That is a separate design question about which result the required
  context should describe.
- Not consolidating the two publishers, and not changing `scorecard-pr.yml`.
- Not editing branch protection, required contexts, or any ruleset.
- Not touching the CodeQL pin comment in this same file that labels
  `cdf488f595d80d6e07e03d4674febd5ab45fa938` as `v4.37.4` when that commit is
  `v4.37.9`. It is a real documentation defect in the org template, it is
  unrelated to this trigger, and folding it in would make a two-line safety
  change carry an unrelated review surface.

## Validation

- Exact commands: `npx tsx --test tests/scripts/scorecard-workflow.test.ts`, `node --input-type=module -e` with the repository's own `yaml` dependency to print the parsed `on:` block and job name, `git diff --numstat HEAD~1 HEAD`, `npm run typecheck`, `npm run build`, `node ./scripts/requirement-governance-check.js`, `node ./scripts/security-check.js`, `tsx --test --test-concurrency=1 'tests/**/*.test.ts'`. All commands run from the repository root of an exact-main-tip tree.
- Observed counts/results: focused workflow test 38/38 PASS on the untouched baseline and 38/38 PASS after the two deletions, and 37 PASS plus 1 FAIL under mutation control M1, whose single red is `default-branch repository reporting remains separate from PR analysis`; repository-wide suite 1906/1916 pass with 8 fail and 2 skipped, the identical figure on both the base and the edited trees; typecheck, governance and security checks each exit 0.
- Check URLs: https://github.com/bytefolk/digital-employee/pull/275/checks

| ID | REQ/AC | Observable acceptance criterion | Command or manual steps | Environment | Expected | Observed | Status |
| --- | --- | --- | --- | --- | --- | --- | --- |
| V1 | REQ-001 | The workflow no longer declares a manual trigger | `node --input-type=module -e` printing `YAML.parse(text).on` | Linux, Node 24, exact head blob | keys are push and schedule only | parsed `on` is push with branches main, plus the weekly cron; no manual trigger key | PASS |
| V2 | REQ-001 | Both surviving triggers keep their exact values | same read of the parsed document | Linux, Node 24 | cron `43 3 * * 1`, branch list `[main]` | cron and branch list unchanged from base | PASS |
| V3 | REQ-002 | The change adds nothing beyond removing the trigger | `git diff --numstat HEAD~1 HEAD` | Linux, git | two paths, two deletions, zero insertions | `1 0` for each file, `2 files changed, 2 deletions(-)` | PASS |
| V4 | REQ-002 | Every pinned reporting property still holds | `npx tsx --test tests/scripts/scorecard-workflow.test.ts` | Linux, Node 24 | 38 tests pass, including the 34 mutations that pin job name, `publish_results`, artifact name, action pins and permissions | 38 pass, 0 fail, 0 skipped | PASS |
| V5 | REQ-003 | The guarded shape is load-bearing, not decorative | re-add only the workflow trigger, keep the test as edited, rerun the suite | Linux, Node 24 | exactly one red, and it is the default-branch reporting test | 37 pass, 1 fail, red named `default-branch repository reporting remains separate from PR analysis`; file restored and hash re-verified | PASS |

### How the evidence was produced

The tree under test is an unpacked codeload archive of `f4d2e41558a3`, the main
tip at the moment of authoring, with the index kept pristine so that
`git write-tree` reproduces the remote tree `666869e71b89b4a68ca01290594055d03ff947ee`;
the two edited files therefore carry only worktree changes, and the reviewable
blobs are `d68e9996bd62d3edf76ea3e007423dbfff375de0` and
`fc5e8e87ea941022f121d284f634f93e4c677996`. Mutation control M1 is the
injection described in AC-003 of the issue, and the workflow file was restored
and hash-checked after it.

The hosted observation, recorded here because the Check URLs field above admits
nothing but a link: this head carries 16 distinct check names, every one of
them `completed` with conclusion `success` on attempt 1. The `OpenSSF Scorecard`
entry among them is not the default-branch workflow running on a pull request,
which is the confusion this change removes; it is run `34669625483`, whose
workflow is `Scorecard PR`, the `pull_request`-side publisher that keeps
`publish_results: false`. That the required context is satisfied by the pull
request leg and only by it is the property being protected.

## Security and compatibility

Nothing weakens a control. Repository-wide reporting keeps its two automatic
paths, a push to main and the weekly schedule, and keeps `publish_results: true`
with the `scorecard-results` artifact, so the published badge and the SARIF
upload on the default branch are byte-for-byte the behaviour they were. The pull
request surface stays on `scorecard-pr.yml` unchanged, including its non-publishing
configuration and its `scorecard-pr-results` artifact.

Compatibility cost, stated plainly: after this merges, nobody can ask Actions for
an off-schedule repository-wide report on demand. The substitute is a push to
main or the Monday 03:43 schedule, and if a genuine need for on-demand reports on
the default branch ever appears, that need is a different design question from the
one being closed here, because a manual input that cannot be constrained to the
default branch reintroduces exactly the false red.

## Known limitations

- AC-003 of the issue is a post-merge observation. The disappearance of the
  manual run button from the Actions page for this workflow can only be
  confirmed after this lands on main, so it is not claimed here.
- The two workflows still publish the identical context name `OpenSSF Scorecard`.
  This change removes the hand path that could paint it red; it does not remove
  the duplication itself, which stays a deliberate non-goal.
- The required-context configuration is read by this author only through the
  maintainer's report and through observed `blocked` states, not through the
  ruleset API, which needs a scope I do not hold. The claim that this context is
  required is therefore carried as maintainer-supplied fact, and is separately
  evidenced by the existing failure on the pull request named in the narrative
  above.
- The repository-wide suite does not run green on this machine, and it does not
  run green on untouched main either: 1916 tests give 1906 pass, 8 fail and 2
  skipped on the base tree and exactly the same figure, with the same eight test
  names, on the edited tree. Those eight sit in CLI resolution, interactive
  answer handling and real-package-archive areas, none of them read either
  workflow file, and the control group is what makes them non-attributable to
  this change rather than something I am asserting about them.
- The five steps that `npm run check` composes were each run individually, in the
  order that script orders them, and not as the single composed invocation.

## Risk and rollback

Low risk, single commit, no data, no migration, no runtime code. The blast radius
is one Actions input. Reverting is one commit, and restoring the trigger also
restores the ability to mark an unrelated pull request red, so a rollback should
be paired with dispatching only against main. Merging requires a CODEOWNERS
eligible reviewer other than me, and this branch carries no auto-close keyword.

## Product review handoff

- Automated pre-review result: no hosted pre-review claimed. Local evidence is the focused workflow suite at 38/38 both before and after, the M1 injection that isolates exactly one red test, a clean exit from each of typecheck, build, governance and security, and a repository-wide control group run twice, on the base tree and on the edited tree, reproducing the same counts and the same set of failing test names; all of it recorded in the Validation table above.
- Human final review: PENDING and deliberately not supplied by the author. No GitHub approval is claimed, requested here, or implied by this body.
- Merge ledger owner: @PeterGuy326
- Product reviewer: @PeterGuy326
- Milestone or release packet: N/A: bounded CI maintenance with no release surface.
- Merge, CI, release, and model judgment do not accept or close the Issue: acknowledged
